### PR TITLE
NAV-30008: Arrange/Act/Assert på alle testfiler

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/BehandlingValideringTest.kt.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/BehandlingValideringTest.kt.kt
@@ -13,6 +13,7 @@ class BehandlingValideringTest {
     fun `Skal kaste feil for alle behandlingstatus utenom UTREDES dersom behandling forsøkes å redigeres på`(
         behandlingStatus: BehandlingStatus,
     ) {
+        // Act & Assert
         val melding = assertThrows<FunksjonellFeil> { validerBehandlingKanRedigeres(behandlingStatus) }.message
 
         assertThat(melding).isEqualTo("Behandlingen er låst for videre redigering da den har statusen ${behandlingStatus.name}")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TekstSaniteringUtilTest.kt
@@ -6,18 +6,22 @@ import org.junit.jupiter.api.Test
 class TekstSaniteringUtilTest {
     @Test
     fun `Sanering av tekst fungerer som forventet`() {
+        // Arrange
         val tekst = "Dette er en tekst med 1234 og spesialtegn som: !@#¤%&/()=?`^*¨'\""
         val forventetResultat = "Detteerentekstmed1234ogspesialtegnsom"
 
+        // Act & Assert
         assertThat(tekst.saner()).isEqualTo(forventetResultat)
     }
 
     @Test
     fun `erSanert fungerer som forventet`() {
+        // Arrange
         val tekst = "Dette er en tekst med 1234 og spesialtegn som: !@#¤%&/()=?`^*¨'\""
         val sanertTekst = "Detteerentekstmed1234ogspesialtegnsom"
         val tomStreng = ""
 
+        // Act & Assert
         assertThat(tekst.erAlfanummerisk()).isFalse()
         assertThat(sanertTekst.erAlfanummerisk()).isTrue()
         assertThat(tomStreng.erAlfanummerisk()).isTrue()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/TidTest.kt
@@ -92,6 +92,7 @@ internal class TidTest {
 
     @Test
     fun `skal bestemme om periode er etterfølgende periode`() {
+        // Arrange
         val personAktørId = randomAktør()
         val behandling = lagBehandling()
         val resultat: Resultat = mockk()
@@ -135,6 +136,7 @@ internal class TidTest {
                 sistEndretIBehandlingId = personResultat.vilkårsvurdering.behandling.id,
             )
 
+        // Act & Assert
         assertTrue(førsteVilkårResultat.erEtterfølgendePeriode(etterfølgendeVilkårResultat))
         assertFalse(førsteVilkårResultat.erEtterfølgendePeriode(ikkeEtterfølgendeVilkårResultat))
     }
@@ -149,6 +151,7 @@ internal class TidTest {
 
     @Test
     fun `sjekk for om to måned perioder helt eller delvis er overlappende`() {
+        // Arrange
         val jan2020Aug2020 = MånedPeriode(YearMonth.of(2020, 1), YearMonth.of(2020, 8))
         val jul2020Des2020 = MånedPeriode(YearMonth.of(2020, 7), YearMonth.of(2020, 12))
         val des2019Sep2021 = MånedPeriode(YearMonth.of(2019, 12), YearMonth.of(2020, 9))
@@ -157,6 +160,7 @@ internal class TidTest {
         val des2019 = MånedPeriode(YearMonth.of(2019, 12), YearMonth.of(2019, 12))
         val sep2021 = MånedPeriode(YearMonth.of(2021, 9), YearMonth.of(2021, 9))
 
+        // Act & Assert
         assertTrue(jan2020Aug2020.overlapperHeltEllerDelvisMed(jul2020Des2020))
         assertTrue(jul2020Des2020.overlapperHeltEllerDelvisMed(jan2020Aug2020))
         assertTrue(jan2020Aug2020.overlapperHeltEllerDelvisMed(des2019Sep2021))
@@ -173,6 +177,7 @@ internal class TidTest {
 
     @Test
     fun `sjekk for om to perioder helt eller delvis er overlappende`() {
+        // Arrange
         val jan2020Aug2020 = Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 8, 1))
         val jul2020Des2020 = Periode(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 12, 1))
         val des2019Sep2021 = Periode(LocalDate.of(2019, 12, 1), LocalDate.of(2020, 9, 1))
@@ -181,6 +186,7 @@ internal class TidTest {
         val des2019 = Periode(LocalDate.of(2019, 12, 1), LocalDate.of(2019, 12, 1))
         val sep2021 = Periode(LocalDate.of(2021, 9, 1), LocalDate.of(2021, 9, 1))
 
+        // Act & Assert
         assertTrue(jan2020Aug2020.overlapperHeltEllerDelvisMed(jul2020Des2020))
         assertTrue(jul2020Des2020.overlapperHeltEllerDelvisMed(jan2020Aug2020))
         assertTrue(jan2020Aug2020.overlapperHeltEllerDelvisMed(des2019Sep2021))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/common/UtilsTest.kt
@@ -35,6 +35,7 @@ internal class UtilsTest {
 
     @Test
     fun `Nullable verdier blir tom string`() {
+        // Arrange
         val adresse =
             GrVegadresseBostedsadresse(
                 matrikkelId = null,
@@ -48,25 +49,34 @@ internal class UtilsTest {
                 poststed = null,
             )
 
+        // Act & Assert
         assertEquals("Test 1, 1234", adresse.tilFrontendString())
     }
 
     @Test
     fun `hent property fra maven skal ikke være blank`() {
+        // Act
         val result = hentPropertyFraMaven("java.version")
+
+        // Assert
         assertTrue(result?.isNotBlank() == true)
     }
 
     @Test
     fun `hent property som mangler skal returnere null`() {
+        // Act
         val result = hentPropertyFraMaven("skalikkefinnes")
+
+        // Assert
         assertTrue(result.isNullOrEmpty())
     }
 
     @Test
     fun `Test transformering av en personer til brevtekst`() {
+        // Arrange
         val førsteBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
 
+        // Act & Assert
         assertEquals(
             førsteBarn.fødselsdato.tilKortString(),
             listOf(førsteBarn.fødselsdato).tilBrevTekst(),
@@ -75,9 +85,11 @@ internal class UtilsTest {
 
     @Test
     fun `Test transformering av to personer til brevtekst`() {
+        // Arrange
         val førsteBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
         val andreBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
 
+        // Act & Assert
         assertEquals(
             "${førsteBarn.fødselsdato.tilKortString()} og ${andreBarn.fødselsdato.tilKortString()}",
             listOf(førsteBarn.fødselsdato, andreBarn.fødselsdato).tilBrevTekst(),
@@ -86,10 +98,12 @@ internal class UtilsTest {
 
     @Test
     fun `Test transformering av tre personer til brevtekst`() {
+        // Arrange
         val førsteBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
         val andreBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
         val tredjeBarn = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(6))
 
+        // Act & Assert
         assertEquals(
             "${førsteBarn.fødselsdato.tilKortString()}, ${andreBarn.fødselsdato.tilKortString()} og ${tredjeBarn.fødselsdato.tilKortString()}",
             listOf(førsteBarn.fødselsdato, andreBarn.fødselsdato, tredjeBarn.fødselsdato).tilBrevTekst(),
@@ -110,8 +124,13 @@ internal class UtilsTest {
     inner class TilEtterfølgendePar {
         @Test
         fun `skal plukke ut to og to etterfølgende elementer inkludert det siste elementet`() {
+            // Arrange
             val liste = listOf(1, 2, 3, 4, 5)
+
+            // Act
             val par = liste.tilEtterfølgendePar { a, b -> a to b }
+
+            // Assert
             assertThat(par).hasSize(5)
             assertThat(par[0]).isEqualTo(Pair(1, 2))
             assertThat(par[1]).isEqualTo(Pair(2, 3))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/KafkaAivenErrorHandlerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/KafkaAivenErrorHandlerTest.kt
@@ -24,6 +24,7 @@ class KafkaAivenErrorHandlerTest {
 
     @Test
     fun `handle skal stoppe container hvis man mottar feil med en tom liste med records`() {
+        // Act & Assert
         assertThatThrownBy {
             errorHandler.handleRemaining(
                 RuntimeException("Feil i test"),
@@ -39,7 +40,10 @@ class KafkaAivenErrorHandlerTest {
 
     @Test
     fun `handle skal stoppe container hvis man mottar feil med en liste med records`() {
+        // Arrange
         val consumerRecord = ConsumerRecord("topic", 1, 1, 1, "record")
+
+        // Act & Assert
         assertThatThrownBy {
             errorHandler.handleRemaining(
                 RuntimeException("Feil i test"),
@@ -55,6 +59,7 @@ class KafkaAivenErrorHandlerTest {
 
     @Test
     fun `handle skal stoppe container hvis man mottar feil hvor liste med records er empty`() {
+        // Act & Assert
         assertThatThrownBy {
             errorHandler.handleRemaining(
                 RuntimeException("Feil i test"),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/UnleashServiceInjectionTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/config/UnleashServiceInjectionTest.kt
@@ -12,12 +12,14 @@ import org.springframework.stereotype.Service
 class UnleashServiceInjectionTest {
     @Test
     fun `UnleashService skal kun være injected i FeatureToggleService`() {
+        // Arrange
         val scanner =
             ClassPathScanningCandidateComponentProvider(false).apply {
                 addIncludeFilter(AnnotationTypeFilter(Service::class.java))
                 addIncludeFilter(AnnotationTypeFilter(Component::class.java))
             }
 
+        // Act
         val classesWithUnleashServiceInjection =
             scanner
                 .findCandidateComponents("no.nav.familie.ba.sak")
@@ -38,6 +40,7 @@ class UnleashServiceInjectionTest {
                     hasConstructorInjection || hasFieldInjection
                 }.map { it.simpleName }
 
+        // Assert
         assertThat(classesWithUnleashServiceInjection)
             .describedAs(
                 "UnleashService er feilaktig injected. Bruk FeatureToggleService i stedet.",

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/DtoMappingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/DtoMappingTest.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 class DtoMappingTest {
     @Test
     fun `Manglende angitt flyttedato fra freg mappes som manglende dato`() {
+        // Arrange
         val adresseUtenFlyttedato =
             GrVegadresseBostedsadresse(
                 matrikkelId = 1234,
@@ -39,12 +40,14 @@ class DtoMappingTest {
                 poststed = "poststed",
             ).apply { periode = DatoIntervallEntitet(fom = flyttedato) }
 
+        // Assert
         assertEquals(null, adresseUtenFlyttedato.tilRegisteropplysningDto().fom)
         assertEquals(flyttedato, adresseMedFlyttedato.tilRegisteropplysningDto().fom)
     }
 
     @Test
     fun `Fyller ut og sorterer i rett rekkefølge`() {
+        // Arrange
         val fomA = LocalDate.of(2001, 1, 1)
         val fomB = LocalDate.of(2005, 1, 1)
         val tomB = LocalDate.of(2006, 1, 1)
@@ -55,9 +58,11 @@ class DtoMappingTest {
         val tidligereMedTom = RegisteropplysningDto(fom = fomB, tom = tomB, verdi = "")
         val nåværende = RegisteropplysningDto(fom = fomC, tom = null, verdi = "")
 
+        // Act
         val utfylteOpplysninger =
             listOf(manglerDatoer, tidligereUtenTom, tidligereMedTom, nåværende).shuffled().fyllInnTomDatoer()
 
+        // Assert
         assertEquals(null, utfylteOpplysninger[0].tom)
         assertEquals(fomB.minusDays(1), utfylteOpplysninger[1].tom)
         assertEquals(tomB, utfylteOpplysninger[2].tom)
@@ -66,11 +71,16 @@ class DtoMappingTest {
 
     @Test
     fun `Fyller ut tom-dato når denne mangler og det er påfølgende periode`() {
+        // Arrange
         val tidligereUtenTom = RegisteropplysningDto(fom = LocalDate.of(2001, 1, 1), tom = null, verdi = "")
         val nåværendeFom = LocalDate.of(2005, 1, 1)
         val nåværende = RegisteropplysningDto(fom = nåværendeFom, tom = null, verdi = "")
+
+        // Act
         val utfylteOpplysninger =
             listOf(tidligereUtenTom, nåværende).fyllInnTomDatoer()
+
+        // Assert
         assertEquals(nåværendeFom.minusDays(1), utfylteOpplysninger[0].tom)
     }
 
@@ -82,7 +92,10 @@ class DtoMappingTest {
 
     @Test
     fun `Fyller ikke ut tom-dato når denne er kjent, ved utvandring`() {
+        // Arrange
         val tomDato = LocalDate.of(2006, 1, 1)
+
+        // Assert
         assertEquals(tomDato, listOf(RegisteropplysningDto(fom = LocalDate.of(2005, 1, 1), tom = tomDato, verdi = ""))[0].tom)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysServiceTest.kt
@@ -47,6 +47,7 @@ internal class BisysServiceTest {
 
     @Test
     fun `Skal returnere tom liste siden person ikke har finens i infotrygd og barnetrygd`() {
+        // Arrange
         val fnr = randomFnr()
         val aktør = lagAktør(fnr)
 
@@ -60,22 +61,28 @@ internal class BisysServiceTest {
 
         every { mockFagsakRepository.finnFagsakForAktør(aktør) } returns null
 
+        // Act
         val response = bisysService.hentUtvidetBarnetrygd(fnr, LocalDate.of(2021, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(0)
     }
 
     @Test
     fun `Skal returnere tom liste hvis tjenesten kalles på en bruker som bare har NPID`() {
+        // Arrange
         every { mockPersonidentService.hentIdenter(any(), any()) } answers { listOf(IdentInformasjon("ident av typen npid", false, Type.NPID.name)) }
 
+        // Act
         val response = bisysService.hentUtvidetBarnetrygd("ident av typen npid", LocalDate.of(2021, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(0)
     }
 
     @Test
     fun `Skal returnere periode kun fra infotrygd`() {
+        // Arrange
         val fnr = randomFnr()
         val aktør = lagAktør(fnr)
 
@@ -98,13 +105,16 @@ internal class BisysServiceTest {
 
         every { mockFagsakRepository.finnFagsakForAktør(aktør) } returns null
 
+        // Act
         val response = bisysService.hentUtvidetBarnetrygd(fnr, LocalDate.of(2021, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(1).contains(periodeInfotrygd)
     }
 
     @Test
     fun `Skal returnere utvidet barnetrygdperiode fra basak`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
@@ -132,9 +142,11 @@ internal class BisysServiceTest {
         every { mockPersonidentService.hentAlleFødselsnummerForEnAktør(any()) } answers { listOf(behandling.fagsak.aktør.aktivFødselsnummer()) }
         every { mockPersonidentService.hentIdenter(any(), any()) } answers { listOf(IdentInformasjon(behandling.fagsak.aktør.aktivFødselsnummer(), false, Type.FOLKEREGISTERIDENT.name)) }
 
+        // Act
         val response =
             bisysService.hentUtvidetBarnetrygd(andelTilkjentYtelse.aktør.aktivFødselsnummer(), LocalDate.of(2021, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(1)
         assertThat(response.perioder.first().beløp).isEqualTo(660.0)
         assertThat(response.perioder.first().fomMåned).isEqualTo(YearMonth.of(2020, 1))
@@ -144,6 +156,7 @@ internal class BisysServiceTest {
 
     @Test
     fun `Skal slå sammen resultat fra ba-sak og infotrygd`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
@@ -188,9 +201,11 @@ internal class BisysServiceTest {
         every { mockBehandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns behandling
         every { mockTilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(behandling.id) } returns andelTilkjentYtelse.tilkjentYtelse
 
+        // Act
         val response =
             bisysService.hentUtvidetBarnetrygd(andelTilkjentYtelse.aktør.aktivFødselsnummer(), LocalDate.of(2019, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(1)
         assertThat(response.perioder.first().beløp).isEqualTo(660.0)
         assertThat(response.perioder.first().fomMåned).isEqualTo(YearMonth.of(2019, 1))
@@ -200,6 +215,7 @@ internal class BisysServiceTest {
 
     @Test
     fun `Skal slå sammen resultat fra ba-sak og infotrygd når periodene overlapper`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
@@ -243,9 +259,11 @@ internal class BisysServiceTest {
         every { mockBehandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns behandling
         every { mockTilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(behandling.id) } returns andelTilkjentYtelse.tilkjentYtelse
 
+        // Act
         val response =
             bisysService.hentUtvidetBarnetrygd(andelTilkjentYtelse.aktør.aktivFødselsnummer(), LocalDate.of(2021, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(1)
         assertThat(response.perioder.first().beløp).isEqualTo(1054.0)
         assertThat(response.perioder.first().fomMåned).isEqualTo(YearMonth.of(2020, 9))
@@ -255,6 +273,7 @@ internal class BisysServiceTest {
 
     @Test
     fun `Skal slå sammen resultat fra ba-sak og infotrygd, typisk rett etter en migrering, hvor tomMåned i infotrygd er null`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling, utbetalingsoppdrag = lagMinimalUtbetalingsoppdragString(behandlingId = behandling.id))
@@ -298,9 +317,11 @@ internal class BisysServiceTest {
         every { mockBehandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns behandling
         every { mockTilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(behandling.id) } returns andelTilkjentYtelse.tilkjentYtelse
 
+        // Act
         val response =
             bisysService.hentUtvidetBarnetrygd(andelTilkjentYtelse.aktør.aktivFødselsnummer(), LocalDate.of(2021, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(1)
         assertThat(response.perioder.first().beløp).isEqualTo(1054.0)
         assertThat(response.perioder.first().fomMåned).isEqualTo(YearMonth.of(2019, 3))
@@ -310,6 +331,7 @@ internal class BisysServiceTest {
 
     @Test
     fun `Skal ikke slå sammen resultat fra ba-sak og infotrygd hvis periode er manuelt beregnet i infotrygd`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val tilkjentYtelse =
@@ -356,9 +378,11 @@ internal class BisysServiceTest {
         every { mockBehandlingHentOgPersisterService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns behandling
         every { mockTilkjentYtelseRepository.findByBehandlingAndHasUtbetalingsoppdrag(behandling.id) } returns andelTilkjentYtelse.tilkjentYtelse
 
+        // Act
         val response =
             bisysService.hentUtvidetBarnetrygd(andelTilkjentYtelse.aktør.aktivFødselsnummer(), LocalDate.of(2019, 1, 1))
 
+        // Assert
         assertThat(response.perioder).hasSize(2)
         assertThat(response.perioder.first().beløp).isEqualTo(660.0)
         assertThat(response.perioder.first().fomMåned).isEqualTo(YearMonth.of(2019, 1))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/SendMeldingTilBisysTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/SendMeldingTilBisysTaskTest.kt
@@ -73,6 +73,7 @@ class SendMeldingTilBisysTaskTest {
 
     @Test
     fun `Skal send riktig melding til Bisys hvis barnetrygd er opphørt`() {
+        // Arrange
         val (behandlingRepository, kafkaProducer, tilkjentYtelseRepository, kafkaResult, behandling) = setupMocks()
         val sendMeldingTilBisysTask =
             SendMeldingTilBisysTask(kafkaProducer, tilkjentYtelseRepository, behandlingRepository)
@@ -112,8 +113,10 @@ class SendMeldingTilBisysTaskTest {
             )
         } returns kafkaResult
 
+        // Act
         sendMeldingTilBisysTask.doTask(SendMeldingTilBisysTask.opprettTask(behandling[1].id))
 
+        // Assert
         verify(exactly = 1) { kafkaProducer.kafkaAivenTemplate.send(any(), any(), any()) }
         val jsonMelding = jsonMapper.readValue(meldingSlot.captured, BarnetrygdBisysMelding::class.java)
         assertThat(jsonMelding.søker).isEqualTo(behandling[1].fagsak.aktør.aktivFødselsnummer())
@@ -125,6 +128,7 @@ class SendMeldingTilBisysTaskTest {
 
     @Test
     fun `Skal send riktig melding til Bisys hvis barnetrygd er redusert`() {
+        // Arrange
         val (behandlingRepository, kafkaProducer, tilkjentYtelseRepository, kafkaResult, behandling) = setupMocks()
         val sendMeldingTilBisysTask =
             SendMeldingTilBisysTask(kafkaProducer, tilkjentYtelseRepository, behandlingRepository)
@@ -172,8 +176,10 @@ class SendMeldingTilBisysTaskTest {
             )
         } returns kafkaResult
 
+        // Act
         sendMeldingTilBisysTask.doTask(SendMeldingTilBisysTask.opprettTask(behandling[1].id))
 
+        // Assert
         verify(exactly = 1) { kafkaProducer.kafkaAivenTemplate.send(any(), any(), any()) }
         val jsonMelding = jsonMapper.readValue(meldingSlot.captured, BarnetrygdBisysMelding::class.java)
         assertThat(jsonMelding.søker).isEqualTo(behandling[1].fagsak.aktør.aktivFødselsnummer())
@@ -185,6 +191,7 @@ class SendMeldingTilBisysTaskTest {
 
     @Test
     fun `finnBarnEndretOpplysning() skal return riktig endret opplysning for barn`() {
+        // Arrange
         val (behandlingRepository, kafkaProducer, tilkjentYtelseRepository, _, behandling) = setupMocks()
 
         val sendMeldingTilBisysTask =
@@ -270,7 +277,10 @@ class SendMeldingTilBisysTaskTest {
                 )
             }
 
+        // Act
         val endretPerioder = sendMeldingTilBisysTask.finnBarnEndretOpplysning(behandling[1])
+
+        // Assert
         val barn1Perioder = endretPerioder[barn1.aktør.aktivFødselsnummer()]
         val barn2Perioder = endretPerioder[barn2.aktør.aktivFødselsnummer()]
         val barn3Perioder = endretPerioder[barn3.aktør.aktivFødselsnummer()]
@@ -296,6 +306,7 @@ class SendMeldingTilBisysTaskTest {
 
     @Test
     fun `Skal ikke sende melding til bisys hvis endring ikke er reduksjon eller opphøring`() {
+        // Arrange
         val (behandlingRepository, kafkaProducer, tilkjentYtelseRepository, _, behandling) = setupMocks()
         val sendMeldingTilBisysTask =
             SendMeldingTilBisysTask(kafkaProducer, tilkjentYtelseRepository, behandlingRepository)
@@ -334,8 +345,10 @@ class SendMeldingTilBisysTaskTest {
                 )
             }
 
+        // Act
         sendMeldingTilBisysTask.doTask(SendMeldingTilBisysTask.opprettTask(behandling[1].id))
 
+        // Assert
         verify(exactly = 0) { kafkaProducer.kafkaAivenTemplate.send(any(), any(), any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/TilkjentYtelseDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/restDomene/TilkjentYtelseDtoTest.kt
@@ -11,6 +11,7 @@ import java.math.BigDecimal
 class TilkjentYtelseDtoTest {
     @Test
     fun `Skal slå sammen etterfølgende andeler med samme kalkulert utbetalingsbeløp, ytelsetype og prosent`() {
+        // Arrange
         val aktør = randomAktør()
 
         val andeler =
@@ -33,13 +34,17 @@ class TilkjentYtelseDtoTest {
                 ),
             )
 
+        // Act
         val ytelsePerioderDto = andeler.tilYtelsePerioderDto()
+
+        // Assert
         val forventetYtelsePeriodeDto = listOf(YtelsePeriodeDto(beløp = 1234, stønadFom = årMnd("2020-03"), stønadTom = årMnd("2021-12"), ytelseType = YtelseType.ORDINÆR_BARNETRYGD, skalUtbetales = true))
         Assertions.assertThat(ytelsePerioderDto).containsAll(forventetYtelsePeriodeDto).hasSize(forventetYtelsePeriodeDto.size)
     }
 
     @Test
     fun `Skal ikke slå sammen etterfølgende andeler med forskjellig kalkulert utbetalingsbeløp, ytelsetype eller prosent`() {
+        // Arrange
         val aktør = randomAktør()
 
         val andeler =
@@ -78,7 +83,10 @@ class TilkjentYtelseDtoTest {
                 ),
             )
 
+        // Act
         val ytelsePerioderDto = andeler.tilYtelsePerioderDto()
+
+        // Assert
         val forventetYtelsePerioderDtos =
             listOf(
                 YtelsePeriodeDto(beløp = 1234, stønadFom = årMnd("2020-03"), stønadTom = årMnd("2020-12"), ytelseType = YtelseType.SMÅBARNSTILLEGG, skalUtbetales = true),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/ekstern/tilbakekreving/HentFagsystemsbehandlingRequestConsumerTest.kt
@@ -98,9 +98,13 @@ internal class HentFagsystemsbehandlingRequestConsumerTest {
 
     @Test
     fun `listen skal lytte request og opprette hentFagsystemsbehandlingRespons`() {
+        // Arrange
         val consumerRecord = ConsumerRecord("testtopic", 1, 1, "1", lagRequest())
+
+        // Act
         hentFagsystemsbehandlingRequestConsumer.listen(consumerRecord, acknowledgment)
 
+        // Assert
         verify { fagsystemsbehandlingService.hentFagsystemsbehandling(capture(requestSlot)) }
 
         val request = requestSlot.captured

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ecb/ECBServiceTest.kt
@@ -39,6 +39,7 @@ class ECBServiceTest {
 
     @Test
     fun `Hent valutakurs for utenlandsk valuta til NOK og sjekk at beregning av kurs er riktig`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 6, 28)
         val valutakursNOK = BigDecimal.valueOf(10.337)
         val valutakursSEK = BigDecimal.valueOf(10.6543)
@@ -58,12 +59,17 @@ class ECBServiceTest {
                 valutakursDato,
             )
         } returns ecbExchangeRatesData.toExchangeRates()
+
+        // Act
         val sekTilNOKValutakurs = ecbService.hentValutakurs("SEK", valutakursDato)
+
+        // Assert
         assertEquals(BigDecimal.valueOf(0.9702185972), sekTilNOKValutakurs)
     }
 
     @Test
     fun `Test at ECBService kaster ESBServiceException dersom de returnerte kursene ikke inneholder kurs for forespurt valuta`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 7, 22)
         val ecbExchangeRatesData =
             createECBResponse(
@@ -79,11 +85,14 @@ class ECBServiceTest {
                 valutakursDato,
             )
         } returns ecbExchangeRatesData.toExchangeRates()
+
+        // Act & Assert
         assertThrows<ECBServiceException> { ecbService.hentValutakurs("SEK", valutakursDato) }
     }
 
     @Test
     fun `Test at ECBService kaster ESBServiceException dersom de returnerte kursene ikke inneholder kurser med forespurt dato`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 7, 20)
         val ecbExchangeRatesData =
             createECBResponse(
@@ -99,11 +108,14 @@ class ECBServiceTest {
                 valutakursDato,
             )
         } returns ecbExchangeRatesData.toExchangeRates()
+
+        // Act & Assert
         assertThrows<ECBServiceException> { ecbService.hentValutakurs("SEK", valutakursDato) }
     }
 
     @Test
     fun `Test at ECBService returnerer NOK til EUR dersom den forespurte valutaen er EUR`() {
+        // Arrange
         val nokTilEur = BigDecimal.valueOf(9.4567)
         val valutakursDato = LocalDate.of(2022, 7, 20)
         val ecbExchangeRatesData =
@@ -121,6 +133,8 @@ class ECBServiceTest {
                 valutakursDato,
             )
         } returns ecbExchangeRatesData.toExchangeRates()
+
+        // Act & Assert
         assertEquals(nokTilEur, ecbService.hentValutakurs("EUR", valutakursDato))
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/FamilieIntegrasjonerTilgangskontrollServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/FamilieIntegrasjonerTilgangskontrollServiceTest.kt
@@ -31,7 +31,10 @@ class FamilieIntegrasjonerTilgangskontrollServiceTest {
 
     @Test
     fun `har tilgang skal cacheas`() {
+        // Arrange
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang("1", true)))
+
+        // Act & Assert
         assertThat(testWithBrukerContext { service.sjekkTilgangTilPerson("1") }.harTilgang).isTrue
         fakeFamilieIntegrasjonerTilgangskontrollKlient.reset()
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang("1", false)))
@@ -40,7 +43,10 @@ class FamilieIntegrasjonerTilgangskontrollServiceTest {
 
     @Test
     fun `har ikke tilgang skal caches`() {
+        // Arrange
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang("1", false)))
+
+        // Act & Assert
         assertThat(testWithBrukerContext { service.sjekkTilgangTilPerson("1") }.harTilgang).isFalse
         fakeFamilieIntegrasjonerTilgangskontrollKlient.reset()
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang("1", true)))
@@ -49,37 +55,47 @@ class FamilieIntegrasjonerTilgangskontrollServiceTest {
 
     @Test
     fun `cacher per saksbehandlere`() {
+        // Arrange
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang("1", false)))
 
+        // Act
         // Systemcontext
         service.sjekkTilgangTilPerson("1")
         val kall1 = testWithBrukerContext("saksbehandler1") { service.sjekkTilgangTilPerson("1") }
         fakeFamilieIntegrasjonerTilgangskontrollKlient.reset()
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang("1", true)))
         val kall2 = testWithBrukerContext("saksbehandler2") { service.sjekkTilgangTilPerson("1") }
+
+        // Assert
         assertThat(kall1.harTilgang).isFalse
         assertThat(kall2.harTilgang).isTrue
     }
 
     @Test
     fun `tilgangskontrollerer unike identer`() {
+        // Arrange
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang("1", false)))
 
+        // Act
         testWithBrukerContext("saksbehandler1") { service.sjekkTilgangTilPersoner(listOf("1", "1")) }
 
+        // Assert
         assertThat(fakeFamilieIntegrasjonerTilgangskontrollKlient.antallKallTilSjekkTilgangTilPersoner()).isEqualTo(1)
     }
 
     @Test
     fun `skal ikke hente identer som allerede finnes i cachen`() {
+        // Arrange
         val tilgang = listOf(Tilgang("1", false), Tilgang("2", true), Tilgang("3", false))
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(tilgang)
 
+        // Act
         testWithBrukerContext { service.sjekkTilgangTilPerson("1") }
         val sjekkTilgangTilPersoner = testWithBrukerContext { service.sjekkTilgangTilPersoner(listOf("2", "1", "3")) }
         testWithBrukerContext { service.sjekkTilgangTilPersoner(listOf("2", "1", "3")) }
         testWithBrukerContext { service.sjekkTilgangTilPersoner(listOf("3", "3", "3")) }
 
+        // Assert
         assertThat(sjekkTilgangTilPersoner.all { it.key == it.value.personIdent })
         assertThat(sjekkTilgangTilPersoner.map { it.key to it.value.harTilgang }).containsExactlyInAnyOrderElementsOf(
             tilgang.map { tilgang -> Pair(tilgang.personIdent, tilgang.harTilgang) }.toList(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdControllerTest.kt
@@ -48,6 +48,7 @@ class InfotrygdControllerTest {
 
     @Test
     fun `hentInfotrygdsakerForSøker skal returnere ok dersom saksbehandler har tilgang`() {
+        // Arrange
         val fnr = "12345678910"
 
         every { personidentService.hentAktør(fnr) } returns lagAktør(fnr)
@@ -58,8 +59,11 @@ class InfotrygdControllerTest {
                 any(),
             )
         } returns InfotrygdSøkResponse(listOf(Sak(status = "IP")), emptyList())
+
+        // Act
         val respons = infotrygdController.hentInfotrygdsakerForSøker(Personident(fnr))
 
+        // Assert
         Assertions.assertEquals(HttpStatus.OK, respons.statusCode)
         Assertions.assertEquals(true, respons.body?.data?.harTilgang)
         Assertions.assertEquals(
@@ -73,6 +77,7 @@ class InfotrygdControllerTest {
 
     @Test
     fun `hentInfotrygdsakerForSøker skal returnere ok, men ha gradering satt, dersom saksbehandler ikke har tilgang`() {
+        // Arrange
         val fnr = "12345678910"
 
         every { personidentService.hentAktør(fnr) } returns lagAktør(fnr)
@@ -81,8 +86,10 @@ class InfotrygdControllerTest {
         every { systemOnlyPdlRestKlient.hentAdressebeskyttelse(any()) } returns
             listOf(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.FORTROLIG))
 
+        // Act
         val respons = infotrygdController.hentInfotrygdsakerForSøker(Personident(fnr))
 
+        // Assert
         Assertions.assertEquals(HttpStatus.OK, respons.statusCode)
         Assertions.assertEquals(false, respons.body?.data?.harTilgang)
         Assertions.assertEquals(ADRESSEBESKYTTELSEGRADERING.FORTROLIG, respons.body?.data?.adressebeskyttelsegradering)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdFeedServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdFeedServiceTest.kt
@@ -17,12 +17,17 @@ internal class InfotrygdFeedServiceTest {
 
     @Test
     fun `Skal send riktig start behandling feed`() {
+        // Arrange
         val ident = "12345678900"
         val identSlot = slot<Aktør>()
         every { opprettTaskServiceMock.opprettSendStartBehandlingTilInfotrygdTask(capture(identSlot)) } just runs
 
         val infotrygdFeedService = InfotrygdFeedService(opprettTaskServiceMock)
+
+        // Act
         infotrygdFeedService.sendStartBehandlingTilInfotrygdFeed(lagAktør(ident))
+
+        // Assert
         verify(exactly = 1) {
             opprettTaskServiceMock.opprettSendStartBehandlingTilInfotrygdTask(any())
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/oppgave/OppgaveControllerTest.kt
@@ -50,32 +50,39 @@ class OppgaveControllerTest {
 
     @Test
     fun `Tildeling av oppgave til saksbehandler skal returnere OK og sende med OppgaveId i respons`() {
+        // Arrange
         val oppgaveId = "1234"
         val saksbehandlerId = "Z999999"
         every { oppgaveService.fordelOppgave(any(), any()) } returns oppgaveId
 
+        // Act
         val respons = oppgaveController.fordelOppgave(oppgaveId.toLong(), saksbehandlerId)
 
+        // Assert
         Assertions.assertEquals(HttpStatus.OK, respons.statusCode)
         Assertions.assertEquals(oppgaveId, respons.body?.data)
     }
 
     @Test
     fun `Tilbakestilling av tildeling på oppgave skal returnere OK og sende med Oppgave i respons`() {
+        // Arrange
         val oppgave =
             Oppgave(
                 id = 1234,
             )
         every { oppgaveService.tilbakestillFordelingPåOppgave(oppgave.id!!) } returns oppgave
 
+        // Act
         val respons = oppgaveController.tilbakestillFordelingPåOppgave(oppgave.id!!)
 
+        // Assert
         Assertions.assertEquals(HttpStatus.OK, respons.statusCode)
         Assertions.assertEquals(oppgave, respons.body?.data)
     }
 
     @Test
     fun `Tildeling av oppgave skal returnere feil ved feil fra integrasjonsklienten`() {
+        // Arrange
         val oppgaveId = "1234"
         val saksbehandlerId = "Z999998"
         every {
@@ -85,6 +92,7 @@ class OppgaveControllerTest {
             )
         } throws IntegrasjonException("Kall mot integrasjon feilet ved fordel oppgave")
 
+        // Act & Assert
         val exception =
             assertThrows<IntegrasjonException> {
                 oppgaveController.fordelOppgave(
@@ -98,10 +106,15 @@ class OppgaveControllerTest {
 
     @Test
     fun `hentOppgaver via OppgaveController skal fungere`() {
+        // Arrange
         every {
             oppgaveService.hentOppgaver(any())
         } returns FinnOppgaveResponseDto(1, listOf(Oppgave(tema = Tema.BAR)))
+
+        // Act
         val response = oppgaveController.hentOppgaver(FinnOppgaveRequestDto())
+
+        // Assert
         val oppgaverOgAntall = response.body?.data as FinnOppgaveResponseDto
         Assertions.assertEquals(1, oppgaverOgAntall.antallTreffTotalt)
         Assertions.assertEquals(Tema.BAR, oppgaverOgAntall.oppgaver.first().tema)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PdlGraphqlTest.kt
@@ -26,8 +26,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testDeserialization() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlOkResponse.json")))
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .foedselsdato
@@ -105,8 +108,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testTomAdresse() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlTomAdresseOkResponse.json")))
+
+        // Assert
         assertTrue(
             resp.data.person!!
                 .bostedsadresse
@@ -116,10 +122,13 @@ class PdlGraphqlTest {
 
     @Test
     fun testForelderBarnRelasjon() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonRelasjonerResponse>>(
                 File(getFile("pdl/pdlForelderBarnRelasjonResponse.json")),
             )
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .forelderBarnRelasjon
@@ -138,8 +147,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testMatrikkelAdresse() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlMatrikkelAdresseOkResponse.json")))
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .bostedsadresse
@@ -158,10 +170,13 @@ class PdlGraphqlTest {
 
     @Test
     fun testUkjentBostedAdresse() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(
                 File(getFile("pdl/pdlUkjentBostedAdresseOkResponse.json")),
             )
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .bostedsadresse
@@ -173,10 +188,13 @@ class PdlGraphqlTest {
 
     @Test
     fun testDoedtfodtBarn() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(
                 File(getFile("pdl/pdlDoedfoedtBarnOkResponse.json")),
             )
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .doedfoedtBarn
@@ -187,10 +205,13 @@ class PdlGraphqlTest {
 
     @Test
     fun testAdressebeskyttelse() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlAdressebeskyttelseResponse>>(
                 File(getFile("pdl/pdlAdressebeskyttelseResponse.json")),
             )
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .adressebeskyttelse
@@ -201,8 +222,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testDeserializationOfResponseWithErrors() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlPersonIkkeFunnetResponse.json")))
+
+        // Assert
         assertThat(resp.harFeil()).isTrue
         assertThat(resp.errorMessages()).contains("Fant ikke person", "Ikke tilgang")
         assertThat(resp.errors!!.any { it.extensions?.notFound() == true }).isTrue
@@ -210,8 +234,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testDeserializationOfResponseWithoutFødselsdato() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlManglerFoedselResponse.json")))
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .foedselsdato
@@ -241,8 +268,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testDeserialiseringAvResponsMedToNavn() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlMedToNavnOgToKjonn.json")))
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .navn
@@ -253,8 +283,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testDeserialiseringAvResponsMedToKjønn() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlMedToNavnOgToKjonn.json")))
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .kjoenn
@@ -265,8 +298,11 @@ class PdlGraphqlTest {
 
     @Test
     fun testDeserialiseringAvResponsMedUgyldigeKilder() {
+        // Act
         val resp =
             mapper.readValue<PdlBaseResponse<PdlHentPersonResponse>>(File(getFile("pdl/pdlMedToNavnOgToKjonn.json")))
+
+        // Assert
         assertThat(
             resp.data.person!!
                 .kjoenn

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/sanity/SanityServiceTest.kt
@@ -17,6 +17,7 @@ class SanityServiceTest {
 
     @Test
     fun `hentSanityBegrunnelser - skal hente standardbegrunnelser`() {
+        // Arrange
         every { sanityKlient.hentBegrunnelser() } returns
             Standardbegrunnelse.entries.map {
                 SanityBegrunnelse(
@@ -33,15 +34,19 @@ class SanityServiceTest {
                 )
             }
 
+        // Act
         val begrunnelser = sanityService.hentSanityBegrunnelser()
 
+        // Assert
         assertThat(begrunnelser.keys).isEqualTo(Standardbegrunnelse.entries.toSet())
     }
 
     @Test
     fun `hentSanityBegrunnelser - skal kaste feil hvis det ikke er noen cache`() {
+        // Arrange
         every { sanityKlient.hentBegrunnelser() } throws RuntimeException("Feil ved henting av begrunnelser i test")
 
+        // Act & Assert
         val e = assertThrows<RuntimeException> { sanityService.hentSanityBegrunnelser() }
 
         assertThat(e.message).isEqualTo("Feil ved henting av begrunnelser i test")
@@ -49,6 +54,7 @@ class SanityServiceTest {
 
     @Test
     fun `hentSanityBegrunnelser - skal bruke cachet begrunnelser når sanityklient kaster feil`() {
+        // Arrange
         every { sanityKlient.hentBegrunnelser() } returns
             Standardbegrunnelse.entries.map {
                 SanityBegrunnelse(
@@ -65,6 +71,7 @@ class SanityServiceTest {
                 )
             } andThenThrows RuntimeException("Feil for å teste cachet versjon")
 
+        // Act & Assert
         sanityService.hentSanityBegrunnelser().also { begrunnelser ->
             assertThat(begrunnelser.keys).isEqualTo(Standardbegrunnelse.entries.toSet())
         }
@@ -76,6 +83,7 @@ class SanityServiceTest {
 
     @Test
     fun `hentSanityEØSBegrunnelser - skal ikke filtrere bort nye begrunnelser tilknyttet EØS praksisendring`() {
+        // Arrange
         every { sanityKlient.hentEØSBegrunnelser() } returns
             EØSStandardbegrunnelse.entries.map {
                 SanityEØSBegrunnelse(
@@ -98,15 +106,19 @@ class SanityServiceTest {
                 )
             }
 
+        // Act
         val eøsBegrunnelser = sanityService.hentSanityEØSBegrunnelser()
 
+        // Assert
         assertThat(eøsBegrunnelser.keys).isEqualTo(EØSStandardbegrunnelse.entries.toSet())
     }
 
     @Test
     fun `hentSanityEØSBegrunnelser - skal kaste feil hvis det ikke er noen cache`() {
+        // Arrange
         every { sanityKlient.hentEØSBegrunnelser() } throws RuntimeException("Feil ved henting av EØS-begrunnelser i test")
 
+        // Act & Assert
         val e = assertThrows<RuntimeException> { sanityService.hentSanityEØSBegrunnelser() }
 
         assertThat(e.message).isEqualTo("Feil ved henting av EØS-begrunnelser i test")
@@ -114,6 +126,7 @@ class SanityServiceTest {
 
     @Test
     fun `hentSanityEØSBegrunnelser - skal bruke cachet begrunnelser når sanityklient kaster feil`() {
+        // Arrange
         every { sanityKlient.hentEØSBegrunnelser() } returns
             EØSStandardbegrunnelse.entries.map {
                 SanityEØSBegrunnelse(
@@ -136,6 +149,7 @@ class SanityServiceTest {
                 )
             } andThenThrows RuntimeException("Feil for å teste cachet versjon")
 
+        // Act & Assert
         sanityService.hentSanityEØSBegrunnelser().also { eøsBegrunnelser ->
             assertThat(eøsBegrunnelser).isNotEmpty()
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/HentStatusTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/HentStatusTest.kt
@@ -70,6 +70,7 @@ class HentStatusTest {
 
     @Test
     fun `henter status fra økonomi for behandling der alle utbetalingene hører til denne behandlinga`() {
+        // Arrange
         val tilfeldigPerson = tilfeldigPerson()
         val nyBehandling = lagBehandling()
         lagTilkjentYtelse(nyBehandling, listOf(lagUtbetalingsperiode(nyBehandling)))
@@ -96,14 +97,18 @@ class HentStatusTest {
 
         every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(any()) } returns andelerTilkjentYtelse
 
+        // Act
         val nesteSteg =
             statusFraOppdrag.utførStegOgAngiNeste(nyBehandling, statusFraOppdragMedTask(tilfeldigPerson, nyBehandling))
+
+        // Assert
         assertThat(nesteSteg).isEqualTo(StegType.IVERKSETT_MOT_FAMILIE_TILBAKE)
         verify { økonomiKlient.hentStatus(match { it.behandlingsId == nyBehandling.id.toString() }) }
     }
 
     @Test
     fun `kan håndtere nullutbetaling uten tidligere historikk`() {
+        // Arrange
         val tilfeldigPerson = tilfeldigPerson()
         val nyBehandling = lagBehandling()
         lagTilkjentYtelse(nyBehandling, listOf())
@@ -130,8 +135,11 @@ class HentStatusTest {
 
         every { beregningService.hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(any()) } returns andelerTilkjentYtelse
 
+        // Act
         val nesteSteg =
             statusFraOppdrag.utførStegOgAngiNeste(nyBehandling, statusFraOppdragMedTask(tilfeldigPerson, nyBehandling))
+
+        // Assert
         assertThat(nesteSteg).isEqualTo(StegType.IVERKSETT_MOT_FAMILIE_TILBAKE)
         verify(exactly = 0) { økonomiKlient.hentStatus(any()) }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/KonsistensavstemmingTest.kt
@@ -75,8 +75,11 @@ class KonsistensavstemmingTest {
 
     @Test
     fun `Første gangs kjøring av start task - Verifiser at konsistensavstemOppdragStart oppretter finn perioder for relevante behandlinger task- og avslutt task og sender start melding hvis transaksjon ikke allerede kjørt`() {
+        // Arrange
         val transaksjonsId = UUID.randomUUID()
         val avstemmingsdatoSlot = lagMockForStartTaskHappCase(transaksjonsId)
+
+        // Act
         konistensavstemmingStartTask.doTask(
             Task(
                 payload =
@@ -91,6 +94,7 @@ class KonsistensavstemmingTest {
             ),
         )
 
+        // Assert
         val taskSlots = mutableListOf<Task>()
         verify(atLeast = 1) { taskService.save(capture(taskSlots)) }
         // sjekk at KonsistensavstemMotOppdragFinnPerioderForRelevanteBehandlingerTask er opprettet
@@ -150,6 +154,7 @@ class KonsistensavstemmingTest {
 
     @Test
     fun `Rekjøring av start task - Verifiser at konsistensavstemming ikke kjører hvis alle datachunker allerede er sendt til økonomi for transaksjonId`() {
+        // Arrange
         every { batchRepository.getReferenceById(batchId) } returns
             Batch(
                 kjøreDato = LocalDate.now(),
@@ -157,6 +162,7 @@ class KonsistensavstemmingTest {
             )
         val transaksjonsId = UUID.randomUUID()
 
+        // Act
         konistensavstemmingStartTask.doTask(
             Task(
                 payload =
@@ -171,11 +177,13 @@ class KonsistensavstemmingTest {
             ),
         )
 
+        // Assert
         verify(exactly = 0) { avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker() }
     }
 
     @Test
     fun `Rekjøring av start task - Verifiser at konsistensavstemming kun rekjører chunker som ikke allerede er kjørt`() {
+        // Arrange
         val transaksjonsId = UUID.randomUUID()
         lagMockForStartTaskHappCase(transaksjonsId)
         val datachunks =
@@ -202,6 +210,7 @@ class KonsistensavstemmingTest {
                 .toList()
                 .map { it.toLong() }
 
+        // Act
         konistensavstemmingStartTask.doTask(
             Task(
                 payload =
@@ -216,6 +225,7 @@ class KonsistensavstemmingTest {
             ),
         )
 
+        // Assert
         verify(exactly = 1) { avstemmingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker() }
         val taskSlots = mutableListOf<Task>()
         verify(exactly = 2) { taskService.save(capture(taskSlots)) }
@@ -239,9 +249,11 @@ class KonsistensavstemmingTest {
 
     @Test
     fun `Verifiser at konsistensavstemPeriodeFinnPerioderForRelevanteBehandlingerTask finner perioder for behandlinger og oppretter data task`() {
+        // Arrange
         val transaksjonsId = UUID.randomUUID()
         lagMockFinnPerioderForRelevanteBehandlingerHappeCase()
 
+        // Act
         konsistensavstemMotOppdragFinnPerioderForRelevanteBehandlingerTask.doTask(
             Task(
                 payload =
@@ -258,6 +270,7 @@ class KonsistensavstemmingTest {
             ),
         )
 
+        // Assert
         val taskSlots = mutableListOf<Task>()
         verify(atLeast = 1) { taskService.save(capture(taskSlots)) }
         val konsistensavstemmingDataDto =
@@ -272,6 +285,7 @@ class KonsistensavstemmingTest {
 
     @Test
     fun `Verifiser at konsistensavstemOppdragData sender data og oppdatere datachunk tabellen`() {
+        // Arrange
         val transaksjonsId = UUID.randomUUID()
         lagMockOppdragDataHappeCase(transaksjonsId)
         every { dataChunkRepository.findByTransaksjonsIdAndChunkNr(transaksjonsId, 1) } returns
@@ -288,6 +302,7 @@ class KonsistensavstemmingTest {
             )
         } returns ""
 
+        // Act
         konsistensavstemMotOppdragDataTask.doTask(
             Task(
                 payload =
@@ -304,6 +319,7 @@ class KonsistensavstemmingTest {
             ),
         )
 
+        // Assert
         val dataChunkSlot = slot<DataChunk>()
         verify(exactly = 1) { dataChunkRepository.save(capture(dataChunkSlot)) }
         assertThat(dataChunkSlot.captured.erSendt).isTrue()
@@ -323,8 +339,11 @@ class KonsistensavstemmingTest {
 
     @Test
     fun `Kjør alle tasker med input generert fra task som oppretter tasken`() {
+        // Arrange
         val transaksjonsId = UUID.randomUUID()
         lagMockForStartTaskHappCase(transaksjonsId)
+
+        // Act
         konistensavstemmingStartTask.doTask(
             Task(
                 payload =
@@ -407,8 +426,11 @@ class KonsistensavstemmingTest {
 
     @Test
     fun `Kjør alle tasker med input generert fra task som oppretter tasken og send til økonomi skrudd av`() {
+        // Arrange
         val transaksjonsId = UUID.randomUUID()
         lagMockForStartTaskHappCase(transaksjonsId)
+
+        // Act
         konistensavstemmingStartTask.doTask(
             Task(
                 payload =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtilTest.kt
@@ -14,6 +14,7 @@ import java.time.YearMonth
 class InternKonsistensavstemmingUtilTest {
     @Test
     fun `Skal ignorere forskjeller før første utbetalingsoppdragsperiode`() {
+        // Arrange
         val andelerSisteVedtatteBehandling =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -43,11 +44,13 @@ class InternKonsistensavstemmingUtilTest {
             )
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
 
+        // Act & Assert
         Assertions.assertFalse(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 
     @Test
     fun `skal se at vi mangler andel for oppdragsperiode`() {
+        // Arrange
         val andelerSisteVedtatteBehandling =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -71,11 +74,13 @@ class InternKonsistensavstemmingUtilTest {
             )
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
 
+        // Act & Assert
         Assertions.assertTrue(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 
     @Test
     fun `skal se at andel og oppdragsperiode har forskjellig beløp`() {
+        // Arrange
         val andelerSisteVedtatteBehandling =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -105,11 +110,13 @@ class InternKonsistensavstemmingUtilTest {
             )
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
 
+        // Act & Assert
         Assertions.assertTrue(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 
     @Test
     fun `skal ikke si det er forskjell ved riktig utbetalingsoppdrag når det er flere kjeder`() {
+        // Arrange
         val andelStringer =
             listOf(
                 "2021-05,2021-08,1354,ORDINÆR_BARNETRYGD",
@@ -133,11 +140,13 @@ class InternKonsistensavstemmingUtilTest {
 
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockMedUtvidet)
 
+        // Act & Assert
         Assertions.assertFalse(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 
     @Test
     fun `skal ikke si det er forskjell ved riktig utbetalingsoppdrag når kun ett barn ble endret i siste behandling som iverksatte`() {
+        // Arrange
         val andelStringer =
             listOf(
                 // barn 1, ble laget i siste behandling som iverksatte
@@ -165,11 +174,13 @@ class InternKonsistensavstemmingUtilTest {
 
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockEndringKunEttBarn)
 
+        // Act & Assert
         Assertions.assertFalse(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 
     @Test
     fun `skal ikke si det er forskjell ved opphør`() {
+        // Arrange
         val andelStringer =
             listOf(
                 "2016-02,2019-02,970,ORDINÆR_BARNETRYGD,2193974415300",
@@ -194,11 +205,13 @@ class InternKonsistensavstemmingUtilTest {
 
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockOpphør)
 
+        // Act & Assert
         Assertions.assertFalse(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 
     @Test
     fun `skal si andelene og utbetalingene er like dersom andel blir splittet opp, men betaler ut det samme i periodene`() {
+        // Arrange
         val andelStringer =
             listOf(
                 "2021-01,2022-03,1054,ORDINÆR_BARNETRYGD",
@@ -220,6 +233,7 @@ class InternKonsistensavstemmingUtilTest {
 
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockEnPeriode)
 
+        // Act & Assert
         Assertions.assertFalse(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/ForvalterSchedulerTest.kt
@@ -35,8 +35,10 @@ class ForvalterSchedulerTest {
 
     @Test
     fun `Skal opprette task av type finnSakerMedFlereMigreringsbehandlinger`() {
+        // Act
         service.opprettFinnSakerMedFlereMigreringsbehandlingerTask()
 
+        // Assert
         assertThat(slot.captured.payload).isEqualTo(YearMonth.now().minusMonths(1).toString())
         assertThat(slot.captured.type).isEqualTo("finnSakerMedFlereMigreringsbehandlinger")
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FlerlingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FlerlingUtilsTest.kt
@@ -15,8 +15,11 @@ import java.time.LocalDate
 class FlerlingUtilsTest {
     @Test
     fun `Skal behandle 1 barn når mor ikke har andre barn`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, _) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse = NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barn)),
@@ -31,15 +34,19 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = emptyList(),
             )
 
+        // Assert
         assertEquals(1, barnSomSkalBehandlesForMor.size)
         assertTrue(barnSomSkalBehandlesForMor.contains(barn))
     }
 
     @Test
     fun `Skal behandle 1 barn når mor har andre barn`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
         val barn2 = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, _) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse = NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barn)),
@@ -59,15 +66,19 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = listOf(barn2),
             )
 
+        // Assert
         assertEquals(1, barnSomSkalBehandlesForMor.size)
         assertTrue(barnSomSkalBehandlesForMor.contains(barn))
     }
 
     @Test
     fun `Skal behandle 0 barn når mor har tvillinger og de allerede er behandlet`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
         val barn2 = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, alleBarnSomKanBehandles) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse = NyBehandlingHendelse(morsIdent = morsIdent, barnasIdenter = listOf(barn2)),
@@ -87,15 +98,19 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = listOf(barn, barn2),
             )
 
+        // Assert
         assertEquals(0, barnSomSkalBehandlesForMor.size)
         assertEquals(1, alleBarnSomKanBehandles.size)
     }
 
     @Test
     fun `Skal behandle 2 barn når hendelse inneholder flere barn og mor har ikke andre barn selv om barn ikke er definert som flerling`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
         val barn2 = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, _) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse =
@@ -119,6 +134,7 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = emptyList(),
             )
 
+        // Assert
         assertEquals(2, barnSomSkalBehandlesForMor.size)
         assertTrue(barnSomSkalBehandlesForMor.contains(barn))
         assertTrue(barnSomSkalBehandlesForMor.contains(barn2))
@@ -126,9 +142,12 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal behandle 2 barn når mor har fått tvilling på samme dag og hendelse inneholder 1 barn`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
         val barn2 = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, _) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse =
@@ -152,6 +171,7 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = emptyList(),
             )
 
+        // Assert
         assertEquals(2, barnSomSkalBehandlesForMor.size)
         assertTrue(barnSomSkalBehandlesForMor.contains(barn))
         assertTrue(barnSomSkalBehandlesForMor.contains(barn2))
@@ -159,12 +179,15 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal behandle 4 barn når mor har fått firlinger på samme dag og hendelse inneholder 1 barn`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
         val barn2 = randomFnr()
         val barn3 = randomFnr()
         val barn4 = randomFnr()
         val barn5 = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, _) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse =
@@ -198,6 +221,7 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = listOf(barn5),
             )
 
+        // Assert
         assertEquals(4, barnSomSkalBehandlesForMor.size)
         assertTrue(barnSomSkalBehandlesForMor.contains(barn))
         assertTrue(barnSomSkalBehandlesForMor.contains(barn2))
@@ -207,9 +231,12 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal behandle 2 barn når mor har fått tvilling med 1 dag mellomrom og hendelse inneholder 1 barn født dagen etter tvilling`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
         val barn2 = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, _) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse =
@@ -233,6 +260,7 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = emptyList(),
             )
 
+        // Assert
         assertEquals(2, barnSomSkalBehandlesForMor.size)
         assertTrue(barnSomSkalBehandlesForMor.contains(barn))
         assertTrue(barnSomSkalBehandlesForMor.contains(barn2))
@@ -240,9 +268,12 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal behandle 2 barn når mor har fått tvilling med 1 dag mellomrom og hendelse inneholder 1 barn født dagen før tvilling`() {
+        // Arrange
         val morsIdent = randomFnr()
         val barn = randomFnr()
         val barn2 = randomFnr()
+
+        // Act
         val (barnSomSkalBehandlesForMor, _) =
             finnBarnSomSkalBehandlesForMor(
                 nyBehandlingHendelse =
@@ -266,6 +297,7 @@ class FlerlingUtilsTest {
                 barnaSomHarBlittBehandlet = emptyList(),
             )
 
+        // Assert
         assertEquals(2, barnSomSkalBehandlesForMor.size)
         assertTrue(barnSomSkalBehandlesForMor.contains(barn))
         assertTrue(barnSomSkalBehandlesForMor.contains(barn2))
@@ -273,9 +305,11 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal lage oppgave fordi barnet i hendelse ikke behandles på åpen behandling`() {
+        // Arrange
         val barn = randomAktør()
         val barn2 = randomAktør()
 
+        // Act & Assert
         assertFalse(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(
                 barnaPåHendelse = listOf(barn),
@@ -286,9 +320,11 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal ignorere hendelse fordi barnet i hendelse behandles på åpen behandling`() {
+        // Arrange
         val barn = randomAktør()
         val barn2 = randomAktør()
 
+        // Act & Assert
         assertTrue(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(
                 barnaPåHendelse = listOf(barn),
@@ -299,10 +335,12 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal ignorere hendelse fordi barna i hendelse behandles på åpen behandling`() {
+        // Arrange
         val barn = randomAktør()
         val barn2 = randomAktør()
         val barn3 = randomAktør()
 
+        // Act & Assert
         assertTrue(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(
                 barnaPåHendelse = listOf(barn, barn2),
@@ -313,10 +351,12 @@ class FlerlingUtilsTest {
 
     @Test
     fun `Skal lage oppgave fordi kun 1 av barna i hendelse behandles på åpen behandling`() {
+        // Arrange
         val barn = randomAktør()
         val barn2 = randomAktør()
         val barn3 = randomAktør()
 
+        // Act & Assert
         assertFalse(
             barnPåHendelseBlirAlleredeBehandletIÅpenBehandling(
                 barnaPåHendelse = listOf(barn, barn2),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/FødselshendelseServiceTest.kt
@@ -82,6 +82,7 @@ class FødselshendelseServiceTest {
 
     @Test
     fun `Skal opprette manuell oppgave hvis resultat av fødselshendelse blir INNVILGET_OG_ENDRET`() {
+        // Arrange
         val søkerPerson = lagPerson(type = PersonType.SØKER)
         val fagsak = defaultFagsak(aktør = søkerPerson.aktør)
 
@@ -188,7 +189,10 @@ class FødselshendelseServiceTest {
                 ),
             )
 
+        // Act
         autovedtakFødselshendelseService.kjørBehandling(FødselshendelseData(nyBehandlingHendelse))
+
+        // Assert
         verify(exactly = 0) {
             opprettTaskService.opprettOppgaveForManuellBehandlingTask(
                 behandlingId = any(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelForFlereBarnTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelForFlereBarnTest.kt
@@ -87,11 +87,13 @@ class FiltreringsregelForFlereBarnTest {
 
     @Test
     fun `Regelevaluering skal resultere i NEI når det har gått mellom fem dager og fem måneder siden forrige minst ett barn ble født`() {
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 genererFaktaMedTidligereBarn(1, 3, 7, 0),
             )
 
+        // Assert
         Assertions.assertThat(evalueringer.erOppfylt()).isFalse
         Assertions.assertThat(
             evalueringer
@@ -112,6 +114,7 @@ class FiltreringsregelForFlereBarnTest {
 
     @Test
     fun `Regelevaluering skal resultere i NEI når det er registrert dødsfall på minst ett barn`() {
+        // Arrange
         val behandling = lagBehandling()
         val personInfo = generePersonInfoMedBarn(setOf(barnAktør0, barnAktør1))
 
@@ -192,6 +195,7 @@ class FiltreringsregelForFlereBarnTest {
                     ),
             )
 
+        // Act
         val fødselshendelsefiltreringResultater =
             filtreringsreglerService.kjørFiltreringsregler(
                 NyBehandlingHendelse(
@@ -205,6 +209,7 @@ class FiltreringsregelForFlereBarnTest {
                 behandling,
             )
 
+        // Assert
         Assertions.assertThat(fødselshendelsefiltreringResultater.erOppfylt()).isFalse
         Assertions.assertThat(
             fødselshendelsefiltreringResultater
@@ -215,6 +220,7 @@ class FiltreringsregelForFlereBarnTest {
 
     @Test
     fun `Regelevaluering skal resultere i JA når alle filtreringsregler er oppfylt`() {
+        // Arrange
         val behandling = lagBehandling()
         val personInfo = generePersonInfoMedBarn(setOf(barnAktør0, barnAktør1))
 
@@ -293,6 +299,7 @@ class FiltreringsregelForFlereBarnTest {
                     ),
             )
 
+        // Act
         val fødselshendelsefiltreringResultater =
             filtreringsreglerService.kjørFiltreringsregler(
                 NyBehandlingHendelse(
@@ -306,6 +313,7 @@ class FiltreringsregelForFlereBarnTest {
                 behandling,
             )
 
+        // Assert
         Assertions.assertThat(fødselshendelsefiltreringResultater.erOppfylt()).isTrue
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsregelTest.kt
@@ -19,10 +19,12 @@ internal class FiltreringsregelTest {
 
     @Test
     fun `Regelevaluering skal resultere i Ja`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val restenAvBarna: List<PersonInfo> = listOf()
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -39,15 +41,18 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evalueringer.erOppfylt()).isTrue
     }
 
     @Test
     fun `Regelevaluering skal resultere i NEI når mor mottar utvidet barnetrygd`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val restenAvBarna: List<PersonInfo> = listOf()
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -65,16 +70,19 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
         assertEnesteRegelMedResultatNei(evalueringer, Filtreringsregel.MOR_MOTTAR_IKKE_LØPENDE_UTVIDET)
     }
 
     @Test
     fun `Regelevaluering skal gi resultat IKKE_OPPFYLT når mor har løpende EØS-barnetrygd`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val restenAvBarna: List<PersonInfo> = listOf()
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -93,16 +101,19 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
         assertEnesteRegelMedResultatNei(evalueringer, Filtreringsregel.MOR_HAR_IKKE_LØPENDE_EØS_BARNETRYGD)
     }
 
     @Test
     fun `Regelevaluering skal resultere i NEI når mor er under 18 år`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(17)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val restenAvBarna: List<PersonInfo> = listOf()
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -119,12 +130,14 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
         assertEnesteRegelMedResultatNei(evalueringer, Filtreringsregel.MOR_ER_OVER_18_ÅR)
     }
 
     @Test
     fun `Regelevaluering skal resultere i JA når det har gått mer enn 5 måneder siden forrige barn ble født`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet1 = tilfeldigPerson(LocalDate.now().plusMonths(0)).copy(aktør = gyldigAktørId)
         val barnet2 = tilfeldigPerson(LocalDate.now().minusMonths(1)).copy(aktør = gyldigAktørId)
@@ -134,6 +147,7 @@ internal class FiltreringsregelTest {
                 PersonInfo(LocalDate.now().minusMonths(8)),
             )
 
+        // Act
         val evaluering =
             Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.vurder(
                 FiltreringsreglerFakta(
@@ -149,11 +163,14 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
     }
 
     @Test
     fun `Regelevaluering skal resultere i NEI når det har gått mindre enn 5 måneder siden forrige barn ble født`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet1 = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val barnet2 = tilfeldigPerson(LocalDate.now().minusMonths(1)).copy(aktør = gyldigAktørId)
@@ -163,6 +180,7 @@ internal class FiltreringsregelTest {
                 PersonInfo(LocalDate.now().minusMonths(8)),
             )
 
+        // Act
         val evaluering =
             Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.vurder(
                 FiltreringsreglerFakta(
@@ -179,15 +197,18 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.IKKE_OPPFYLT)
     }
 
     @Test
     fun `Regelevaluering skal resultere i NEI når det er registrert dødsfall på mor`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val restenAvBarna: List<PersonInfo> = listOf()
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -204,16 +225,19 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
         assertEnesteRegelMedResultatNei(evalueringer, Filtreringsregel.MOR_LEVER)
     }
 
     @Test
     fun `Regelevaluering skal resultere i NEI når det er registrert dødsfall på barnet`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val restenAvBarna: List<PersonInfo> = listOf()
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -230,16 +254,19 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
         assertEnesteRegelMedResultatNei(evalueringer, Filtreringsregel.BARN_LEVER)
     }
 
     @Test
     fun `Regelevaluering skal resultere i NEI når mor har verge`() {
+        // Arrange
         val mor = tilfeldigPerson(LocalDate.now().minusYears(20)).copy(aktør = gyldigAktørId)
         val barnet = tilfeldigPerson(LocalDate.now()).copy(aktør = gyldigAktørId)
         val restenAvBarna: List<PersonInfo> = listOf()
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -256,6 +283,7 @@ internal class FiltreringsregelTest {
                 ),
             )
 
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
         assertEnesteRegelMedResultatNei(evalueringer, Filtreringsregel.MOR_HAR_IKKE_VERGE)
     }
@@ -276,12 +304,14 @@ internal class FiltreringsregelTest {
 
     @Test
     fun `Mor er under 18`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2019-10-23"), aktør = lagAktør("21111777001"))
         val barn2PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2020-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -297,17 +327,20 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.MOR_ER_OVER_18_ÅR)
     }
 
     @Test
     fun `Barn med mindre mellomrom enn 5mnd`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør("21111777001"))
         val barn2PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2020-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -323,17 +356,21 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN)
     }
 
     @Test
     fun `Tvillinger født på samme dag skal gi oppfylt`() {
+        // Arrange
         val mor =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør(randomFnr()))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør(randomFnr()))
         val barn2PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2020-10-23"))
 
+        // Act
         val evaluering =
             Filtreringsregel.MER_ENN_5_MND_SIDEN_FORRIGE_BARN.vurder(
                 FiltreringsreglerFakta(
@@ -349,17 +386,21 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
     }
 
     @Test
     fun `Mor lever ikke`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør("21111777001"))
         val barn2PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2018-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -375,17 +416,21 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.MOR_LEVER)
     }
 
     @Test
     fun `Barnet lever ikke`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør("21111777001"))
         val barn2PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2018-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -401,17 +446,20 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.BARN_LEVER)
     }
 
     @Test
     fun `Mor har verge`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør("21111777001"))
         val barn2PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2018-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -427,17 +475,21 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.MOR_HAR_IKKE_VERGE)
     }
 
     @Test
     fun `Mor er død og er under vergemål`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør("21111777001"))
         val barn2PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2018-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -453,11 +505,14 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.MOR_LEVER)
     }
 
     @Test
     fun `Flere barn født`() {
+        // Arrange
         val nyligFødselsdato = LocalDate.now().minusDays(2)
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
@@ -467,6 +522,7 @@ internal class FiltreringsregelTest {
             tilfeldigPerson(fødselsdato = nyligFødselsdato, aktør = lagAktør("23128438785"))
         val barn3PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2018-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -482,17 +538,21 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         Assertions.assertTrue(evalueringer.erOppfylt())
     }
 
     @Test
     fun `Mor har ugyldig fødselsnummer`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("23236789111"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"), aktør = lagAktør("21111777001"))
         val barn3PersonInfo = PersonInfo(fødselsdato = LocalDate.parse("2018-09-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -508,11 +568,14 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.MOR_GYLDIG_FNR)
     }
 
     @Test
     fun `Barn med ugyldig fødselsnummer`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
@@ -520,6 +583,7 @@ internal class FiltreringsregelTest {
         val barn2Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2018-09-23"), aktør = lagAktør("23091823456"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -535,16 +599,20 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertIkkeOppfyltFiltreringsregel(evalueringer, Filtreringsregel.BARN_GYLDIG_FNR)
     }
 
     @Test
     fun `Fagsak migrert etter barn født`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"), aktør = lagAktør("04086226621"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-09-23"), aktør = lagAktør("23092023456"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -561,6 +629,8 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertIkkeOppfyltFiltreringsregel(
             evalueringer,
             Filtreringsregel.FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT,
@@ -569,6 +639,7 @@ internal class FiltreringsregelTest {
 
     @Test
     fun `Saken er godkjent fordi barnet er født i denne måneden`() {
+        // Arrange
         val fødselsdatoIDenneMåned = LocalDate.now().withDayOfMonth(1)
 
         val søkerPerson =
@@ -576,6 +647,7 @@ internal class FiltreringsregelTest {
         val barn1Person =
             tilfeldigPerson(fødselsdato = fødselsdatoIDenneMåned, aktør = lagAktør("23091823456"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -591,16 +663,20 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         Assertions.assertTrue(evalueringer.erOppfylt())
     }
 
     @Test
     fun `Skal returnere ikke oppfylt for regelevaluering når det allerede løper barnetrygd for barnet på annen forelder`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -616,16 +692,20 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         Assertions.assertTrue(!evalueringer.erOppfylt())
     }
 
     @Test
     fun `Skal returnere ikke oppfylt for regelevaluering når mor oppfyller vilkår for utvidet barnetrygd`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -641,16 +721,19 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
     }
 
     @Test
     fun `Skal returnere oppfylt for regelevaluering når mor ikke oppfyller vilkår for utvidet barnetrygd`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -666,16 +749,20 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = true,
                 ),
             )
+
+        // Assert
         assertThat(evalueringer.erOppfylt()).isTrue
     }
 
     @Test
     fun `Skal returnere ikke oppfylt for regelevaluering når mor har opphørt barnetrygd`() {
+        // Arrange
         val søkerPerson =
             tilfeldigSøker(fødselsdato = LocalDate.parse("1962-10-23"))
         val barn1Person =
             tilfeldigPerson(fødselsdato = LocalDate.parse("2020-10-23"))
 
+        // Act
         val evalueringer =
             FiltreringsregelEvaluering.evaluerFiltreringsregler(
                 FiltreringsreglerFakta(
@@ -691,6 +778,8 @@ internal class FiltreringsregelTest {
                     morHarIkkeOpphørtBarnetrygd = false,
                 ),
             )
+
+        // Assert
         assertThat(evalueringer.erOppfylt()).isFalse
     }
 
@@ -705,6 +794,7 @@ internal class FiltreringsregelTest {
 
     @Test
     fun `Filtreringsreglene skal følge en fagbestemt rekkefølge`() {
+        // Arrange
         val fagbestemtFiltreringsregelrekkefølge =
             listOf(
                 Filtreringsregel.MOR_GYLDIG_FNR,
@@ -721,6 +811,8 @@ internal class FiltreringsregelTest {
                 Filtreringsregel.MOR_HAR_IKKE_OPPFYLT_UTVIDET_VILKÅR_VED_FØDSELSDATO,
                 Filtreringsregel.MOR_HAR_IKKE_OPPHØRT_BARNETRYGD,
             )
+
+        // Assert
         assertThat(Filtreringsregel.entries.size).isEqualTo(fagbestemtFiltreringsregelrekkefølge.size)
         assertThat(
             Filtreringsregel

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsreglerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/filtreringsregler/FiltreringsreglerServiceTest.kt
@@ -70,6 +70,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat ikke oppfylt når mors vilkår om utvidet barnetrygd er oppfylt i tidsrommet barnet er mellom 0 og 18`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val nyBehandlingHendelse = NyBehandlingHendelse(mor.aktør.aktørId, listOf(barn.aktør.aktørId))
@@ -103,8 +104,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured
@@ -120,6 +123,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat oppfylt når mors vilkår om utvidet barnetrygd er oppfylt utenfor tidsrommet barnet er mellom 0 og 18`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val nyBehandlingHendelse = NyBehandlingHendelse(mor.aktør.aktørId, listOf(barn.aktør.aktørId))
@@ -153,8 +157,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured
@@ -170,6 +176,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat ikke oppfylt når en vilkårsperiode for utvidet barnetrygd er oppfylt i tidsrommet barnet er mellom 0 og 18`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val nyBehandlingHendelse = NyBehandlingHendelse(mor.aktør.aktørId, listOf(barn.aktør.aktørId))
@@ -208,8 +215,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured
@@ -225,6 +234,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat ikke oppfylt når tom-dato er null på vilkåret utvidet barnetrygd`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val nyBehandlingHendelse = NyBehandlingHendelse(mor.aktør.aktørId, listOf(barn.aktør.aktørId))
@@ -263,8 +273,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured
@@ -280,6 +292,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat oppfylt når begge barnas fødselsdatoer er etter tom på vilkåret utvidet barnetrygd`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn1 = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val barn2 = tilfeldigPerson(fødselsdato = LocalDate.of(2020, 1, 1))
@@ -321,8 +334,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured
@@ -338,6 +353,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat ikke oppfylt når mors vilkår om utvidet barnetrygd er oppfylt i tidsrommet et av barna er mellom 0 og 18`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn1 = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val barn2 = tilfeldigPerson(fødselsdato = LocalDate.of(2020, 1, 1))
@@ -379,8 +395,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured
@@ -396,6 +414,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat ikke oppfylt når mor har opphørt barnetrygd`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val nyBehandlingHendelse = NyBehandlingHendelse(mor.aktør.aktørId, listOf(barn.aktør.aktørId))
@@ -416,8 +435,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured
@@ -433,6 +454,7 @@ class FiltreringsreglerServiceTest {
 
     @Test
     fun `kjørFiltreringsregler - skal gi resultat oppfylt når vilkår er oppfylt og mor ikke har opphørt barnetrygd`() {
+        // Arrange
         val mor = tilfeldigSøker(fødselsdato = LocalDate.of(1985, 1, 1))
         val barn = tilfeldigPerson(fødselsdato = LocalDate.of(2021, 1, 1))
         val nyBehandlingHendelse = NyBehandlingHendelse(mor.aktør.aktørId, listOf(barn.aktør.aktørId))
@@ -448,8 +470,10 @@ class FiltreringsreglerServiceTest {
         mockkObject(FiltreringsregelEvaluering)
         val filtreringsreglerFaktaSlot = slot<FiltreringsreglerFakta>()
 
+        // Act
         filtreringsreglerService.kjørFiltreringsregler(nyBehandlingHendelse, behandling)
 
+        // Assert
         verify { FiltreringsregelEvaluering.evaluerFiltreringsregler(capture(filtreringsreglerFaktaSlot)) }
 
         val fødselshendelsefiltreringResultat = fødselshendelsefiltreringResultatSlot.captured

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/BarnBorMedSøkerVilkårTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/BarnBorMedSøkerVilkårTest.kt
@@ -14,41 +14,61 @@ import org.junit.jupiter.api.Test
 class BarnBorMedSøkerVilkårTest {
     @Test
     fun `Samme matrikkelId men ellers forskjellige adresser`() {
+        // Arrange
         val faktaPerson = opprettFaktaPerson(adresseMatrikkelId1barn, adresseMatrikkelId1SøkerBruksenhetsnummer)
 
+        // Act
         val evaluering = vilkår.vurderVilkår(faktaPerson)
+
+        // Assert
         Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
     }
 
     @Test
     fun `Forskjellige matrikkelId`() {
+        // Arrange
         val faktaPerson = opprettFaktaPerson(adresseMatrikkelId1barn, adresseMatrikkelId2Søker)
 
+        // Act
         val evaluering = vilkår.vurderVilkår(faktaPerson)
+
+        // Assert
         Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.IKKE_OPPFYLT)
     }
 
     @Test
     fun `Address som mangler postnummer`() {
+        // Arrange
         val faktaPerson = opprettFaktaPerson(adresseIkkePostnummerBarn, adresseIkkePostnummerSøker)
 
+        // Act
         val evaluering = vilkår.vurderVilkår(faktaPerson)
+
+        // Assert
         Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.IKKE_OPPFYLT)
     }
 
     @Test
     fun `Address som mangler matrikkelid`() {
+        // Arrange
         val faktaPerson = opprettFaktaPerson(adresseAttrBarn, adresseAttrSøker)
 
+        // Act
         val evaluering = vilkår.vurderVilkår(faktaPerson)
+
+        // Assert
         Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
     }
 
     @Test
     fun `To forskjellige address som begge mangler matrikkelid`() {
+        // Arrange
         val faktaPerson = opprettFaktaPerson(adresseAttrBarn, adresseAttr2Søker)
 
+        // Act
         val evaluering = vilkår.vurderVilkår(faktaPerson)
+
+        // Assert
         Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.IKKE_OPPFYLT)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/BosattIRiketVilkårTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/BosattIRiketVilkårTest.kt
@@ -29,6 +29,7 @@ class BosattIRiketVilkårTest {
 
     @Test
     fun `Skal sjekke at person bor i riket dersom vedkommende har vært utvandret langt tilbake i tid`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER, fødselsdato = LocalDate.of(1950, 1, 1))
 
         søker.apply {
@@ -98,17 +99,20 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusDays(1),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.OPPFYLT, evaluering.resultat)
     }
 
     @Test
     fun `Skal sjekke at person ikke bor i riket`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
 
         søker.apply {
@@ -130,17 +134,20 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusDays(1),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
     }
 
     @Test
     fun `Skal sjekke at person ikke bor i riket dersom vedkommende har vært utvandret`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
 
         søker.apply {
@@ -162,17 +169,20 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusMonths(4),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
     }
 
     @Test
     fun `Skal sjekke at person ikke bor i riket dersom vedkommende har vært utvandret først i perioden`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
 
         søker.apply {
@@ -187,17 +197,20 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusMonths(4),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
     }
 
     @Test
     fun `Skal sjekke at person ikke bor i riket dersom vedkommende har vært utvandret sist i perioden`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
 
         søker.apply {
@@ -213,17 +226,20 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusMonths(4),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
     }
 
     @Test
     fun `Skal sjekke at person bor i riket selv om hen har ekstra adresse uten fom`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER, fødselsdato = LocalDate.now().minusMonths(7))
 
         søker.apply {
@@ -244,17 +260,20 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusMonths(4),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.OPPFYLT, evaluering.resultat)
     }
 
     @Test
     fun `Skal sjekke at person bor i riket selv om hen kun har en adresse uten fom `() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
 
         søker.apply {
@@ -269,18 +288,21 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusMonths(4),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.OPPFYLT, evaluering.resultat)
         assertEquals(VilkårOppfyltÅrsak.BOR_I_RIKET_KUN_ADRESSER_UTEN_FOM, evaluering.evalueringÅrsaker.single())
     }
 
     @Test
     fun `Skal sjekke at person ikke bor i riket om hen har flere adresser uten fom `() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
 
         søker.apply {
@@ -307,12 +329,14 @@ class BosattIRiketVilkårTest {
                 )
         }
 
+        // Act
         val evaluering =
             VurderPersonErBosattIRiket(
                 adresser = søker.bostedsadresser,
                 vurderFra = LocalDate.now().minusMonths(4),
             ).vurder()
 
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
         assertEquals(
             VilkårIkkeOppfyltÅrsak.BOR_IKKE_I_RIKET_FLERE_ADRESSER_UTEN_FOM,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/GiftEllerPartnerskapVilkårTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/GiftEllerPartnerskapVilkårTest.kt
@@ -12,7 +12,10 @@ import org.junit.jupiter.api.Test
 class GiftEllerPartnerskapVilkårTest {
     @Test
     fun `Gift-vilkår gir resultat JA for fødselshendelse når sivilstand er uoppgitt`() {
+        // Act
         val evaluering = vilkår.vurderVilkår(barn)
+
+        // Assert
         Assertions.assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/LovligOppholdVilkårTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/vilkårsvurdering/LovligOppholdVilkårTest.kt
@@ -22,13 +22,19 @@ import java.time.LocalDate
 class LovligOppholdVilkårTest {
     @Test
     fun `Ikke lovlig opphold dersom søker ikke har noen gjeldende opphold registrert`() {
+        // Act
         val evaluering = vilkår.vurderVilkår(tredjelandsborger).evaluering
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.IKKE_OPPFYLT)
     }
 
     @Test
     fun `Ikke lovlig opphold dersom søker er statsløs og ikke har noen gjeldende opphold registrert`() {
+        // Act
         val statsløsEvaluering = vilkår.vurderVilkår(statsløsPerson).evaluering
+
+        // Assert
         assertThat(statsløsEvaluering.resultat).isEqualTo(Resultat.IKKE_OPPFYLT)
 
         val ukjentStatsborgerskapEvaluering =
@@ -38,7 +44,10 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold vurdert på bakgrunn av status`() {
+        // Act
         var evaluering = vilkår.vurderVilkår(faktaPerson(OPPHOLDSTILLATELSE.MIDLERTIDIG, null)).evaluering
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
         evaluering = vilkår.vurderVilkår(faktaPerson(OPPHOLDSTILLATELSE.PERMANENT, null)).evaluering
         assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
@@ -48,6 +57,7 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold vurdert på bakgrunn av status for statsløs søker`() {
+        // Act
         var evaluering =
             vilkår
                 .vurderVilkår(
@@ -56,6 +66,8 @@ class LovligOppholdVilkårTest {
                             mutableListOf(GrOpphold(gyldigPeriode = null, type = OPPHOLDSTILLATELSE.MIDLERTIDIG, person = this))
                     },
                 ).evaluering
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
 
         evaluering =
@@ -87,6 +99,7 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Ikke lovlig opphold dersom utenfor gyldig periode`() {
+        // Act
         var evaluering =
             vilkår
                 .vurderVilkår(
@@ -113,6 +126,8 @@ class LovligOppholdVilkårTest {
                             ),
                     ),
                 ).evaluering
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.IKKE_OPPFYLT)
 
         evaluering =
@@ -138,6 +153,7 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold dersom status med gjeldende periode`() {
+        // Act
         var evaluering =
             vilkår
                 .vurderVilkår(
@@ -173,6 +189,8 @@ class LovligOppholdVilkårTest {
                             ),
                     ),
                 ).evaluering
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
 
         evaluering =
@@ -207,6 +225,7 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold blir oppfylt for mor med EØS medlemskap og har løpende arbeidsforhold`() {
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -222,12 +241,15 @@ class LovligOppholdVilkårTest {
                             )
                     },
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.OPPFYLT, evaluering.resultat)
         assertEquals(listOf(VilkårOppfyltÅrsak.EØS_MED_LØPENDE_ARBEIDSFORHOLD), evaluering.evalueringÅrsaker)
     }
 
     @Test
     fun `Lovlig opphold blir ikke oppfylt for mor med EØS medlemskap, uten løpende arbeidsforhold og annen forelder`() {
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -237,12 +259,15 @@ class LovligOppholdVilkårTest {
                         },
                     annenForelder = null,
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
         assertEquals(listOf(VilkårIkkeOppfyltÅrsak.EØS_STATSBORGERSKAP_ANNEN_FORELDER_UKLART), evaluering.evalueringÅrsaker)
     }
 
     @Test
     fun `Lovlig opphold blir ikke oppfylt for mor med EØS medlemskap, uten løpende arbeidsforhold og annen forelder bor ikke med mor`() {
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -264,6 +289,8 @@ class LovligOppholdVilkårTest {
                                 ),
                         ),
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
         assertEquals(
             listOf(VilkårIkkeOppfyltÅrsak.EØS_BOR_IKKE_SAMMEN_MED_ANNEN_FORELDER),
@@ -273,6 +300,7 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold blir ikke oppfylt for mor med EØS medlemskap, uten løpende arbeidsforhold og annen forelder har bodd med mor`() {
+        // Arrange
         val tidligereAdresse =
             lagGrVegadresse(adressenavn = "Uteveien", husnummer = "123", postnummer = "0245").also {
                 it.periode =
@@ -282,6 +310,7 @@ class LovligOppholdVilkårTest {
                     )
             }
 
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -307,6 +336,8 @@ class LovligOppholdVilkårTest {
                                 ),
                         ),
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
         assertEquals(
             listOf(VilkårIkkeOppfyltÅrsak.EØS_BOR_IKKE_SAMMEN_MED_ANNEN_FORELDER),
@@ -316,7 +347,10 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold blir oppfylt for mor med EØS medlemskap, uten løpende arbeidsforhold og annen forelder bor med mor og nordisk`() {
+        // Arrange
         val adresse = lagGrVegadresse(adressenavn = "Osloveien", husnummer = "123", postnummer = "0245")
+
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -334,6 +368,8 @@ class LovligOppholdVilkårTest {
                                 ),
                         ),
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.OPPFYLT, evaluering.resultat)
         assertEquals(
             listOf(VilkårOppfyltÅrsak.ANNEN_FORELDER_NORDISK),
@@ -343,7 +379,10 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold blir ikke oppfylt for mor med EØS medlemskap, annen forelder(EØS) ikke løpende arbeidsforhold`() {
+        // Arrange
         val adresse = lagGrVegadresse(adressenavn = "Osloveien", husnummer = "123", postnummer = "0245")
+
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -362,6 +401,8 @@ class LovligOppholdVilkårTest {
                             arbeidsforhold = mutableListOf(),
                         ),
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
         assertEquals(
             listOf(VilkårIkkeOppfyltÅrsak.EØS_ANNEN_FORELDER_EØS_MEN_IKKE_MED_LØPENDE_ARBEIDSFORHOLD),
@@ -371,7 +412,10 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold blir oppfylt for mor med EØS medlemskap, annen forelder(EØS) har løpende arbeidsforhold`() {
+        // Arrange
         val adresse = lagGrVegadresse(adressenavn = "Osloveien", husnummer = "123", postnummer = "0245")
+
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -398,6 +442,8 @@ class LovligOppholdVilkårTest {
                                 )
                         },
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.OPPFYLT, evaluering.resultat)
         assertEquals(
             listOf(VilkårOppfyltÅrsak.ANNEN_FORELDER_EØS_MEN_MED_LØPENDE_ARBEIDSFORHOLD),
@@ -407,7 +453,10 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold blir ikke oppfylt for mor med EØS medlemskap, annen forelder er tredjelandsborger`() {
+        // Arrange
         val adresse = lagGrVegadresse(adressenavn = "Osloveien", husnummer = "123", postnummer = "0245")
+
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -423,6 +472,8 @@ class LovligOppholdVilkårTest {
                                 mutableListOf(adresse)
                         },
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
         assertEquals(
             listOf(VilkårIkkeOppfyltÅrsak.EØS_MEDFORELDER_TREDJELANDSBORGER),
@@ -432,7 +483,10 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold blir ikke oppfylt for mor med EØS medlemskap, annen forelder er statsløs`() {
+        // Arrange
         val adresse = lagGrVegadresse(adressenavn = "Osloveien", husnummer = "123", postnummer = "0245")
+
+        // Act
         val evaluering =
             vilkår
                 .vurderVilkår(
@@ -448,6 +502,8 @@ class LovligOppholdVilkårTest {
                                 mutableListOf(adresse)
                         },
                 ).evaluering
+
+        // Assert
         assertEquals(Resultat.IKKE_OPPFYLT, evaluering.resultat)
         assertEquals(
             listOf(VilkårIkkeOppfyltÅrsak.EØS_MEDFORELDER_STATSLØS),
@@ -457,7 +513,10 @@ class LovligOppholdVilkårTest {
 
     @Test
     fun `Lovlig opphold gir resultat JA for barn ved fødselshendelse`() {
+        // Act
         val evaluering = vilkår.vurderVilkår(barn).evaluering
+
+        // Assert
         assertThat(evaluering.resultat).isEqualTo(Resultat.OPPFYLT)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOmregningPgaAlderServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOmregningPgaAlderServiceTest.kt
@@ -93,6 +93,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at løpende fagsak med avsluttede behandlinger og barn på 18 ikke oppretter en behandling for omregning`() {
+        // Arrange
         val behandling = initMock(alder = 18, medSøsken = false).first
 
         val autobrevPgaAlderDTO =
@@ -102,6 +103,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
                 årMåned = inneværendeMåned(),
             )
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.INGEN_LØPENDE_UTBETALING_FOR_BARN_UNDER_18)
@@ -111,6 +113,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at behandling for omregning ikke opprettes om barn med angitt ålder ikke finnes`() {
+        // Arrange
         val behandling = initMock(alder = 7, medSøsken = false).first
 
         val autobrevPgaAlderDTO =
@@ -120,6 +123,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
                 årMåned = inneværendeMåned(),
             )
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.INGEN_BARN_I_ALDER)
@@ -129,6 +133,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at behandling for omregning ikke opprettes om fagsak ikke er løpende`() {
+        // Arrange
         val behandling = initMock(fagsakStatus = FagsakStatus.OPPRETTET, alder = 18, medSøsken = false).first
 
         val autobrevPgaAlderDTO =
@@ -138,6 +143,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
                 årMåned = inneværendeMåned(),
             )
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.FAGSAK_IKKE_LØPENDE)
@@ -147,6 +153,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at behandling for omregning blir trigget for løpende fagsak med barn som fyller 18 år inneværende måned og som har søsken`() {
+        // Arrange
         val behandling = initMock(alder = 18, medSøsken = true).first
 
         val autobrevPgaAlderDTO =
@@ -162,6 +169,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
         every { taskRepository.save(any()) } returns Task(type = "test", payload = "")
         every { autovedtakStegService.kjørBehandlingOmregning(any(), any(), any()) } returns ""
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.OK)
@@ -177,6 +185,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at behandling for omregning ikke blir trigget for løpende fagsak med barn som fyller 18år inneværende måned, hvis barnet ikke har løpende andel tilkjent ytelse`() {
+        // Arrange
         val (behandling, _, barnIBrytningsalder) = initMock(alder = 18, medSøsken = true)
 
         val autobrevPgaAlderDTO =
@@ -216,6 +225,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
         every { taskRepository.save(any()) } returns Task(type = "test", payload = "")
         every { autovedtakStegService.kjørBehandlingOmregning(any(), any()) } returns ""
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.INGEN_LØPENDE_YTELSE_FOR_BARN_I_BRYTNINGSALDER)
@@ -230,6 +240,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at behandling for omregning ikke blir trigget for løpende fagsak med barn som fyller 18 år inneværende måned, hvis det er nullutbetaling eøs`() {
+        // Arrange
         val behandling = initMock(alder = 18, medSøsken = true, eøsNullUtbetaling = true).first
 
         val autobrevPgaAlderDTO =
@@ -245,6 +256,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
         every { taskRepository.save(any()) } returns Task(type = "test", payload = "")
         every { autovedtakStegService.kjørBehandlingOmregning(any(), any()) } returns ""
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.EØS_MED_NULLUTBETALING)
@@ -259,6 +271,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at vi ikke oppretter behandling hvis brev er sendt fra infotrygd`() {
+        // Arrange
         val behandling = initMock(alder = 18, medSøsken = true).first
 
         val autobrevPgaAlderDTO =
@@ -274,6 +287,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
         every { vedtaksperiodeService.oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(any(), any()) } just runs
         every { taskRepository.save(any()) } returns Task(type = "test", payload = "")
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.HAR_ALT_SENDT)
@@ -297,6 +311,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
 
     @Test
     fun `Verifiser at behandling for omregning blir trigget for skjermet barn fagsak med barn som fyller 18 år inneværende måned`() {
+        // Arrange
         val søkerAktør = randomAktør()
         val skjermetBarnSøker = SkjermetBarnSøker(aktør = søkerAktør)
         val skjermetBarnFagsak =
@@ -320,6 +335,7 @@ internal class AutobrevOmregningPgaAlderServiceTest {
         every { taskRepository.save(any()) } returns Task(type = "test", payload = "")
         every { autovedtakStegService.kjørBehandlingOmregning(any(), any(), any()) } returns ""
 
+        // Act & Assert
         assertThat(
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(autobrevPgaAlderDTO),
         ).isEqualTo(AutobrevOmregningSvar.OK)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevOpphørSmåbarnstilleggServiceTest.kt
@@ -80,6 +80,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
 
     @Test
     fun `Verifiser at løpende fagsak med småbarnstillegg sender opphørsbrev måneden etter yngste barn ble 3 år`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn3ÅrForrigeMåned = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3).minusMonths(1))
         val personopplysningGrunnlag: PersonopplysningGrunnlag =
@@ -95,9 +96,11 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
         every { vedtaksperiodeService.oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(any(), any()) } just runs
         every { autovedtakStegService.kjørBehandlingOmregning(any(), any(), any()) } returns ""
 
+        // Act
         autobrevOpphørSmåbarnstilleggService
             .kjørBehandlingOgSendBrevForOpphørAvSmåbarnstillegg(fagsakId = behandling.fagsak.id)
 
+        // Assert
         verify(exactly = 1) {
             autovedtakStegService.kjørBehandlingOmregning(
                 any(),
@@ -109,6 +112,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
 
     @Test
     fun `Skal ikke sende lage autobrevbehandling om det i forrige måned ble vedtatt en reduksjon på småbarnstillegg`() {
+        // Arrange
         val behandling =
             lagBehandling().apply {
                 status = BehandlingStatus.AVSLUTTET
@@ -150,9 +154,11 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
             )
         every { behandlingRepository.hentBegrunnelserPåBehandlingIPeriode(behandling.id, any()) } returns listOf("REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_BARN_UNDER_TRE_ÅR")
 
+        // Act
         autobrevOpphørSmåbarnstilleggService
             .kjørBehandlingOgSendBrevForOpphørAvSmåbarnstillegg(fagsakId = behandling.fagsak.id)
 
+        // Assert
         verify(exactly = 0) {
             autovedtakService.opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
                 any(),
@@ -166,6 +172,7 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
 
     @Test
     fun `Verifiser at behandling ikke blir opprettet om behandling allerede har kjørt`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn3ÅrForrigeMåned = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3).minusMonths(1))
         val personopplysningGrunnlag: PersonopplysningGrunnlag =
@@ -179,9 +186,11 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
         every { stegService.håndterNyBehandling(any()) } returns behandling
         every { vedtaksperiodeService.oppdaterFortsattInnvilgetPeriodeMedAutobrevBegrunnelse(any(), any()) } just runs
 
+        // Act
         autobrevOpphørSmåbarnstilleggService
             .kjørBehandlingOgSendBrevForOpphørAvSmåbarnstillegg(fagsakId = behandling.fagsak.id)
 
+        // Assert
         verify(exactly = 0) {
             autovedtakService.opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
                 any(),
@@ -195,61 +204,86 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
 
     @Test
     fun `overgangstønadOpphørteForrigeMåned - en periode med opphør denne måneden gir false`() {
+        // Arrange
         val fom = LocalDate.now().minusYears(1)
         val tom = LocalDate.now()
         val input: List<PeriodeOvergangsstønadGrunnlag> =
             listOf(
                 lagPeriodeOvergangsstønadGrunnlag(fom, tom),
             )
+
+        // Act
         val overgangstønadOpphørteForrigeMåned =
             autobrevOpphørSmåbarnstilleggService.overgangstønadOpphørteForrigeMåned(input)
+
+        // Assert
         assertFalse(overgangstønadOpphørteForrigeMåned)
     }
 
     @Test
     fun `overgangstønadOpphørteForrigeMåned - tom liste gir false`() {
+        // Arrange
         val input: List<PeriodeOvergangsstønadGrunnlag> = emptyList()
+
+        // Act
         val overgangstønadOpphørteForrigeMåned =
             autobrevOpphørSmåbarnstilleggService.overgangstønadOpphørteForrigeMåned(input)
+
+        // Assert
         assertFalse(overgangstønadOpphørteForrigeMåned)
     }
 
     @Test
     fun `overgangstønadOpphørteForrigeMåned - neste måned gir false`() {
+        // Arrange
         val fom = LocalDate.now().minusYears(1)
         val tom = LocalDate.now().førsteDagINesteMåned()
         val input: List<PeriodeOvergangsstønadGrunnlag> =
             listOf(
                 lagPeriodeOvergangsstønadGrunnlag(fom, tom),
             )
+
+        // Act
         val overgangstønadOpphørteForrigeMåned =
             autobrevOpphørSmåbarnstilleggService.overgangstønadOpphørteForrigeMåned(input)
+
+        // Assert
         assertFalse(overgangstønadOpphørteForrigeMåned)
     }
 
     @Test
     fun `overgangstønadOpphørteForrigeMåned - forrige måned gir true`() {
+        // Arrange
         val fom = LocalDate.now().minusYears(1)
         val tom = LocalDate.now().minusMonths(1)
         val input: List<PeriodeOvergangsstønadGrunnlag> =
             listOf(
                 lagPeriodeOvergangsstønadGrunnlag(fom, tom),
             )
+
+        // Act
         val overgangstønadOpphørteForrigeMåned =
             autobrevOpphørSmåbarnstilleggService.overgangstønadOpphørteForrigeMåned(input)
+
+        // Assert
         assertTrue(overgangstønadOpphørteForrigeMåned)
     }
 
     @Test
     fun `overgangstønadOpphørteForrigeMåned - ett år siden gir false`() {
+        // Arrange
         val fom = LocalDate.now().minusYears(1)
         val tom = LocalDate.now().minusYears(1)
         val input: List<PeriodeOvergangsstønadGrunnlag> =
             listOf(
                 lagPeriodeOvergangsstønadGrunnlag(fom, tom),
             )
+
+        // Act
         val overgangstønadOpphørteForrigeMåned =
             autobrevOpphørSmåbarnstilleggService.overgangstønadOpphørteForrigeMåned(input)
+
+        // Assert
         assertFalse(overgangstønadOpphørteForrigeMåned)
     }
 
@@ -257,60 +291,72 @@ internal class AutobrevOpphørSmåbarnstilleggServiceTest {
 
     @Test
     fun `minsteBarnFylteTreÅrForrigeMåned - et barn som fylte tre forrige måned gir true`() {
+        // Arrange
         val barn3ForrigeMåned = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3).minusMonths(1))
         val peronsopplysningGrunnalg: PersonopplysningGrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandlingId, barn3ForrigeMåned)
 
+        // Act & Assert
         assertTrue(autobrevOpphørSmåbarnstilleggService.yngsteBarnFylteTreÅrForrigeMåned(peronsopplysningGrunnalg))
     }
 
     @Test
     fun `minsteBarnFylteTreÅrForrigeMåned - et barn som fylte tre forrige måned og et eldre gir true`() {
+        // Arrange
         val barn3ForrigeMåned = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3).minusMonths(1))
         val barnOverTre = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(4))
         val peronsopplysningGrunnalg: PersonopplysningGrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandlingId, barn3ForrigeMåned, barnOverTre)
 
+        // Act & Assert
         assertTrue(autobrevOpphørSmåbarnstilleggService.yngsteBarnFylteTreÅrForrigeMåned(peronsopplysningGrunnalg))
     }
 
     @Test
     fun `minsteBarnFylteTreÅrForrigeMåned - to barn som fylte tre forrige måned gir true`() {
+        // Arrange
         val barn3ForrigeMåned = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3).minusMonths(1))
         val ekstraBarn3ForrigeMåned = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3).minusMonths(1))
         val peronsopplysningGrunnalg: PersonopplysningGrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandlingId, barn3ForrigeMåned, ekstraBarn3ForrigeMåned)
 
+        // Act & Assert
         assertTrue(autobrevOpphørSmåbarnstilleggService.yngsteBarnFylteTreÅrForrigeMåned(peronsopplysningGrunnalg))
     }
 
     @Test
     fun `minsteBarnFylteTreÅrForrigeMåned - to barn over tre gir false`() {
+        // Arrange
         val barnOverTre = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(4))
         val ekstraBarnOverTre = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(4))
         val peronsopplysningGrunnalg: PersonopplysningGrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandlingId, barnOverTre, ekstraBarnOverTre)
 
+        // Act & Assert
         assertFalse(autobrevOpphørSmåbarnstilleggService.yngsteBarnFylteTreÅrForrigeMåned(peronsopplysningGrunnalg))
     }
 
     @Test
     fun `minsteBarnFylteTreÅrForrigeMåned - to barn under tre gir false`() {
+        // Arrange
         val barnUnderTre = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(2))
         val ekstraBarnUnderTre = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3))
         val peronsopplysningGrunnalg: PersonopplysningGrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandlingId, barnUnderTre, ekstraBarnUnderTre)
 
+        // Act & Assert
         assertFalse(autobrevOpphørSmåbarnstilleggService.yngsteBarnFylteTreÅrForrigeMåned(peronsopplysningGrunnalg))
     }
 
     @Test
     fun `minsteBarnFylteTreÅrForrigeMåned - et barn under tre og et barn 3 forrige måned gir false`() {
+        // Arrange
         val barnUnderTre = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(2))
         val barn3ForrigeMåned = tilfeldigPerson(fødselsdato = LocalDate.now().minusYears(3).minusMonths(1))
         val peronsopplysningGrunnalg: PersonopplysningGrunnlag =
             lagTestPersonopplysningGrunnlag(behandlingId = behandlingId, barnUnderTre, barn3ForrigeMåned)
 
+        // Act & Assert
         assertFalse(autobrevOpphørSmåbarnstilleggService.yngsteBarnFylteTreÅrForrigeMåned(peronsopplysningGrunnalg))
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevTaskTest.kt
@@ -36,6 +36,7 @@ internal class AutobrevTaskTest {
 
     @Test
     fun `oppretter ingen autobrev tasker for 6 år, 2 for 18 år og 1 for småbarnstillegg`() {
+        // Arrange
         val fagsaker =
             setOf(
                 Fagsak(1, aktør = lagAktør(randomFnr())),
@@ -48,8 +49,10 @@ internal class AutobrevTaskTest {
         every { opprettTaskService.opprettAutovedtakForOpphørSmåbarnstilleggTask(any()) } just runs
         every { behandlingHentOgPersisterService.partitionByIverksatteBehandlinger<Long>(any()) } returns listOf(1L)
 
+        // Act
         autobrevTask.doTask(autoBrevTask)
 
+        // Assert
         verify(exactly = 0) {
             opprettTaskService.opprettSendAutobrevPgaAlderTask(any(), 6)
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/omregning/AutobrevUtilsTest.kt
@@ -9,19 +9,23 @@ import org.junit.jupiter.api.assertThrows
 class AutobrevUtilsTest {
     @Test
     fun `Skal sjekke at historiske og gjeldene begrunnelser blir hentet for 18 år`() {
+        // Act
         val begrunnelser = AutobrevUtils.hentStandardbegrunnelserReduksjonForAlder(alder = 18)
 
+        // Assert
         assertEquals(listOf("REDUKSJON_UNDER_18_ÅR_AUTOVEDTAK", "REDUKSJON_UNDER_18_ÅR"), begrunnelser.map { it.name })
     }
 
     @Test
     fun `Skal sjekke at gjeldende begrunnelse for autobrev er i listen over alle`() {
+        // Act & Assert
         assertThrows<Feil> {
             AutobrevUtils
                 .hentStandardbegrunnelserReduksjonForAlder(6)
                 .contains(AutobrevUtils.hentGjeldendeVedtakbegrunnelseReduksjonForAlder(6))
         }.apply { assertEquals("Alder må være oppgitt til 18 år.", message) }
 
+        // Act & Assert
         assertTrue(
             AutobrevUtils
                 .hentStandardbegrunnelserReduksjonForAlder(18)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendring/StartSatsendringTest.kt
@@ -66,6 +66,7 @@ internal class StartSatsendringTest {
 
     @Test
     fun `start satsendring og opprett satsendringtask på sak hvis toggler er på `() {
+        // Arrange
         every { featureToggleService.isEnabled(FeatureToggle.SATSENDRING_ENABLET, false) } returns true
 
         val behandling = lagBehandling()
@@ -79,13 +80,16 @@ internal class StartSatsendringTest {
 
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id) } returns behandling
 
+        // Act
         startSatsendring.startSatsendring(5)
 
+        // Assert
         verify(exactly = 1) { taskRepository.save(any()) }
     }
 
     @Test
     fun `finnLøpendeFagsaker har totalt antall sider 3, så den skal kalle finnLøpendeFagsaker 3 ganger for å få 5 satsendringer`() {
+        // Arrange
         every { featureToggleService.isEnabled(any(), false) } returns true
         every { featureToggleService.isEnabled(any<FeatureToggle>()) } returns true
 
@@ -101,14 +105,17 @@ internal class StartSatsendringTest {
 
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id) } returns behandling
 
+        // Act
         startSatsendring.startSatsendring(5)
 
+        // Assert
         verify(exactly = 5) { taskRepository.save(any()) }
         verify(exactly = 3) { fagsakRepository.finnLøpendeFagsakerForSatsendring(any(), any()) }
     }
 
     @Test
     fun `kanStarteSatsendringPåFagsak gir false når vi ikke har noen tidligere behandling`() {
+        // Arrange
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(1L) } returns null
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns
             Satskjøring(
@@ -116,11 +123,13 @@ internal class StartSatsendringTest {
                 satsTidspunkt = hentAktivSatsendringstidspunkt(),
             )
 
+        // Act & Assert
         assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 
     @Test
     fun `kanStarteSatsendringPåFagsak gir false når vi har en satskjøring for fagsaken i satskjøringsrepoet`() {
+        // Arrange
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns
             Satskjøring(
@@ -128,47 +137,58 @@ internal class StartSatsendringTest {
                 satsTidspunkt = hentAktivSatsendringstidspunkt(),
             )
 
+        // Act & Assert
         assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 
     @Test
     fun `kanStarteSatsendringPåFagsak gir false når harSisteSats er true`() {
+        // Arrange
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns null
         every { satsendringService.erFagsakOppdatertMedSisteSatser(any()) } returns true
 
+        // Act & Assert
         assertFalse(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 
     @Test
     fun `kanStarteSatsendringPåFagsak gir true når harSisteSats er false`() {
+        // Arrange
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns null
         every { satsendringService.erFagsakOppdatertMedSisteSatser(any()) } returns false
 
+        // Act & Assert
         assertTrue(startSatsendring.kanStarteSatsendringPåFagsak(1L))
     }
 
     @Test
     fun `kanGjennomføreSatsendringManuelt gir false når vi ikke har noen tidligere behandling`() {
+        // Arrange
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(1L) } returns null
 
+        // Act & Assert
         assertFalse(startSatsendring.kanGjennomføreSatsendringManuelt(1L))
     }
 
     @Test
     fun `kanGjennomføreSatsendringManuelt gir false når harSisteSats er true`() {
+        // Arrange
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(1L) } returns lagBehandling()
         every { satskjøringRepository.findByFagsakIdAndSatsTidspunkt(1L, any()) } returns null
         every { satsendringService.erFagsakOppdatertMedSisteSatser(any()) } returns true
 
+        // Act & Assert
         assertFalse(startSatsendring.kanGjennomføreSatsendringManuelt(1L))
     }
 
     @Test
     fun `opprettSatsendringSynkrontVedGammelSats skal kaste dersom man ikke kan starte satsendring`() {
+        // Arrange
         every { startSatsendring.kanStarteSatsendringPåFagsak(any()) } returns false
 
+        // Act & Assert
         assertThrows<Exception> {
             startSatsendring.gjennomførSatsendringManuelt(0L)
         }
@@ -176,8 +196,10 @@ internal class StartSatsendringTest {
 
     @Test
     fun `kanGjennomføreSatsendringManuelt skal kaste feil for alle andre resultater enn OK`() {
+        // Arrange
         every { startSatsendring.kanGjennomføreSatsendringManuelt(any()) } returns true
 
+        // Act & Assert
         SatsendringSvar.entries.forEach {
             every { autovedtakSatsendringService.kjørBehandling(any()) } returns it
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/AutovedtakSmåbarnstilleggUtilsTest.kt
@@ -18,6 +18,7 @@ import java.time.YearMonth
 class AutovedtakSmåbarnstilleggUtilsTest {
     @Test
     fun `Skal legge til innvilgelsesbegrunnelse for småbarnstillegg`() {
+        // Arrange
         val vedtaksperiodeMedBegrunnelser =
             lagVedtaksperiodeMedBegrunnelser(
                 fom = LocalDate.now().førsteDagIInneværendeMåned(),
@@ -25,6 +26,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
                 type = Vedtaksperiodetype.UTBETALING,
             )
 
+        // Act
         val oppdatertVedtaksperiodeMedBegrunnelser =
             finnAktuellVedtaksperiodeOgLeggTilSmåbarnstilleggbegrunnelse(
                 vedtaksperioderMedBegrunnelser =
@@ -39,6 +41,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
                 redusertMånedPeriode = null,
             )
 
+        // Assert
         assertNotNull(oppdatertVedtaksperiodeMedBegrunnelser)
         assertTrue(oppdatertVedtaksperiodeMedBegrunnelser.begrunnelser.any { it.standardbegrunnelse == Standardbegrunnelse.INNVILGET_SMÅBARNSTILLEGG })
         assertTrue(oppdatertVedtaksperiodeMedBegrunnelser.begrunnelser.none { it.standardbegrunnelse == Standardbegrunnelse.REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_FULL_OVERGANGSSTØNAD })
@@ -46,6 +49,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal legge til reduksjonsbegrunnelse for småbarnstillegg`() {
+        // Arrange
         val vedtaksperiodeMedBegrunnelser =
             lagVedtaksperiodeMedBegrunnelser(
                 fom = LocalDate.now().nesteMåned().førsteDagIInneværendeMåned(),
@@ -53,6 +57,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
                 type = Vedtaksperiodetype.UTBETALING,
             )
 
+        // Act
         val oppdatertVedtaksperiodeMedBegrunnelser =
             finnAktuellVedtaksperiodeOgLeggTilSmåbarnstilleggbegrunnelse(
                 vedtaksperioderMedBegrunnelser =
@@ -67,6 +72,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
                     ),
             )
 
+        // Assert
         assertNotNull(oppdatertVedtaksperiodeMedBegrunnelser)
         assertTrue(oppdatertVedtaksperiodeMedBegrunnelser.begrunnelser.none { it.standardbegrunnelse == Standardbegrunnelse.INNVILGET_SMÅBARNSTILLEGG })
         assertTrue(oppdatertVedtaksperiodeMedBegrunnelser.begrunnelser.any { it.standardbegrunnelse == Standardbegrunnelse.REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_FULL_OVERGANGSSTØNAD })
@@ -74,6 +80,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal legge til reduksjonsbegrunnelse fra inneværende måned for småbarnstillegg`() {
+        // Arrange
         val vedtaksperiodeMedBegrunnelser =
             lagVedtaksperiodeMedBegrunnelser(
                 fom = LocalDate.now().førsteDagIInneværendeMåned(),
@@ -81,6 +88,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
                 type = Vedtaksperiodetype.UTBETALING,
             )
 
+        // Act
         val oppdatertVedtaksperiodeMedBegrunnelser =
             finnAktuellVedtaksperiodeOgLeggTilSmåbarnstilleggbegrunnelse(
                 vedtaksperioderMedBegrunnelser =
@@ -95,6 +103,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
                     ),
             )
 
+        // Assert
         assertNotNull(oppdatertVedtaksperiodeMedBegrunnelser)
         assertTrue(oppdatertVedtaksperiodeMedBegrunnelser.begrunnelser.none { it.standardbegrunnelse == Standardbegrunnelse.INNVILGET_SMÅBARNSTILLEGG })
         assertTrue(oppdatertVedtaksperiodeMedBegrunnelser.begrunnelser.any { it.standardbegrunnelse == Standardbegrunnelse.REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_FULL_OVERGANGSSTØNAD })
@@ -102,6 +111,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal kaste feil om det ikke finnes innvilget eller redusert periode å begrunne`() {
+        // Arrange
         val vedtaksperiodeMedBegrunnelser =
             lagVedtaksperiodeMedBegrunnelser(
                 fom = LocalDate.now().nesteMåned().førsteDagIInneværendeMåned(),
@@ -109,6 +119,7 @@ class AutovedtakSmåbarnstilleggUtilsTest {
                 type = Vedtaksperiodetype.UTBETALING,
             )
 
+        // Act & Assert
         assertThrows<VedtaksperiodefinnerSmåbarnstilleggFeil> {
             finnAktuellVedtaksperiodeOgLeggTilSmåbarnstilleggbegrunnelse(
                 vedtaksperioderMedBegrunnelser =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/småbarnstillegg/RestartAvSmåbarnstilleggServiceTest.kt
@@ -30,6 +30,7 @@ class RestartAvSmåbarnstilleggServiceTest {
 
     @Test
     fun `Skal ikke inkludere saker som er migrert forrige måned ved opprettelse av restartet småbarnstillegg oppgave`() {
+        // Arrange
         every { behandlingHentOgPersisterService.partitionByIverksatteBehandlinger<Long>(any()) } returns
             listOf(0L, 1L, 2L)
 
@@ -48,6 +49,7 @@ class RestartAvSmåbarnstilleggServiceTest {
             restartAvSmåbarnstilleggService.periodeMedRestartetSmåbarnstilleggErAlleredeBegrunnet(any(), any())
         } returns false
 
+        // Act & Assert
         Assertions.assertEquals(
             listOf(0L, 2L),
             restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/AutomatiskBeslutningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/AutomatiskBeslutningServiceTest.kt
@@ -17,6 +17,7 @@ class AutomatiskBeslutningServiceTest {
 
     @Test
     fun `behandlingSkalAutomatiskBesluttes - skal returnere true dersom behandling er helmanuell migrering med avvik innenfor beløpsgrenser og det ikke finnes manuelle posteringer`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -25,22 +26,26 @@ class AutomatiskBeslutningServiceTest {
         every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns true
         every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns false
 
+        // Act & Assert
         assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isTrue
     }
 
     @Test
     fun `behandlingSkalAutomatiskBesluttes - skal returnere true dersom behandling er endre migreringsdato behandling`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
                 årsak = BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
             )
 
+        // Act & Assert
         assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isTrue
     }
 
     @Test
     fun `behandlingSkalAutomatiskBesluttes - skal returnere false dersom behandling er helmanuell migrering med avvik innenfor beløpsgrenser men det finnes manuelle posteringer`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -49,11 +54,13 @@ class AutomatiskBeslutningServiceTest {
         every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns true
         every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns true
 
+        // Act & Assert
         assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
     }
 
     @Test
     fun `behandlingSkalAutomatiskBesluttes - skal returnere false dersom behandling er helmanuell migrering med avvik utenfor beløpsgrenser og det ikke finnes manuelle posteringer`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -62,11 +69,13 @@ class AutomatiskBeslutningServiceTest {
         every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns false
         every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns false
 
+        // Act & Assert
         assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
     }
 
     @Test
     fun `behandlingSkalAutomatiskBesluttes - skal returnere false dersom behandling er helmanuell migrering med avvik utenfor beløpsgrenser og det finnes manuelle posteringer`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -75,6 +84,7 @@ class AutomatiskBeslutningServiceTest {
         every { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) } returns false
         every { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) } returns true
 
+        // Act & Assert
         assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
     }
 
@@ -91,11 +101,14 @@ class AutomatiskBeslutningServiceTest {
                     BehandlingType.MIGRERING_FRA_INFOTRYGD_OPPHØRT,
                 ).contains(it)
             }.forEach { behandlingType ->
+                // Arrange
                 val behandling =
                     lagBehandling(
                         behandlingType = behandlingType,
                         årsak = behandlingÅrsak,
                     )
+
+                // Act & Assert
                 assertThat(automatiskBeslutningService.behandlingSkalAutomatiskBesluttes(behandling)).isFalse
             }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingUtilsTest.kt
@@ -119,11 +119,14 @@ class BehandlingUtilsTest {
 
     @Test
     fun `Skal finne ut at omregningsbehandling allerede har kjørt inneværende måned`() {
+        // Arrange
         val fgb = lagBehandling()
         val omregning6År =
             lagBehandling(
                 årsak = BehandlingÅrsak.OMREGNING_18ÅR,
             )
+
+        // Act
         val behandlingsårsakHarAlleredeKjørt =
             Behandlingutils.harBehandlingsårsakAlleredeKjørt(
                 behandlingÅrsak = BehandlingÅrsak.OMREGNING_18ÅR,
@@ -131,12 +134,16 @@ class BehandlingUtilsTest {
                 måned = YearMonth.now(),
             )
 
+        // Assert
         assertTrue(behandlingsårsakHarAlleredeKjørt)
     }
 
     @Test
     fun `Skal finne ut at omregningsbehandling ikke har kjørt inneværende måned`() {
+        // Arrange
         val fgb = lagBehandling()
+
+        // Act
         val behandlingsårsakHarAlleredeKjørt =
             Behandlingutils.harBehandlingsårsakAlleredeKjørt(
                 behandlingÅrsak = BehandlingÅrsak.OMREGNING_18ÅR,
@@ -144,11 +151,13 @@ class BehandlingUtilsTest {
                 måned = YearMonth.now(),
             )
 
+        // Assert
         assertFalse(behandlingsårsakHarAlleredeKjørt)
     }
 
     @Test
     fun `Skal kaste feil etter at vedtaksbrev er distribuert`() {
+        // Arrange
         val fgb = lagBehandling()
         fgb.behandlingStegTilstand.clear()
         fgb.behandlingStegTilstand.add(
@@ -159,11 +168,13 @@ class BehandlingUtilsTest {
             ),
         )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> { validerBehandlingIkkeSendtTilEksterneTjenester(fgb) }
     }
 
     @Test
     fun `Skal kaste feil etter iverksetting mot økonomi`() {
+        // Arrange
         val fgb = lagBehandling()
         fgb.behandlingStegTilstand.clear()
         fgb.behandlingStegTilstand.add(
@@ -174,11 +185,13 @@ class BehandlingUtilsTest {
             ),
         )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> { validerBehandlingIkkeSendtTilEksterneTjenester(fgb) }
     }
 
     @Test
     fun `Skal kaste feil etter at brev er journalført`() {
+        // Arrange
         val fgb = lagBehandling()
         fgb.behandlingStegTilstand.clear()
         fgb.behandlingStegTilstand.add(
@@ -189,6 +202,7 @@ class BehandlingUtilsTest {
             ),
         )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> { validerBehandlingIkkeSendtTilEksterneTjenester(fgb) }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/HenleggÅrsakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/HenleggÅrsakTest.kt
@@ -10,25 +10,37 @@ class HenleggÅrsakTest {
     @ParameterizedTest
     @EnumSource(BehandlingÅrsak::class, names = ["SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID", "SMÅBARNSTILLEGG"])
     fun `Skal returnere HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG for AUTOMATISK_HENLAGT hvis årsaken er småbarnstillegg relatert`(behandlingÅrsak: BehandlingÅrsak) {
+        // Act
         val resultat = HenleggÅrsak.AUTOMATISK_HENLAGT.tilBehandlingsresultat(behandlingÅrsak)
+
+        // Assert
         assertEquals(Behandlingsresultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG, resultat)
     }
 
     @Test
     fun `Skal returnere riktig behandlingsresultat for FEILAKTIG_OPPRETTET`() {
+        // Act
         val resultat = HenleggÅrsak.FEILAKTIG_OPPRETTET.tilBehandlingsresultat(BehandlingÅrsak.FØDSELSHENDELSE)
+
+        // Assert
         assertEquals(Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET, resultat)
     }
 
     @Test
     fun `Skal returnere riktig behandlingsresultat for SØKNAD_TRUKKET`() {
+        // Act
         val resultat = HenleggÅrsak.SØKNAD_TRUKKET.tilBehandlingsresultat(BehandlingÅrsak.FØDSELSHENDELSE)
+
+        // Assert
         assertEquals(Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET, resultat)
     }
 
     @Test
     fun `Skal returnere riktig behandlingsresultat for TEKNISK_VEDLIKEHOLD`() {
+        // Act
         val resultat = HenleggÅrsak.TEKNISK_VEDLIKEHOLD.tilBehandlingsresultat(BehandlingÅrsak.FØDSELSHENDELSE)
+
+        // Assert
         assertEquals(Behandlingsresultat.HENLAGT_TEKNISK_VEDLIKEHOLD, resultat)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/LagreMigreringsdatoTest.kt
@@ -72,11 +72,13 @@ class LagreMigreringsdatoTest {
 
     @Test
     fun `Lagre første migreringstidspunkt skal ikke kaste feil`() {
+        // Arrange
         every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(any()) } returns null
         every { behandlingMigreringsinfoRepository.save(any()) } returns mockk()
         every { vilkårsvurderingService.hentTidligsteVilkårsvurderingKnyttetTilMigrering(any()) } returns YearMonth.now()
         every { behandlingHentOgPersisterService.hentBehandlinger(any()) } returns emptyList()
 
+        // Act & Assert
         assertDoesNotThrow {
             behandlingService.lagreNedMigreringsdato(
                 migreringsdato = LocalDate.now(),
@@ -87,10 +89,12 @@ class LagreMigreringsdatoTest {
 
     @Test
     fun `Lagre likt migreringstidspunkt skal kaste feil`() {
+        // Arrange
         every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(any()) } returns LocalDate.now()
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns null
         every { behandlingMigreringsinfoRepository.save(any()) } returns mockk()
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 behandlingService.lagreNedMigreringsdato(
@@ -102,6 +106,8 @@ class LagreMigreringsdatoTest {
                         ),
                 )
             }
+
+        // Assert
         assertEquals(
             "Migreringsdatoen du har lagt inn er lik eller senere enn eksisterende migreringsdato. Du må velge en tidligere migreringsdato for å fortsette.",
             feil.melding,
@@ -110,10 +116,12 @@ class LagreMigreringsdatoTest {
 
     @Test
     fun `Lagre tidligere migreringstidspunkt skal ikke kaste feil`() {
+        // Arrange
         every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(any()) } returns LocalDate.now()
         every { behandlingHentOgPersisterService.hentBehandlinger(any()) } returns emptyList()
         every { behandlingMigreringsinfoRepository.save(any()) } returns mockk()
 
+        // Act & Assert
         assertDoesNotThrow {
             behandlingService.lagreNedMigreringsdato(
                 migreringsdato = LocalDate.now().minusMonths(1),
@@ -128,6 +136,7 @@ class LagreMigreringsdatoTest {
 
     @Test
     fun `Lagre tidligere migreringstidspunkt skal kaste feil dersom forrige behandling ikke har lagret migreringsdato`() {
+        // Arrange
         every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(any()) } returns null
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns
             lagBehandling(behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD).also {
@@ -138,6 +147,7 @@ class LagreMigreringsdatoTest {
 
         every { behandlingMigreringsinfoRepository.save(any()) } returns mockk()
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 behandlingService.lagreNedMigreringsdato(
@@ -149,6 +159,8 @@ class LagreMigreringsdatoTest {
                         ),
                 )
             }
+
+        // Assert
         assertEquals(
             "Migreringsdatoen du har lagt inn er lik eller senere enn eksisterende migreringsdato. Du må velge en tidligere migreringsdato for å fortsette.",
             feil.melding,
@@ -157,6 +169,7 @@ class LagreMigreringsdatoTest {
 
     @Test
     fun `Lagre tidligere migreringstidspunkt skal ikke kaste feil dersom forrige behandling ikke er migreringsbehandling`() {
+        // Arrange
         every { behandlingMigreringsinfoRepository.finnSisteMigreringsdatoPåFagsak(any()) } returns null
         every { behandlingHentOgPersisterService.hentSisteBehandlingSomErVedtatt(any()) } returns
             lagBehandling(behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING).also {
@@ -167,6 +180,7 @@ class LagreMigreringsdatoTest {
 
         every { behandlingMigreringsinfoRepository.save(any()) } returns mockk()
 
+        // Act & Assert
         assertDoesNotThrow {
             behandlingService.lagreNedMigreringsdato(
                 migreringsdato = LocalDate.now(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/ValiderBrevmottakerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/ValiderBrevmottakerServiceTest.kt
@@ -44,13 +44,16 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal ikke kaste funksjonell feil når en behandling ikke inneholder noen manuelle brevmottakere`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns emptyList()
 
+        // Act
         validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
             behandlingId,
             ekstraBarnLagtTilIBrev = emptyList(),
         )
 
+        // Assert
         verify(exactly = 1) { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) }
         verify(exactly = 0) { persongrunnlagService.hentAktiv(any()) }
         verify(exactly = 0) {
@@ -62,6 +65,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal kaste en FunksjonellFeil exception når en behandling inneholder minst en strengt fortrolig person og minst en manuell brevmottaker`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns listOf(brevmottaker)
         every { persongrunnlagService.hentAktiv(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -73,6 +77,7 @@ class ValiderBrevmottakerServiceTest {
                 søker.aktør.aktivFødselsnummer(),
             )
 
+        // Act & Assert
         assertThatThrownBy {
             validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
                 behandlingId,
@@ -83,6 +88,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal ikke kaste funksjonell feil når behandling ikke inneholder noen strengt fortrolige personer og inneholder minst en manuell brevmottaker`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns listOf(brevmottaker)
         every { persongrunnlagService.hentAktiv(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -91,10 +97,13 @@ class ValiderBrevmottakerServiceTest {
             )
         every { familieIntegrasjonerTilgangskontrollService.hentIdenterMedStrengtFortroligAdressebeskyttelse(any()) } returns emptyList()
 
+        // Act
         validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
             behandlingId,
             ekstraBarnLagtTilIBrev = emptyList(),
         )
+
+        // Assert
         verify(exactly = 1) {
             familieIntegrasjonerTilgangskontrollService.hentIdenterMedStrengtFortroligAdressebeskyttelse(
                 any(),
@@ -104,6 +113,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal ikke kaste en exception når en behandling inneholder minst en strengt fortrolig person og ingen manuelle brevmottakere`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns emptyList()
         every { persongrunnlagService.hentAktiv(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -115,6 +125,7 @@ class ValiderBrevmottakerServiceTest {
                 søker.aktør.aktivFødselsnummer(),
             )
 
+        // Act
         validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
             behandlingId,
             ekstraBarnLagtTilIBrev = emptyList(),
@@ -123,6 +134,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal kaste en FunksjonellFeil exception når en behandling inneholder minst en strengt fortrolig person og det blir forsøkt lagt til en ny manuell brevmottaker`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns emptyList()
         every { persongrunnlagService.hentAktiv(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -134,6 +146,7 @@ class ValiderBrevmottakerServiceTest {
                 søker.aktør.aktivFødselsnummer(),
             )
 
+        // Act & Assert
         assertThatThrownBy {
             validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
                 behandlingId,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingStegTilstandTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/domene/BehandlingStegTilstandTest.kt
@@ -11,10 +11,14 @@ import org.junit.jupiter.api.Test
 class BehandlingStegTilstandTest {
     @Test
     fun `Verifiser at siste steg får status IKKE_UTFØRT`() {
+        // Arrange
         val behandling = opprettBehandling()
+
+        // Act
         behandling.leggTilBehandlingStegTilstand(StegType.REGISTRERE_PERSONGRUNNLAG)
         behandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
 
+        // Assert
         assertEquals(
             BehandlingStegStatus.UTFØRT,
             behandling.behandlingStegTilstand.first { it.behandlingSteg == StegType.REGISTRERE_SØKNAD }.behandlingStegStatus,
@@ -31,11 +35,15 @@ class BehandlingStegTilstandTest {
 
     @Test
     fun `Verifiser maks et steg av hver type`() {
+        // Arrange
         val behandling = opprettBehandling()
+
+        // Act
         behandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
         behandling.leggTilBehandlingStegTilstand(StegType.REGISTRERE_PERSONGRUNNLAG)
         behandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
 
+        // Assert
         assertEquals(
             BehandlingStegStatus.IKKE_UTFØRT,
             behandling.behandlingStegTilstand.single { it.behandlingSteg == StegType.VILKÅRSVURDERING }.behandlingStegStatus,
@@ -44,12 +52,16 @@ class BehandlingStegTilstandTest {
 
     @Test
     fun `Verifiser at alle steg med høyere rekkefølge enn siste fjernes`() {
+        // Arrange
         val behandling = opprettBehandling()
         behandling.leggTilBehandlingStegTilstand(StegType.REGISTRERE_PERSONGRUNNLAG)
         behandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
         behandling.leggTilBehandlingStegTilstand(StegType.SEND_TIL_BESLUTTER)
+
+        // Act
         behandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
 
+        // Assert
         assertEquals(
             BehandlingStegStatus.UTFØRT,
             behandling.behandlingStegTilstand.single { it.behandlingSteg == StegType.REGISTRERE_PERSONGRUNNLAG }.behandlingStegStatus,
@@ -67,12 +79,16 @@ class BehandlingStegTilstandTest {
 
     @Test
     fun `Verifiser henlegg søknad ikke endrer stegstatus`() {
+        // Arrange
         val behandling = opprettBehandling()
         behandling.leggTilBehandlingStegTilstand(StegType.REGISTRERE_PERSONGRUNNLAG)
         behandling.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING)
         behandling.leggTilBehandlingStegTilstand(StegType.SEND_TIL_BESLUTTER)
+
+        // Act
         behandling.leggTilHenleggStegOmDetIkkeFinnesFraFør()
 
+        // Assert
         assertEquals(
             BehandlingStegStatus.UTFØRT,
             behandling.behandlingStegTilstand.single { it.behandlingSteg == StegType.REGISTRERE_SØKNAD }.behandlingStegStatus,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -45,6 +45,7 @@ class BehandlingsresultatOpphørUtilsTest {
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere IKKE_OPPHØRT dersom nåværende andeler strekker seg lengre enn dagens dato`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -80,6 +81,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -88,11 +90,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom nåværende andeler opphører mens forrige andeler ikke opphører til og med dagens dato`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -128,6 +132,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -136,11 +141,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom nåværende andeler opphører tidligere enn forrige andeler og dagens dato`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -176,6 +183,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -184,11 +192,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom vi går fra andeler på person til fullt opphør på person`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndeler =
@@ -201,6 +211,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = emptyList(),
@@ -209,11 +220,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere FORTSATT_OPPHØRT dersom nåværende andeler har lik opphørsdato som forrige andeler`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -249,6 +262,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -257,11 +271,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.FORTSATT_OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere IKKE_OPPHØRT dersom nåværende andeler har lik opphørsdato som forrige andeler men det er i fremtiden`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -297,6 +313,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -305,12 +322,14 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
     }
 
     @ParameterizedTest
     @EnumSource(Årsak::class, names = ["ALLEREDE_UTBETALT", "ENDRE_MOTTAKER", "ETTERBETALING_3ÅR"])
     internal fun `filtrerBortIrrelevanteAndeler - skal filtrere andeler som har 0 i beløp og endret utbetaling andel med årsak ALLEREDE_UTBETALT, ENDRE_MOTTAKER eller ETTERBETALING_3ÅR`(årsak: Årsak) {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val barnAktør = barn.aktør
 
@@ -354,14 +373,17 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val andelerEtterFiltrering = andeler.filtrerBortIrrelevanteAndeler(endretUtBetalingAndeler)
 
+        // Assert
         assertEquals(andelerEtterFiltrering.minOf { it.stønadFom }, for1mndSiden)
         assertEquals(andelerEtterFiltrering.maxOf { it.stønadTom }, om1mnd)
     }
 
     @Test
     internal fun `filtrerBortIrrelevanteAndeler - skal ikke filtrere andeler som har 0 i beløp og endret utbetaling andel med årsak DELT_BOSTED`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val barnAktør = barn.aktør
 
@@ -405,14 +427,17 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val andelerEtterFiltrering = andeler.filtrerBortIrrelevanteAndeler(endretUtBetalingAndeler)
 
+        // Assert
         assertEquals(andelerEtterFiltrering.minOf { it.stønadFom }, for3mndSiden)
         assertEquals(andelerEtterFiltrering.maxOf { it.stønadTom }, om4mnd)
     }
 
     @Test
     internal fun `filtrerBortIrrelevanteAndeler - skal ikke filtrere andeler som har 0 i beløp grunnet differanseberegning`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val barnAktør = barn.aktør
         val søker = lagPerson(type = PersonType.SØKER)
@@ -443,14 +468,17 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val andelerEtterFiltrering = andeler.filtrerBortIrrelevanteAndeler(endretAndeler = emptyList())
 
+        // Assert
         assertEquals(andelerEtterFiltrering.minOf { it.stønadFom }, for3mndSiden)
         assertEquals(andelerEtterFiltrering.maxOf { it.stønadTom }, om4mnd)
     }
 
     @Test
     fun `utledOpphørsdatoForNåværendeBehandlingMedFallback - skal returnere null hvis det ikke finnes andeler i inneværende behandling og kun irrelevante nullutbetalinger i forrige behandling`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
 
         val forrigeAndeler =
@@ -489,6 +517,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørstidspunktInneværendeBehandling =
             emptyList<AndelTilkjentYtelse>().utledOpphørsdatoForNåværendeBehandlingMedFallback(
                 forrigeAndelerIBehandling = forrigeAndeler,
@@ -496,11 +525,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåværendeEndretAndelerIBehandling = emptyList(),
             )
 
+        // Assert
         assertNull(opphørstidspunktInneværendeBehandling)
     }
 
     @Test
     fun `utledOpphørsdatoForNåværendeBehandlingMedFallback - skal returnere tidligste fom på andeler i forrige behandling hvis det ikke finnes andeler i inneværende behandling`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
 
         val forrigeAndeler =
@@ -531,6 +562,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørstidspunktInneværendeBehandling =
             emptyList<AndelTilkjentYtelse>().utledOpphørsdatoForNåværendeBehandlingMedFallback(
                 forrigeAndelerIBehandling = forrigeAndeler,
@@ -538,6 +570,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåværendeEndretAndelerIBehandling = emptyList(),
             )
 
+        // Assert
         assertEquals(for1mndSiden, opphørstidspunktInneværendeBehandling)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
@@ -35,6 +35,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal bare utlede resultater for personer det er framstilt krav for`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
@@ -45,6 +46,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 aktør = barn1Aktør,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = listOf(forrigeAndel),
@@ -53,11 +55,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = emptyList(),
             )
 
+        // Assert
         assertThat(søknadsResultat, Is(emptyList()))
     }
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere ingen relevante endringer dersom beløpene for periodene er lik forrige behandling`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
@@ -68,6 +72,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 aktør = barn1Aktør,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = listOf(forrigeAndel),
@@ -76,12 +81,14 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = emptyList(),
             )
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER))
     }
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere innvilget dersom det finnes beløp for perioder som er annerledes enn sist og større enn 0`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
@@ -92,6 +99,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 aktør = barn1Aktør,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = listOf(forrigeAndel),
@@ -103,12 +111,14 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = emptyList(),
             ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INNVILGET))
     }
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere ingen relevante endringer dersom beløp på nåværende andel er 0 og det ikke finnes noen endringsperioder eller differanse beregning`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
 
         val forrigeAndel =
@@ -119,6 +129,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 aktør = barn1Aktør,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = listOf(forrigeAndel),
@@ -130,12 +141,14 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = emptyList(),
             )
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER))
     }
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere INNVILGET dersom beløp på nåværende andel er 0 og det finnes endringsperiode som DELT_BOSTED`() {
+        // Arrange
         val barn1Person = lagPerson(type = PersonType.BARN)
         val barn1Aktør = barn1Person.aktør
 
@@ -158,6 +171,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 årsak = Årsak.DELT_BOSTED,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = emptyList(),
@@ -169,6 +183,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
             ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INNVILGET))
     }
@@ -178,6 +193,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere AVSLÅTT dersom beløp på nåværende andel er 0 og det finnes endringsperiode som ikke er DELT_BOSTED`(
         årsak: Årsak,
     ) {
+        // Arrange
         val barn1Person = lagPerson(type = PersonType.BARN)
         val barn1Aktør = barn1Person.aktør
 
@@ -200,6 +216,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 årsak = årsak,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = emptyList(),
@@ -211,6 +228,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
             ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.AVSLÅTT))
     }
@@ -220,6 +238,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere INGEN_RELEVANTE_ENDRINGER dersom beløp på nåværende andel er 0 og andelen eksisterte forrige gang (beløp større eller lik 0)`(
         årsak: Årsak,
     ) {
+        // Arrange
         val barn1Person = lagPerson(type = PersonType.BARN)
         val barn1Aktør = barn1Person.aktør
 
@@ -241,6 +260,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 årsak = årsak,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = listOf(forrigeAndel),
@@ -252,12 +272,14 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
             )
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER))
     }
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere INNVILGET dersom beløpet på nåværende andel er 0 men er differanseberegnet`() {
+        // Arrange
         val barn1Person = lagPerson(type = PersonType.BARN)
         val barn1Aktør = barn1Person.aktør
 
@@ -271,6 +293,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 aktør = barn1Aktør,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = emptyList(),
@@ -285,12 +308,14 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = emptyList(),
             ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INNVILGET))
     }
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere INNVILGET OG AVSLÅTT dersom 1 barn får innvilget og 1 barn får avslått`() {
+        // Arrange
         val barn1Person = lagPerson(type = PersonType.BARN)
         val barn1Aktør = barn1Person.aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
@@ -330,6 +355,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 årsak = Årsak.ALLEREDE_UTBETALT,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = forrigeAndeler,
@@ -338,6 +364,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = listOf(endretUtbetalingAndel),
             ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
+        // Assert
         assertThat(søknadsResultat.size, Is(2))
         assertThat(
             søknadsResultat,
@@ -350,6 +377,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
     @Test
     fun `utledSøknadResultatFraAndelerTilkjentYtelse skal returnere INNVILGET dersom småbarnstillegg blir lagt til`() {
+        // Arrange
         val barn1Person = lagPerson(type = PersonType.BARN)
         val barn1Aktør = barn1Person.aktør
         val søker = lagPerson(type = PersonType.SØKER)
@@ -371,6 +399,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 ytelseType = YtelseType.UTVIDET_BARNETRYGD,
             )
 
+        // Act
         val søknadsResultat =
             utledSøknadResultatFraAndelerTilkjentYtelse(
                 forrigeAndeler = listOf(forrigeAndelBarn, forrigeAndelUtvidet),
@@ -390,16 +419,20 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 endretUtbetalingAndeler = emptyList(),
             ).filter { it != Søknadsresultat.INGEN_RELEVANTE_ENDRINGER }
 
+        // Assert
         assertThat(søknadsResultat.size, Is(1))
         assertThat(søknadsResultat[0], Is(Søknadsresultat.INNVILGET))
     }
 
     @Test
     fun `kombinerSøknadsresultater skal kaste feil dersom lista ikke inneholder noe som helst`() {
+        // Arrange
         val listeMedIngenSøknadsresultat = listOf<Søknadsresultat>()
 
+        // Act & Assert
         val feil = assertThrows<FunksjonellFeil> { listeMedIngenSøknadsresultat.kombinerSøknadsresultater(behandlingÅrsak = BehandlingÅrsak.SØKNAD) }
 
+        // Assert
         assertThat(feil.message, Is("Klarer ikke utlede søknadsresultat. Finner ingen resultater."))
     }
 
@@ -408,10 +441,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
     internal fun `kombinerSøknadsresultater skal alltid returnere innholdet som det er hvis det bare 1 resultat i lista`(
         søknadsresultat: Søknadsresultat,
     ) {
+        // Arrange
         val listeMedSøknadsresultat = listOf(søknadsresultat)
 
+        // Act
         val kombinertResultat = listeMedSøknadsresultat.kombinerSøknadsresultater(behandlingÅrsak = BehandlingÅrsak.SØKNAD)
 
+        // Assert
         assertThat(kombinertResultat, Is(søknadsresultat))
     }
 
@@ -420,16 +456,20 @@ internal class BehandlingsresultatSøknadUtilsTest {
     internal fun `kombinerSøknadsresultater skal ignorere INGEN_RELEVANTE_ENDRINGER dersom den er paret opp med INNVILGET eller AVSLÅTT`(
         søknadsresultat: Søknadsresultat,
     ) {
+        // Arrange
         val listeMedSøknadsresultat =
             listOf(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, søknadsresultat)
 
+        // Act
         val kombinertResultat = listeMedSøknadsresultat.kombinerSøknadsresultater(behandlingÅrsak = BehandlingÅrsak.SØKNAD)
 
+        // Assert
         assertThat(kombinertResultat, Is(søknadsresultat))
     }
 
     @Test
     fun `kombinerSøknadsresultater skal returnere DELVIS_INNVILGET dersom lista består av INNVILGET, AVSLÅTT OG INGEN_RELEVANTE_ENDRINGER`() {
+        // Arrange
         val listeMedSøknadsresultat =
             listOf(
                 Søknadsresultat.INNVILGET,
@@ -437,8 +477,10 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 Søknadsresultat.INGEN_RELEVANTE_ENDRINGER,
             )
 
+        // Act
         val kombinertResultat = listeMedSøknadsresultat.kombinerSøknadsresultater(behandlingÅrsak = BehandlingÅrsak.SØKNAD)
 
+        // Assert
         assertThat(kombinertResultat, Is(Søknadsresultat.DELVIS_INNVILGET))
     }
 
@@ -459,6 +501,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
     @Test
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom det er søkt for barn som ikke er registrert`() {
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -470,11 +513,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = true,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom det er eksplisitt avslag på søker (uten at det er søkt om utvidet)`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
         val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -491,6 +536,8 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 erEksplisittAvslagPåSøknad = true,
                 lagFullstendigVilkårResultat = true,
             )
+
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -502,12 +549,14 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
     }
 
     @ParameterizedTest
     @EnumSource(value = Resultat::class, names = ["IKKE_OPPFYLT", "IKKE_VURDERT"])
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom behandlingen er en fødselshendelse og det finnes vilkårsvurdering som ikke er oppfylt eller vurdert`(resultat: Resultat) {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -522,6 +571,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 personType = PersonType.BARN,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -533,11 +583,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom er eksplisitt avslag på minst en person det er framstilt krav for`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -555,6 +607,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -566,11 +619,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere INNVILGET dersom barnet det er søkt for har fått andeler med positive beløp som er annerledes enn forrige gang`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -597,6 +652,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -608,11 +664,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.INNVILGET))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere DELVIS_INNVILGET dersom det finnes et barn som har fått innvilget men også et barn som ikke er registrert`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -639,6 +697,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -650,11 +709,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = true,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.DELVIS_INNVILGET))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere INGEN_RELEVANTE_ENDRINGER dersom barnet det er søkt for har fått helt lik andel som forrige behandling`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -681,6 +742,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = andeler,
@@ -692,6 +754,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -29,6 +29,7 @@ class BehandlingsresultatUtilsTest {
         opphørsresultat: Opphørsresultat,
         behandlingsresultat: Behandlingsresultat,
     ) {
+        // Act
         val kombinertResultat =
             BehandlingsresultatUtils.kombinerResultaterTilBehandlingsresultat(
                 søknadsresultat,
@@ -36,6 +37,7 @@ class BehandlingsresultatUtilsTest {
                 opphørsresultat,
             )
 
+        // Assert
         assertEquals(kombinertResultat, behandlingsresultat)
     }
 
@@ -46,6 +48,7 @@ class BehandlingsresultatUtilsTest {
         endringsresultat: Endringsresultat,
         opphørsresultat: Opphørsresultat,
     ) {
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             BehandlingsresultatUtils.kombinerResultaterTilBehandlingsresultat(
                 søknadsresultat,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseUtledRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelTilkjentYtelseUtledRegelverkTest.kt
@@ -37,28 +37,36 @@ class AndelTilkjentYtelseUtledRegelverkTest {
 
     @Test
     fun `EØS-forordning om alle relevante vilkår er satt til regelverk EØS forordning`() {
+        // Act
         val regelverk = andelTilkjentYtelse.vurdertEtter(setOf(genererPersonresultat()))
 
+        // Assert
         assertEquals(Regelverk.EØS_FORORDNINGEN, regelverk)
     }
 
     @Test
     fun `Nasjonale regler om alle relevante vilkår er satt til regelverk nasonale regler`() {
+        // Arrange
         val personResultat =
             genererPersonresultat(Regelverk.NASJONALE_REGLER, Regelverk.NASJONALE_REGLER, Regelverk.NASJONALE_REGLER)
 
+        // Act
         val regelverk = andelTilkjentYtelse.vurdertEtter(setOf(personResultat))
 
+        // Assert
         assertEquals(Regelverk.NASJONALE_REGLER, regelverk)
     }
 
     @Test
     fun `Default til nasjonale regler om relevante vilkår er satt til forskjellig regelverk`() {
+        // Arrange
         val personResultat =
             genererPersonresultat(Regelverk.EØS_FORORDNINGEN, Regelverk.NASJONALE_REGLER, Regelverk.NASJONALE_REGLER)
 
+        // Act
         val regelverk = andelTilkjentYtelse.vurdertEtter(setOf(personResultat))
 
+        // Assert
         assertEquals(Regelverk.NASJONALE_REGLER, regelverk)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -49,6 +49,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
         fun `For behandling med årsak satsendring, månedlig valutajustering, finnmarkstillegg, svalbardtillegg og satsendring EØS blir ikke endrete utbetalinger filtrert bort`(
             årsak: BehandlingÅrsak,
         ) {
+            // Arrange
             val behandling =
                 lagBehandling(
                     behandlingType = BehandlingType.REVURDERING,
@@ -61,13 +62,16 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
             every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns emptyList()
             every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns listOf(endretUtbetalingAndel)
 
+            // Act
             val endreteUtbetalinger = andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
 
+            // Assert
             assertThat(endreteUtbetalinger).hasSize(1)
         }
 
         @Test
         fun `For behandling med årsak nye opplysinger blir endrete utbetalinger uten overlappende andeler filtrert bort`() {
+            // Arrange
             val behandling =
                 lagBehandling(
                     behandlingType = BehandlingType.REVURDERING,
@@ -95,8 +99,10 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
                     ),
                 )
 
+            // Act
             val endreteUtbetalinger = andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
 
+            // Assert
             assertThat(endreteUtbetalinger)
                 .singleElement()
                 .extracting { it.andelerTilkjentYtelse }
@@ -105,6 +111,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
 
         @Test
         fun `For behandling med årsak nye opplsyninger blir endrete utbetalinger med overlappende andeler kombinert`() {
+            // Arrange
             val behandling =
                 lagBehandling(
                     behandlingType = BehandlingType.REVURDERING,
@@ -137,8 +144,10 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
                     ),
                 )
 
+            // Act
             val endreteUtbetalinger = andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
 
+            // Assert
             assertThat(endreteUtbetalinger)
                 .singleElement()
                 .extracting { it.andelerTilkjentYtelse }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest.kt
@@ -58,6 +58,7 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
 
     @Test
     fun `minimal oppfylt vilkårsvurdering ett barn skal gi utbetalinger etter satsendringer`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.nov(2017)
 
@@ -85,11 +86,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 barn får alt av 2012 i feb(2026)..okt(2035),
             )
 
+        // Act & Assert
         assertEquals(forventedeAndeler, vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `minimal oppfylt vilkårsvurdering to barn skal gi utbetalinger etter satsendringer`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn1 = barn født 14.nov(2017)
         val barn2 = barn født 1.mai(2013)
@@ -131,11 +134,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 barn2 får alt av 2012 i feb(2026)..apr(2031),
             )
 
+        // Act & Assert
         assertEquals(forventedeAndeler, vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `vilkårsvurdering med søker og ett barn der søker mangler vurdering av ett vilkår, skal ikke gi utbetalinger`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019)
 
@@ -148,11 +153,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 (UNDER_18_ÅR oppfylt barn.under18år()) og
                 (GIFT_PARTNERSKAP og BOR_MED_SØKER og BOSATT_I_RIKET og LOVLIG_OPPHOLD oppfylt 26.jan(2020)..uendelig)
 
+        // Act & Assert
         assertEquals(emptyList<BeregnetAndel>(), vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `vilkårsvurdering med søker og ett barn der barn mangler vurdering av ett vilkår, skal ikke gi utbetalinger`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019)
 
@@ -165,11 +172,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 // mangler LOVLIG_OPPHOLD
                 (GIFT_PARTNERSKAP og BOR_MED_SØKER og BOSATT_I_RIKET oppfylt 26.jan(2020)..uendelig)
 
+        // Act & Assert
         assertEquals(emptyList<BeregnetAndel>(), vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `vilkårsvurdering der søkers vilkårsresultater ikke overlapper for noen vilkår, skal ikke gi utbetalinger`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019)
 
@@ -182,11 +191,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 (UNDER_18_ÅR oppfylt barn.under18år()) og
                 (GIFT_PARTNERSKAP og BOR_MED_SØKER og BOSATT_I_RIKET og LOVLIG_OPPHOLD oppfylt 26.jan(2020)..uendelig)
 
+        // Act & Assert
         assertEquals(emptyList<BeregnetAndel>(), vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `vilkårsvurdering der barnet vilkårsresultater ikke overlapper for noen vilkår, skal ikke gi utbetalinger`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019)
 
@@ -201,11 +212,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 (BOSATT_I_RIKET oppfylt 1.aug(2027)..31.des(2031)) og
                 (LOVLIG_OPPHOLD oppfylt 1.jan(2032)..uendelig)
 
+        // Act & Assert
         assertEquals(emptyList<BeregnetAndel>(), vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `minimal vilkårsvurdering ett barn og delt bosted`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019)
 
@@ -232,11 +245,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 barn får alt av 2012 i feb(2026)..nov(2037),
             )
 
+        // Act & Assert
         assertEquals(forventedeAndeler, vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS dagen andre dag i måneden`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019)
 
@@ -264,11 +279,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 barn får alt av 1654 i sep(2021)..nov(2021),
             )
 
+        // Act & Assert
         assertEquals(forventedeAndeler, vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `vilkårsvurdering ett barn som dør før fylte 18`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019) død 9.des(2024)
 
@@ -294,11 +311,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 barn får alt av 1766 i jul(2023)..des(2024),
             )
 
+        // Act & Assert
         assertEquals(forventedeAndeler, vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `vilkårsvurdering ett barn som dør samme måned som fylte 18`() {
+        // Arrange
         val søker = søker født 19.nov(1995)
         val barn = barn født 14.des(2019) død 9.des(2037)
 
@@ -326,11 +345,13 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 barn får alt av 2012 i feb(2026)..nov(2037),
             )
 
+        // Act & Assert
         assertEquals(forventedeAndeler, vurdering.beregnAndelerTilkjentYtelseForBarna())
     }
 
     @Test
     fun `skal opprette riktige satser for barn og søker ved utvidet barnetrygd`() {
+        // Arrange
         val søker = PersonType.SØKER født 19.nov(1995)
         val barn = PersonType.BARN født 14.des(2018)
 
@@ -365,6 +386,7 @@ internal class BeregnAndelerTilkjentYtelseMedGjeldendeSatserTest {
                 søker får 2572 i feb(2026)..nov(2036),
             )
 
+        // Act & Assert
         assertEquals(forventedeAndeler, vurdering.beregnAndelerTilkjentYtelse())
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnetAndelDslTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregnetAndelDslTest.kt
@@ -17,9 +17,13 @@ import java.time.YearMonth
 class BeregnetAndelDslTest {
     @Test
     fun `sjekk at andel bygges riktig`() {
+        // Arrange
         val barn = barn født 14.des(2019) død 9.des(2024)
+
+        // Act
         val andel = barn får alt av 1054 i feb(2020)..aug(2020)
 
+        // Assert
         Assertions.assertEquals(barn, andel.person)
         Assertions.assertEquals(BigDecimal.valueOf(100), andel.prosent)
         Assertions.assertEquals(1054, andel.beløp)
@@ -30,8 +34,13 @@ class BeregnetAndelDslTest {
 
     @Test
     fun `sjekk at halvparten av oddetall rundes opp`() {
+        // Arrange
         val barn = barn født 14.des(2019)
+
+        // Act
         val andel = barn får halvparten av 1723
+
+        // Assert
         Assertions.assertEquals(BigDecimal.valueOf(50), andel.prosent)
         Assertions.assertEquals(862, andel.beløp)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -144,6 +144,7 @@ class BeregningServiceTest {
 
     @Test
     fun `Skal mappe perioderesultat til andel ytelser for innvilget vedtak med 18-års vilkår som sluttdato`() {
+        // Arrange
         val behandling = lagBehandling()
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
@@ -196,11 +197,13 @@ class BeregningServiceTest {
                 listOf(barn.aktør.aktivFødselsnummer()),
             )
 
+        // Act
         beregningService.oppdaterBehandlingMedBeregning(
             behandling = behandling,
             personopplysningGrunnlag = personopplysningGrunnlag,
         )
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(capture(slot)) }
 
         Assertions.assertEquals(1, slot.captured.andelerTilkjentYtelse.size)
@@ -226,6 +229,7 @@ class BeregningServiceTest {
 
     @Test
     fun `Skal mappe perioderesultat til andel ytelser for innvilget vedtak som spenner over flere satsperioder`() {
+        // Arrange
         val behandling = lagBehandling()
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
 
@@ -278,11 +282,13 @@ class BeregningServiceTest {
                 listOf(barn.aktør.aktivFødselsnummer()),
             )
 
+        // Act
         beregningService.oppdaterBehandlingMedBeregning(
             behandling = behandling,
             personopplysningGrunnlag = personopplysningGrunnlag,
         )
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(capture(slot)) }
 
         Assertions.assertEquals(2, slot.captured.andelerTilkjentYtelse.size)
@@ -302,6 +308,7 @@ class BeregningServiceTest {
 
     @Test
     fun `Skal verifisere at endret utbetaling andel appliseres på en innvilget utbetaling andel`() {
+        // Arrange
         val behandling = lagBehandling()
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2016, 4, 5))
@@ -384,11 +391,13 @@ class BeregningServiceTest {
 
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id) } returns andelTilkjentYtelser
 
+        // Act
         beregningService.oppdaterBehandlingMedBeregning(
             behandling = behandling,
             personopplysningGrunnlag = personopplysningGrunnlag,
         )
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(capture(slot)) }
 
         Assertions.assertEquals(1, slot.captured.andelerTilkjentYtelse.size)
@@ -402,6 +411,7 @@ class BeregningServiceTest {
 
     @Test
     fun `Skal mappe perioderesultat til andel ytelser for avslått vedtak`() {
+        // Arrange
         val behandling = lagBehandling()
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
         val barn = lagPerson(type = PersonType.BARN)
@@ -447,11 +457,13 @@ class BeregningServiceTest {
                 listOf(barn.aktør.aktivFødselsnummer()),
             )
 
+        // Act
         beregningService.oppdaterBehandlingMedBeregning(
             behandling = behandling,
             personopplysningGrunnlag = personopplysningGrunnlag,
         )
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(capture(slot)) }
 
         Assertions.assertTrue(slot.captured.andelerTilkjentYtelse.isEmpty())
@@ -459,6 +471,7 @@ class BeregningServiceTest {
 
     @Test
     fun `For flere barn med forskjellige perioderesultat skal perioderesultat mappes til andel ytelser`() {
+        // Arrange
         val behandling = lagBehandling()
         every { behandlingHentOgPersisterService.hent(behandling.id) } returns behandling
         val barnFødselsdato = LocalDate.of(2019, 1, 1)
@@ -562,11 +575,13 @@ class BeregningServiceTest {
                 listOf(barn1.aktør.aktivFødselsnummer(), barn2.aktør.aktivFødselsnummer()),
             )
 
+        // Act
         beregningService.oppdaterBehandlingMedBeregning(
             behandling = behandling,
             personopplysningGrunnlag = personopplysningGrunnlag,
         )
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(capture(slot)) }
 
         Assertions.assertEquals(5, slot.captured.andelerTilkjentYtelse.size)
@@ -602,6 +617,7 @@ class BeregningServiceTest {
 
     @Test
     fun `Skal ikke oppdatere utvidet andeler basert på endringsperioder med årsak=delt bosted`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(2))
         val søker = lagPerson(type = PersonType.SØKER, fødselsdato = LocalDate.now().minusYears(31))
 
@@ -614,6 +630,7 @@ class BeregningServiceTest {
         val endretUtbetalingAndelFom = utvidetFom.minusMonths(2).toYearMonth()
         val endretUtbetalingAndelTom = utvidetTom.minusMonths(2).toYearMonth()
 
+        // Act
         val andelerTilkjentYtelse =
             genererAndelerTilkjentYtelseForScenario(
                 endretUtbetalingÅrsak = Årsak.DELT_BOSTED,
@@ -629,6 +646,7 @@ class BeregningServiceTest {
                 søker = søker,
             )
 
+        // Assert
         Assertions.assertEquals(5, andelerTilkjentYtelse.size)
 
         val (andelerSøker, andelerBarn) = andelerTilkjentYtelse.partition { it.aktør.aktivFødselsnummer() == søker.aktør.aktivFødselsnummer() }
@@ -673,6 +691,7 @@ class BeregningServiceTest {
 
     @Test
     fun `Skal oppdatere utvidet andeler og småbarnstillegg med riktig periode og sats ved endringsperiode med årsak=etterbetaling 3år`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(2))
         val søker = lagPerson(type = PersonType.SØKER, fødselsdato = LocalDate.now().minusYears(31))
 
@@ -685,6 +704,7 @@ class BeregningServiceTest {
         val endretUtbetalingAndelFom = utvidetFom.minusMonths(2).toYearMonth()
         val endretUtbetalingAndelTom = utvidetTom.minusMonths(2).toYearMonth()
 
+        // Act
         val andelerTilkjentYtelse =
             genererAndelerTilkjentYtelseForScenario(
                 endretUtbetalingÅrsak = Årsak.ETTERBETALING_3ÅR,
@@ -700,6 +720,7 @@ class BeregningServiceTest {
                 søker = søker,
             )
 
+        // Assert
         Assertions.assertEquals(7, andelerTilkjentYtelse.size)
 
         val (andelerSøker, andelerBarn) = andelerTilkjentYtelse.partition { it.aktør.aktivFødselsnummer() == søker.aktør.aktivFødselsnummer() }
@@ -756,6 +777,7 @@ class BeregningServiceTest {
 
     @Test
     fun `Skal få utvidet, men ikke småbarnstillegg hvis to barn, men barn under 3 år har endringsperiode med årsak=etterbetaling 3 år`() {
+        // Arrange
         val barnUnder3År = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(2))
         val barnOver3År = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(7))
         val søker = lagPerson(type = PersonType.SØKER, fødselsdato = LocalDate.now().minusYears(31))
@@ -769,6 +791,7 @@ class BeregningServiceTest {
         val endretUtbetalingAndelFom = fom.plusMonths(1).toYearMonth()
         val endretUtbetalingAndelTom = utvidetTom.minusMonths(2).toYearMonth()
 
+        // Act
         val andelerTilkjentYtelse =
             genererAndelerTilkjentYtelseForScenario(
                 endretUtbetalingÅrsak = Årsak.ETTERBETALING_3ÅR,
@@ -789,6 +812,7 @@ class BeregningServiceTest {
         // BARNA
         val (andelerBarnUnder3År, andelerBarnOver3År) = andelerBarn.partition { it.aktør.aktivFødselsnummer() == barnUnder3År.aktør.aktivFødselsnummer() }
 
+        // Assert
         Assertions.assertEquals(2, andelerBarnUnder3År.size)
         // Barn (under 3 år) under endringsperiode
         Assertions.assertEquals(barnUnder3År.aktør, andelerBarnUnder3År[0].aktør)
@@ -837,7 +861,10 @@ class BeregningServiceTest {
 
     @Test
     fun `Dersom barn har flere godkjente perioderesultat back2back skal det ikke bli glippe i andel ytelser`() {
+        // Arrange
         val førstePeriodeTomForBarnet = LocalDate.of(2020, 11, 30)
+
+        // Act
         kjørScenarioForBack2Backtester(
             førstePeriodeTomForBarnet = førstePeriodeTomForBarnet,
             andrePeriodeFomForBarnet = førstePeriodeTomForBarnet.plusDays(1),
@@ -849,7 +876,10 @@ class BeregningServiceTest {
 
     @Test
     fun `Dersom barn har flere godkjente perioderesultat som ikke følger back2back skal det bli glippe på en måned i andel ytelser`() {
+        // Arrange
         val førstePeriodeTomForBarnet = LocalDate.of(2020, 11, 29)
+
+        // Act
         kjørScenarioForBack2Backtester(
             førstePeriodeTomForBarnet = førstePeriodeTomForBarnet,
             andrePeriodeFomForBarnet = førstePeriodeTomForBarnet.plusDays(2),
@@ -861,7 +891,10 @@ class BeregningServiceTest {
 
     @Test
     fun `Dersom barn har flere godkjente perioderesultat back2back og delt bosted kun i første periode skal det ikke bli glippe i andel ytelser men beløpsendringen skal inntreffe som normalt neste måned`() {
+        // Arrange
         val førstePeriodeTomForBarnet = LocalDate.of(2020, 11, 30)
+
+        // Act
         kjørScenarioForBack2Backtester(
             førstePeriodeTomForBarnet = førstePeriodeTomForBarnet,
             andrePeriodeFomForBarnet = LocalDate.of(2020, 12, 1),
@@ -874,7 +907,10 @@ class BeregningServiceTest {
 
     @Test
     fun `Dersom barn har flere godkjente perioderesultat back2back og delt bosted kun i andre periode skal det ikke bli glippe i andel ytelser men beløpsendringen skal inntreffe som normalt neste måned`() {
+        // Arrange
         val førstePeriodeTomForBarnet = LocalDate.of(2020, 11, 30)
+
+        // Act
         kjørScenarioForBack2Backtester(
             førstePeriodeTomForBarnet = førstePeriodeTomForBarnet,
             andrePeriodeFomForBarnet = LocalDate.of(2020, 12, 1),
@@ -887,7 +923,10 @@ class BeregningServiceTest {
 
     @Test
     fun `Dersom barn har flere godkjente perioderesultat back2back der alle er delt bosted skal det ikke bli glippe i andel ytelser`() {
+        // Arrange
         val førstePeriodeTomForBarnet = LocalDate.of(2020, 11, 30)
+
+        // Act
         kjørScenarioForBack2Backtester(
             førstePeriodeTomForBarnet = førstePeriodeTomForBarnet,
             andrePeriodeFomForBarnet = førstePeriodeTomForBarnet.plusDays(1),
@@ -901,6 +940,7 @@ class BeregningServiceTest {
 
     @Test
     fun `erEndringerIUtbetalingMellomNåværendeOgForrigeBehandling skal returnere INGEN_ENDRING_I_UTBETALING dersom det utbetalingsbeløpene er like mellom nåværende og forrige behandling`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
@@ -941,9 +981,11 @@ class BeregningServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns nåværendeAndeler
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns forrigeAndeler
 
+        // Act
         val erEndringIUtbetaling =
             beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(nåværendeBehandling)
 
+        // Assert
         Assertions.assertEquals(erEndringIUtbetaling, EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING)
 
         verify { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(nåværendeBehandling) }
@@ -953,6 +995,7 @@ class BeregningServiceTest {
 
     @Test
     fun `erEndringerIUtbetalingMellomNåværendeOgForrigeBehandling skal returnere INGEN_ENDRING_I_UTBETALING dersom man har gått fra andeler med 0 i beløp til ingen andeler`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
@@ -978,9 +1021,11 @@ class BeregningServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns forrigeAndeler
 
+        // Act
         val erEndringIUtbetaling =
             beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(nåværendeBehandling)
 
+        // Assert
         Assertions.assertEquals(erEndringIUtbetaling, EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING)
 
         verify { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(nåværendeBehandling) }
@@ -990,6 +1035,7 @@ class BeregningServiceTest {
 
     @Test
     fun `erEndringerIUtbetalingMellomNåværendeOgForrigeBehandling skal returnere INGEN_ENDRING_I_UTBETALING dersom man har gått fra ingen andeler til andeler med 0 i beløp`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
@@ -1015,9 +1061,11 @@ class BeregningServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns nåværendeAndeler
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns emptyList()
 
+        // Act
         val erEndringIUtbetaling =
             beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(nåværendeBehandling)
 
+        // Assert
         Assertions.assertEquals(erEndringIUtbetaling, EndringerIUtbetalingForBehandlingSteg.INGEN_ENDRING_I_UTBETALING)
 
         verify { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(nåværendeBehandling) }
@@ -1027,6 +1075,7 @@ class BeregningServiceTest {
 
     @Test
     fun `erEndringerIUtbetalingMellomNåværendeOgForrigeBehandling skal returnere ENDRING_I_UTBETALING dersom man har gått fra ingen andeler til andeler med over 0 i beløp`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
@@ -1052,9 +1101,11 @@ class BeregningServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns nåværendeAndeler
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns emptyList()
 
+        // Act
         val erEndringIUtbetaling =
             beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(nåværendeBehandling)
 
+        // Assert
         Assertions.assertEquals(erEndringIUtbetaling, EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING)
 
         verify { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(nåværendeBehandling) }
@@ -1064,6 +1115,7 @@ class BeregningServiceTest {
 
     @Test
     fun `erEndringerIUtbetalingMellomNåværendeOgForrigeBehandling skal returnere ENDRING_I_UTBETALING dersom man fikk beløp over 0 i forrige behandling og det har forandret på seg`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
@@ -1105,9 +1157,11 @@ class BeregningServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nåværendeBehandling.id) } returns nåværendeAndeler
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(forrigeBehandling.id) } returns forrigeAndeler
 
+        // Act
         val erEndringIUtbetaling =
             beregningService.hentEndringerIUtbetalingFraForrigeBehandlingSendtTilØkonomi(nåværendeBehandling)
 
+        // Assert
         Assertions.assertEquals(erEndringIUtbetaling, EndringerIUtbetalingForBehandlingSteg.ENDRING_I_UTBETALING)
 
         verify { behandlingHentOgPersisterService.hentForrigeBehandlingSomErIverksatt(nåværendeBehandling) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/InternPeriodeOvergangsstønadTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/InternPeriodeOvergangsstønadTest.kt
@@ -12,7 +12,10 @@ import java.time.LocalDate
 class InternPeriodeOvergangsstønadTest {
     @Test
     fun `Skal slå sammen perioder som er sammenhengende`() {
+        // Arrange
         val personIdent = randomFnr()
+
+        // Act
         val sammenslåttePerioder =
             listOf(
                 InternPeriodeOvergangsstønad(
@@ -27,12 +30,16 @@ class InternPeriodeOvergangsstønadTest {
                 ),
             ).slåSammenSammenhengendePerioder()
 
+        // Assert
         assertEquals(1, sammenslåttePerioder.size)
     }
 
     @Test
     fun `Skal ikke slå sammen perioder som ikke er sammenhengende`() {
+        // Arrange
         val personIdent = randomFnr()
+
+        // Act
         val sammenslåttePerioder =
             listOf(
                 InternPeriodeOvergangsstønad(
@@ -47,6 +54,7 @@ class InternPeriodeOvergangsstønadTest {
                 ),
             ).slåSammenSammenhengendePerioder()
 
+        // Assert
         assertEquals(2, sammenslåttePerioder.size)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/OrdinærBarnetrygdUtilTest.kt
@@ -29,6 +29,7 @@ import java.time.YearMonth
 class OrdinærBarnetrygdUtilTest {
     @Test
     fun `Skal lage riktig tidslinje med rett til prosent for person med start og stopp av delt bosted`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(9))
         val vilkårsvurdering = Vilkårsvurdering(behandling = lagBehandling())
 
@@ -91,6 +92,7 @@ class OrdinærBarnetrygdUtilTest {
 
         personResultat.setSortedVilkårResultater(vilkårResulater + borMedSøkerVilkår)
 
+        // Act
         val tidslinje =
             personResultat.tilTidslinjeMedRettTilProsentForPerson(
                 person = barn,
@@ -99,6 +101,7 @@ class OrdinærBarnetrygdUtilTest {
 
         val perioder = tidslinje.tilPerioderIkkeNull().toList()
 
+        // Assert
         assertEquals(3, perioder.size)
 
         val periode1 = perioder[0]
@@ -127,6 +130,7 @@ class OrdinærBarnetrygdUtilTest {
 
     @Test
     fun `Skal returnere 50 prosent hvis vilkårsvurderingen har delt bosted i perioden`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val personResultat =
             PersonResultat(
@@ -145,13 +149,16 @@ class OrdinærBarnetrygdUtilTest {
                 )
             }
 
+        // Act
         val prosent = vilkårResultater.mapTilProsentEllerNull(personType = PersonType.BARN, fagsakType = FagsakType.NORMAL)
 
+        // Assert
         assertEquals(BigDecimal(50), prosent)
     }
 
     @Test
     fun `Skal returnere 100 prosent hvis vilkårsvurderingen ikke har delt bosted i perioden`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val personResultat =
             PersonResultat(
@@ -170,13 +177,16 @@ class OrdinærBarnetrygdUtilTest {
                 )
             }
 
+        // Act
         val prosent = vilkårResultater.mapTilProsentEllerNull(personType = PersonType.BARN, fagsakType = FagsakType.NORMAL)
 
+        // Assert
         assertEquals(BigDecimal(100), prosent)
     }
 
     @Test
     fun `Skal returnere null hvis ikke alle vilkår for barn er oppfylt`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val personResultat =
             PersonResultat(
@@ -199,13 +209,16 @@ class OrdinærBarnetrygdUtilTest {
                 }
             }
 
+        // Act
         val prosent = vilkårResultater.mapTilProsentEllerNull(personType = PersonType.BARN, fagsakType = FagsakType.NORMAL)
 
+        // Assert
         assertEquals(null, prosent)
     }
 
     @Test
     fun `Skal returnere null hvis ikke alle vilkår for søker er oppfylt`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val personResultat =
             PersonResultat(
@@ -228,8 +241,10 @@ class OrdinærBarnetrygdUtilTest {
                 }
             }
 
+        // Act
         val prosent = vilkårResultater.mapTilProsentEllerNull(personType = PersonType.SØKER, fagsakType = FagsakType.NORMAL)
 
+        // Assert
         assertEquals(null, prosent)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SatsServiceTest.kt
@@ -33,11 +33,14 @@ import java.time.LocalDate
 class SatsServiceTest {
     @Test
     fun `Skal opprette korrekt tidslinje for ordinær barnetrygd for barn som ble 6 år mens TILLEGGS_ORBA var aktivt`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2017, 4, 6))
 
+        // Act
         val ordinærTidslinje = lagOrdinærTidslinje(barn)
         val ordinærePerioder = ordinærTidslinje.tilPerioderIkkeNull().toList()
 
+        // Assert
         assertEquals(12, ordinærePerioder.size)
 
         assertPeriode(TestKrPeriode(beløp = 970, fom = "2017-04", tom = "2019-02"), ordinærePerioder[0])
@@ -56,11 +59,14 @@ class SatsServiceTest {
 
     @Test
     fun `Skal opprette korrekt tidslinje for ordinær barnetrygd for barn som er født etter at TILLEGGS_ORBA er ferdig`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2025, 1, 6))
 
+        // Act
         val ordinærTidslinje = lagOrdinærTidslinje(barn)
         val ordinærePerioder = ordinærTidslinje.tilPerioderIkkeNull().toList()
 
+        // Assert
         assertEquals(3, ordinærePerioder.size)
 
         assertPeriode(TestKrPeriode(beløp = 1766, fom = "2025-01", tom = "2025-04"), ordinærePerioder[0])
@@ -70,11 +76,14 @@ class SatsServiceTest {
 
     @Test
     fun `Skal opprette korrekt tidslinje for ordinær barnetrygd for barn som blir 6 år etter at TILLEGGS_ORBA er fjernet`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 12, 6))
 
+        // Act
         val ordinærTidslinje = lagOrdinærTidslinje(barn)
         val ordinærePerioder = ordinærTidslinje.tilPerioderIkkeNull().toList()
 
+        // Assert
         assertEquals(8, ordinærePerioder.size)
 
         assertPeriode(TestKrPeriode(beløp = 1054, fom = "2019-12", tom = "2020-08"), ordinærePerioder[0])
@@ -114,6 +123,7 @@ class SatsServiceTest {
     inner class SatstypeTidslinje {
         @Test
         fun `Skal gi riktig sats for ordinær barnetrygd, 6 til 18 år`() {
+            // Arrange
             val forventet =
                 (uendelig..feb(2019)).tilTidslinje { 970 } +
                     (mar(2019)..feb(2023)).tilTidslinje { 1054 } +
@@ -124,13 +134,16 @@ class SatsServiceTest {
                     (mai(2025)..jan(2026)).tilTidslinje { 1968 } +
                     (feb(2026)..uendelig).tilTidslinje { 2012 }
 
+            // Act
             val faktisk = satstypeTidslinje(ORBA)
 
+            // Assert
             assertEquals(forventet.tilPerioder(), faktisk.tilPerioder())
         }
 
         @Test
         fun `Skal gi riktig sats for tillegg ordinær barnetrygd, 0 til 6 år`() {
+            // Arrange
             val forventet =
                 (uendelig..feb(2019)).tilTidslinje { 970 } +
                     (mar(2019)..aug(2020)).tilTidslinje { 1054 } +
@@ -140,26 +153,32 @@ class SatsServiceTest {
                     (mar(2023)..jun(2023)).tilTidslinje { 1723 } +
                     (jul(2023)..aug(2024)).tilTidslinje { 1766 }
 
+            // Act
             val faktisk = satstypeTidslinje(TILLEGG_ORBA)
 
+            // Assert
             assertEquals(forventet.tilPerioder(), faktisk.tilPerioder())
         }
 
         @Test
         fun `Skal gi riktig sats for småbarnstillegg`() {
+            // Arrange
             val forventet =
                 (uendelig..feb(2023)).tilTidslinje { 660 } +
                     (mar(2023)..jun(2023)).tilTidslinje { 678 } +
                     (jul(2023)..jan(2026)).tilTidslinje { 696 } +
                     (feb(2026)..uendelig).tilTidslinje { 712 }
 
+            // Act
             val faktisk = satstypeTidslinje(SMA)
 
+            // Assert
             assertEquals(forventet.tilPerioder(), faktisk.tilPerioder())
         }
 
         @Test
         fun `Skal gi riktig sats for utvidet barnetrygd`() {
+            // Arrange
             val forventet =
                 (uendelig..feb(2019)).tilTidslinje { 970 } +
                     (mar(2019)..feb(2023)).tilTidslinje { 1054 } +
@@ -167,8 +186,10 @@ class SatsServiceTest {
                     (jul(2023)..jan(2026)).tilTidslinje { 2516 } +
                     (feb(2026)..uendelig).tilTidslinje { 2572 }
 
+            // Act
             val faktisk = satstypeTidslinje(UTVIDET_BARNETRYGD)
 
+            // Assert
             assertEquals(forventet.tilPerioder(), faktisk.tilPerioder())
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggGeneratorTest.kt
@@ -44,6 +44,7 @@ class SmåbarnstilleggGeneratorTest {
 
     @Test
     fun `Skal kun få småbarnstillegg når alle tre krav er oppfylt i samme periode`() {
+        // Arrange
         val overgangsstønadPerioder =
             listOf(
                 InternPeriodeOvergangsstønad(
@@ -73,6 +74,7 @@ class SmåbarnstilleggGeneratorTest {
                 ),
             )
 
+        // Act
         val småbarnstilleggAndeler =
             SmåbarnstilleggGenerator(tilkjentYtelse = tilkjentYtelse)
                 .lagSmåbarnstilleggAndeler(
@@ -82,6 +84,7 @@ class SmåbarnstilleggGeneratorTest {
                     barnasAktørerOgFødselsdatoer = listOf(Pair(barn3.aktør, barn3.fødselsdato)),
                 )
 
+        // Assert
         Assertions.assertEquals(1, småbarnstilleggAndeler.size)
         Assertions.assertEquals(YearMonth.now().minusYears(2), småbarnstilleggAndeler.single().stønadFom)
         Assertions.assertEquals(barn3.fødselsdato.plusYears(3).toYearMonth(), småbarnstilleggAndeler.single().stønadTom)
@@ -90,6 +93,7 @@ class SmåbarnstilleggGeneratorTest {
 
     @Test
     fun `Skal lage småbarnstillegg-andeler med 0kr når enten utvidet eller barnet under 3 år er overstyrt til 0kr`() {
+        // Arrange
         val overgangsstønadPerioder =
             listOf(
                 InternPeriodeOvergangsstønad(
@@ -139,6 +143,7 @@ class SmåbarnstilleggGeneratorTest {
                 ),
             )
 
+        // Act
         val småbarnstilleggAndeler =
             SmåbarnstilleggGenerator(tilkjentYtelse = tilkjentYtelse)
                 .lagSmåbarnstilleggAndeler(
@@ -148,6 +153,7 @@ class SmåbarnstilleggGeneratorTest {
                     barnasAktørerOgFødselsdatoer = listOf(Pair(barn3.aktør, barn3.fødselsdato)),
                 )
 
+        // Assert
         Assertions.assertEquals(2, småbarnstilleggAndeler.size)
         Assertions.assertEquals(barn3.fødselsdato.plusMonths(1).toYearMonth(), småbarnstilleggAndeler.first().stønadFom)
         Assertions.assertEquals(YearMonth.now().minusYears(2), småbarnstilleggAndeler.first().stønadTom)
@@ -160,6 +166,7 @@ class SmåbarnstilleggGeneratorTest {
 
     @Test
     fun `Skal lage småbarnstillegg-andeler med riktig prosent når vi har to barn hvor 1 av de har nullutbetaling`() {
+        // Arrange
         val overgangsstønadPerioder =
             listOf(
                 InternPeriodeOvergangsstønad(
@@ -202,6 +209,7 @@ class SmåbarnstilleggGeneratorTest {
                 ),
             )
 
+        // Act
         val småbarnstilleggAndeler =
             SmåbarnstilleggGenerator(tilkjentYtelse = tilkjentYtelse)
                 .lagSmåbarnstilleggAndeler(
@@ -215,6 +223,7 @@ class SmåbarnstilleggGeneratorTest {
                         ),
                 )
 
+        // Assert
         Assertions.assertEquals(2, småbarnstilleggAndeler.size)
         Assertions.assertEquals(barn1.fødselsdato.plusMonths(1).toYearMonth(), småbarnstilleggAndeler.first().stønadFom)
         Assertions.assertEquals(barn2.fødselsdato.toYearMonth(), småbarnstilleggAndeler.first().stønadTom)
@@ -227,6 +236,7 @@ class SmåbarnstilleggGeneratorTest {
 
     @Test
     fun `Skal lage småbarnstillegg-andeler med 0kr for 2 barn når søker sin utvidet del er overstyrt til 0kr`() {
+        // Arrange
         val overgangsstønadPerioder =
             listOf(
                 InternPeriodeOvergangsstønad(
@@ -269,6 +279,7 @@ class SmåbarnstilleggGeneratorTest {
                 ),
             )
 
+        // Act
         val småbarnstilleggAndeler =
             SmåbarnstilleggGenerator(tilkjentYtelse = tilkjentYtelse)
                 .lagSmåbarnstilleggAndeler(
@@ -282,6 +293,7 @@ class SmåbarnstilleggGeneratorTest {
                         ),
                 )
 
+        // Assert
         Assertions.assertEquals(2, småbarnstilleggAndeler.size)
         Assertions.assertEquals(barn1.fødselsdato.plusMonths(1).toYearMonth(), småbarnstilleggAndeler.first().stønadFom)
         Assertions.assertEquals(YearMonth.now().minusYears(1), småbarnstilleggAndeler.first().stønadTom)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/SmåbarnstilleggUtilsTest.kt
@@ -36,6 +36,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal generere tidslinje for barn med rett til småbarnstillegg kun hvor barn er under 3 år`() {
+        // Arrange
         val barn = lagPerson(fødselsdato = LocalDate.now().minusYears(4), type = PersonType.BARN)
 
         val barnasAndeler =
@@ -48,12 +49,14 @@ class SmåbarnstilleggUtilsTest {
                 ),
             )
 
+        // Act
         val generertePerioder =
             lagTidslinjeForPerioderMedBarnSomGirRettTilSmåbarnstillegg(
                 barnasAndeler = barnasAndeler,
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barn.aktør, barn.fødselsdato)),
             ).tilPerioder()
 
+        // Assert
         assertEquals(1, generertePerioder.size)
         assertEquals(barn.fødselsdato.plusMonths(1).toYearMonth(), generertePerioder.single().fom?.toYearMonth())
         assertEquals(barn.fødselsdato.plusYears(3).toYearMonth(), generertePerioder.single().tom?.toYearMonth())
@@ -62,6 +65,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal generere tidslinje for barn med rett til småbarnstillegg med riktig utbetalings-info for ett barn`() {
+        // Arrange
         val barn = lagPerson(fødselsdato = LocalDate.now().minusYears(4), type = PersonType.BARN)
 
         val brytningstidspunkt = LocalDate.now().minusYears(3)
@@ -83,12 +87,14 @@ class SmåbarnstilleggUtilsTest {
                 ),
             )
 
+        // Act
         val generertePerioder =
             lagTidslinjeForPerioderMedBarnSomGirRettTilSmåbarnstillegg(
                 barnasAndeler = barnasAndeler,
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barn.aktør, barn.fødselsdato)),
             ).tilPerioder().sortedBy { it.fom }
 
+        // Assert
         assertEquals(2, generertePerioder.size)
         assertEquals(barn.fødselsdato.plusMonths(1).toYearMonth(), generertePerioder.first().fom?.toYearMonth())
         assertEquals(brytningstidspunkt.toYearMonth(), generertePerioder.first().tom?.toYearMonth())
@@ -101,6 +107,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal bare ta hensyn til ordinære andeler ved generering av tidslinje for barn med rett`() {
+        // Arrange
         val barn = lagPerson(fødselsdato = LocalDate.now().minusYears(4), type = PersonType.BARN)
 
         val brytningstidspunkt = LocalDate.now().minusYears(3)
@@ -129,12 +136,14 @@ class SmåbarnstilleggUtilsTest {
                 ),
             )
 
+        // Act
         val generertePerioder =
             lagTidslinjeForPerioderMedBarnSomGirRettTilSmåbarnstillegg(
                 barnasAndeler = barnasAndeler,
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barn.aktør, barn.fødselsdato)),
             ).tilPerioder().sortedBy { it.fom }
 
+        // Assert
         assertEquals(2, generertePerioder.size)
         assertEquals(barn.fødselsdato.plusMonths(1).toYearMonth(), generertePerioder.first().fom?.toYearMonth())
         assertEquals(brytningstidspunkt.toYearMonth(), generertePerioder.first().tom?.toYearMonth())
@@ -147,6 +156,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal generere tidslinje for barn med rett til småbarnstillegg med riktig utbetalings-info når det er flere barn`() {
+        // Arrange
         val barn1 = lagPerson(fødselsdato = LocalDate.now().minusYears(4), type = PersonType.BARN)
         val barn2 = lagPerson(fødselsdato = LocalDate.now().minusYears(6), type = PersonType.BARN)
         val barn3 = lagPerson(fødselsdato = LocalDate.now().minusYears(1), type = PersonType.BARN)
@@ -190,6 +200,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             )
 
+        // Act
         val generertePerioder =
             lagTidslinjeForPerioderMedBarnSomGirRettTilSmåbarnstillegg(
                 barnasAndeler = barnasAndeler,
@@ -201,6 +212,7 @@ class SmåbarnstilleggUtilsTest {
                     ),
             ).tilPerioder().sortedBy { it.fom }
 
+        // Assert
         assertEquals(3, generertePerioder.size)
         assertEquals(barn2.fødselsdato.plusMonths(1).toYearMonth(), generertePerioder.first().fom?.toYearMonth())
         assertEquals(brytningstidspunkt2.toYearMonth(), generertePerioder.first().tom?.toYearMonth())
@@ -217,6 +229,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal kun få småbarnstillegg når alle tre tidslinjene har oppfylt kravene`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val overgangsstønadPerioder =
             listOf(
@@ -246,6 +259,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             ).tilTidslinje()
 
+        // Act
         val kombinertTidslinje =
             kombinerAlleTidslinjerTilProsentTidslinje(
                 perioderMedFullOvergangsstønadTidslinje = overgangsstønadPerioder.tilTidslinje(),
@@ -253,6 +267,7 @@ class SmåbarnstilleggUtilsTest {
                 barnSomGirRettTilSmåbarnstilleggTidslinje = barnSomGirRettTilSmåbarnstilleggTidslinje,
             )
 
+        // Assert
         val perioderMedSmåbarnstillegg = kombinertTidslinje.tilPerioderIkkeNull()
 
         assertEquals(1, perioderMedSmåbarnstillegg.size)
@@ -263,6 +278,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal få småbarnstillegg med nullutbetaling når utvidet eller barn er overstyrt til 0kr`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val brytningstidspunkt1 = YearMonth.now().minusYears(3)
         val brytningstidspunkt2 = YearMonth.now().minusYears(2)
@@ -307,6 +323,7 @@ class SmåbarnstilleggUtilsTest {
                 ),
             ).tilTidslinje()
 
+        // Act
         val kombinertTidslinje =
             kombinerAlleTidslinjerTilProsentTidslinje(
                 perioderMedFullOvergangsstønadTidslinje = overgangsstønadPerioder.tilTidslinje(),
@@ -314,6 +331,7 @@ class SmåbarnstilleggUtilsTest {
                 barnSomGirRettTilSmåbarnstilleggTidslinje = barnsSomGirRettTilSmåbarnstilleggTidslinje,
             )
 
+        // Assert
         val perioderMedSmåbarnstillegg = kombinertTidslinje.tilPerioderIkkeNull().toList()
 
         assertEquals(3, perioderMedSmåbarnstillegg.size)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseGeneratorTest.kt
@@ -94,6 +94,7 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `Barn som fyller 6 år i det vilkårene er oppfylt får andel måneden etter`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2016, 2, 2)
         val barnSeksårsdag = barnFødselsdato.plusYears(6)
 
@@ -106,12 +107,14 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val tilkjentYtelse =
             tilkjentYtelseGenerator.genererTilkjentYtelse(
                 behandling = vilkårsvurdering.behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
 
+        // Assert
         assertEquals(1, tilkjentYtelse.andelerTilkjentYtelse.size)
 
         val andelTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.first()
@@ -126,6 +129,7 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `Barn som fyller 6 år i det vilkårene ikke lenger er oppfylt får andel den måneden også`() {
+        // Arrange
         val barnSeksårsdag = LocalDate.of(2022, 2, 2)
         val barnFødselsdato = barnSeksårsdag.minusYears(6)
 
@@ -141,12 +145,14 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val tilkjentYtelse =
             tilkjentYtelseGenerator.genererTilkjentYtelse(
                 behandling = vilkårsvurdering.behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
 
+        // Assert
         assertEquals(2, tilkjentYtelse.andelerTilkjentYtelse.size)
 
         val andelTilkjentYtelseFør6År = tilkjentYtelse.andelerTilkjentYtelse.first()
@@ -166,6 +172,7 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `Det skal utbetales for inneværende måned hvis barn dør minst 1 måned før 18 års datoen`() {
+        // Arrange
         val barnFødselsDato = LocalDate.of(2012, 2, 2)
         val barnDødsfallsDato = LocalDate.of(2030, 1, 1)
 
@@ -180,12 +187,14 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val tilkjentYtelse =
             tilkjentYtelseGenerator.genererTilkjentYtelse(
                 behandling = vilkårsvurdering.behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
 
+        // Assert
         assertEquals(2, tilkjentYtelse.andelerTilkjentYtelse.size)
 
         val andelFør6År = tilkjentYtelse.andelerTilkjentYtelse.first()
@@ -200,6 +209,7 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `Det skal ikke utbetales for inneværende måned hvis barn dør samme måned som 18 års datoen`() {
+        // Arrange
         val barnFødselsDato = LocalDate.of(2012, 2, 20)
         val barnDødsfallsDato = LocalDate.of(2030, 2, 2)
 
@@ -214,12 +224,14 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val tilkjentYtelse =
             tilkjentYtelseGenerator.genererTilkjentYtelse(
                 behandling = vilkårsvurdering.behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
 
+        // Assert
         assertEquals(2, tilkjentYtelse.andelerTilkjentYtelse.size)
 
         val andelFør6År = tilkjentYtelse.andelerTilkjentYtelse.first()
@@ -234,6 +246,7 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `1 barn får normal utbetaling med satsendring fra september 2020, september 2021 og januar 2022`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 2, 2)
         val barnSeksårsdag = barnFødselsdato.plusYears(6)
 
@@ -246,6 +259,7 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -255,6 +269,7 @@ class TilkjentYtelseGeneratorTest {
                 .toList()
                 .sortedBy { it.stønadFom }
 
+        // Assert
         assertEquals(4, andeler.size)
 
         val andelTilkjentYtelseFør6ÅrSeptember2020 = andeler[0]
@@ -297,6 +312,7 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `Halvt beløp av grunnsats utbetales ved delt bosted`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 2, 2)
 
         val (vilkårsvurdering, personopplysningGrunnlag) =
@@ -309,6 +325,7 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -319,6 +336,8 @@ class TilkjentYtelseGeneratorTest {
                 .sortedBy { it.stønadFom }
 
         val andelTilkjentYtelseFør6ÅrSeptember2020 = andeler[0]
+
+        // Assert
         assertEquals(677, andelTilkjentYtelseFør6ÅrSeptember2020.kalkulertUtbetalingsbeløp)
 
         val andelTilkjentYtelseFør6ÅrSeptember2021 = andeler[1]
@@ -333,6 +352,7 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `Skal opprette riktig tilkjent ytelse-perioder for perioder på barn som ikke er back-to-back over månedskiftet`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2016, 2, 5)
 
         val (vilkårsvurdering, personopplysningGrunnlag) =
@@ -354,6 +374,7 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns oppdatertVilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -363,12 +384,14 @@ class TilkjentYtelseGeneratorTest {
                 .toList()
                 .sortedBy { it.stønadFom }
 
+        // Assert
         assertEquals(YearMonth.of(2019, 8), andeler[1].stønadTom)
         assertEquals(YearMonth.of(2019, 10), andeler[2].stønadFom)
     }
 
     @Test
     fun `Skal opprette riktig tilkjent ytelse-perioder for perioder på søker som ikke er back-to-back over månedskiftet`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2016, 2, 5)
 
         val (vilkårsvurdering, personopplysningGrunnlag) =
@@ -390,6 +413,7 @@ class TilkjentYtelseGeneratorTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns oppdatertVilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -399,6 +423,7 @@ class TilkjentYtelseGeneratorTest {
                 .toList()
                 .sortedBy { it.stønadFom }
 
+        // Assert
         assertEquals(YearMonth.of(2019, 8), andeler[1].stønadTom)
         assertEquals(YearMonth.of(2019, 10), andeler[2].stønadFom)
     }
@@ -406,6 +431,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Far søker om delt bosted - Mor har tidligere mottatt fult utvidet og ordinær barnetrygd
     @Test
     fun `Skal støtte endret utbetaling som delvis overlapper delt bosted på søker og barn og småbarnstillegg på søker`() {
+        // Arrange
         val barnFødtAugust2019 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 8, 15))
         val månedFørBarnBlir18 =
             barnFødtAugust2019.fødselsdato
@@ -419,6 +445,7 @@ class TilkjentYtelseGeneratorTest {
                 .toYearMonth()
         val barnFyller3ÅrDato = barnFødtAugust2019.fødselsdato.plusYears(3).toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 endretAndeler =
@@ -453,6 +480,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2022) }
+
+        // Assert
         assertEquals(6, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -488,6 +517,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Far søker om delt bosted - Mor har tidligere mottatt fult, men har ikke mottatt utvidet
     @Test
     fun `Skal støtte endret utbetaling som kun gjelder barn på delt bosted utbetaling`() {
+        // Arrange
         val barnFødtAugust2019 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 8, 15))
         val månedFørBarnBlir18 =
             barnFødtAugust2019.fødselsdato
@@ -501,6 +531,7 @@ class TilkjentYtelseGeneratorTest {
                 .toYearMonth()
         val barnFyller3ÅrDato = barnFødtAugust2019.fødselsdato.plusYears(3).toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 endretAndeler =
@@ -528,6 +559,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2022) }
+
+        // Assert
         assertEquals(4, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -558,6 +591,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Mor har tidligere mottatt barnetrygden - Far har nå søkt om delt bosted og mors barnetrygd skal også deles
     @Test
     fun `Skal gi riktig resultat når barnetrygden går over til å være delt, kun småbarnstillegg og utvidet blir delt i første periode`() {
+        // Arrange
         val barnFødtAugust2019 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 8, 15))
         val månedFørBarnBlir18 =
             barnFødtAugust2019.fødselsdato
@@ -571,6 +605,7 @@ class TilkjentYtelseGeneratorTest {
                 .toYearMonth()
         val barnFyller3ÅrDato = barnFødtAugust2019.fødselsdato.plusYears(3).toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 endretAndeler =
@@ -612,6 +647,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2022) }
+
+        // Assert
         assertEquals(5, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -645,6 +682,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Mor har tidligere mottatt barnetrygden - Far har nå søkt om delt bosted og mors barnetrygd skal også deles 2
     @Test
     fun `Delt, utvidet og ordinær barnetrygd deles fra juni, men skal utbetales fult fra juni til og med juli - deles som vanlig fra August`() {
+        // Arrange
         val barnFødtAugust2019 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 8, 15))
         val månedFørBarnBlir18 =
             barnFødtAugust2019.fødselsdato
@@ -658,6 +696,7 @@ class TilkjentYtelseGeneratorTest {
                 .toYearMonth()
         val barnFyller3ÅrDato = barnFødtAugust2019.fødselsdato.plusYears(3).toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 endretAndeler =
@@ -706,6 +745,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2022) }
+
+        // Assert
         assertEquals(7, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -742,6 +783,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Far søker om utvidet barnetrygd - Har full overgangsstønad, men søker sent og får ikke etterbetalt mer enn 3år
     @Test
     fun `Småbarnstillleg, utvidet og ordinær barnetrygd fra april, men skal ikke utbetales før august på grunn av etterbetaling 3 år`() {
+        // Arrange
         val barnFødtAugust2016 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2016, 8, 15))
         val månedFørBarnBlir18 =
             barnFødtAugust2016.fødselsdato
@@ -749,6 +791,7 @@ class TilkjentYtelseGeneratorTest {
                 .minusMonths(1)
                 .toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 endretAndeler =
@@ -783,6 +826,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2019) }
+
+        // Assert
         assertEquals(6, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -817,6 +862,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Far har mottatt delt utvidet barnetrygd for barn 12år - Søker nå om barnetrygd for barn som flyttet til han for over 3 år siden
     @Test
     fun `Det er småbarnstillegg på søker og ordinær barnetrygd på barn 1 fra april, men det skal ikke utbetales før august på grunn av etterbetaling 3 år - Søker og barn 2 har utbetalinger fra tidligere behandlinger som ikke skal overstyres`() {
+        // Arrange
         val barnFødtAugust2016 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2016, 8, 15))
         val månedFørBarnFødtAugust2016Blir18 =
             barnFødtAugust2016.fødselsdato
@@ -826,6 +872,7 @@ class TilkjentYtelseGeneratorTest {
         val barnFødtDesember2006 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2006, 12, 1))
         val månedFørBarnFødtDesember2006Blir18 = barnFødtDesember2006.fødselsdato.til18ÅrsVilkårsdato().toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 endretAndeler =
@@ -869,6 +916,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2019) }
+
+        // Assert
         assertEquals(8, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -913,6 +962,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Far søker om utvidet barnetrygd for barn under 3 år - han har full overgangsstlnad for bare deler av perioden
     @Test
     fun `Skal gi riktig resultat når det overgangsstønad i deler av utbetalingen`() {
+        // Arrange
         val barnFødtAugust2019 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 8, 15))
         val månedFørBarnBlir6 =
             barnFødtAugust2019.fødselsdato
@@ -920,6 +970,7 @@ class TilkjentYtelseGeneratorTest {
                 .minusMonths(1)
                 .toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 atypiskeVilkårBarna =
@@ -946,6 +997,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2022) }
+
+        // Assert
         assertEquals(3, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -970,6 +1023,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Far søker om utvidet barnetrygd for barn under 3år, men oppfyller vilkårene kun tilbake i tid
     @Test
     fun `Skal gi riktig resultat når det overgangsstønad i deler av utbetalingen - Overgangsstønaden stopper før barn fyller 3 år fordi søker ikke lenger har rett til utvidet barnetrygd`() {
+        // Arrange
         val barnFødtAugust2019 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 8, 15))
         val månedFørBarnBlir6 =
             barnFødtAugust2019.fødselsdato
@@ -977,6 +1031,7 @@ class TilkjentYtelseGeneratorTest {
                 .minusMonths(1)
                 .toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 atypiskeVilkårBarna =
@@ -1003,6 +1058,8 @@ class TilkjentYtelseGeneratorTest {
 
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2022) }
+
+        // Assert
         assertEquals(3, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -1028,6 +1085,7 @@ class TilkjentYtelseGeneratorTest {
     // src/test/resources/scenario/Far søker om utvidet barnetrygd for barn under 3 år - Har full overgangsstønad som opphører når barnet fyller 3 år
     @Test
     fun `Skal gi riktig resultat når søker har rett på ordinær og utvidet barnetrygd fra mars og rett på overgangsstønad fra April`() {
+        // Arrange
         val barnFødtAugust2019 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2019, 8, 15))
         val månedFørBarnBlir18 =
             barnFødtAugust2019.fødselsdato
@@ -1040,6 +1098,7 @@ class TilkjentYtelseGeneratorTest {
                 .minusMonths(1)
                 .toYearMonth()
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 atypiskeVilkårBarna =
@@ -1058,6 +1117,7 @@ class TilkjentYtelseGeneratorTest {
         val andelerTilkjentYtelseITidsrom =
             tilkjentYtelse.andelerTilkjentYtelse.filter { it.stønadFom.isSameOrBefore(desember2022) }
 
+        // Assert
         assertEquals(3, andelerTilkjentYtelseITidsrom.size)
 
         val (søkersAndeler, barnasAndeler) = andelerTilkjentYtelseITidsrom.partition { it.erSøkersAndel() }
@@ -1083,9 +1143,11 @@ class TilkjentYtelseGeneratorTest {
 
     @Test
     fun `genrering av utvidet skal avhenge av endret utbetaling med årsak ENDRE_MOTTAKER`() {
+        // Arrange
         val barnMedFullUtbetaling = lagPerson(type = PersonType.BARN, fødselsdato = januar2019.atDay(1))
         val barnMedHalvUtbetaling = lagPerson(type = PersonType.BARN, fødselsdato = januar2019.atDay(1))
 
+        // Act
         val tilkjentYtelse =
             settOppScenarioOgBeregnTilkjentYtelse(
                 endretAndeler =
@@ -1141,6 +1203,7 @@ class TilkjentYtelseGeneratorTest {
                 overgangsstønadPerioder = emptyList(),
             )
 
+        // Assert
         assertEquals(9, tilkjentYtelse.andelerTilkjentYtelse.size)
 
         val (søkersAndeler, barnasAndeler) = tilkjentYtelse.andelerTilkjentYtelse.partition { it.erSøkersAndel() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsEndretUtbetalingAndelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/TilkjentYtelseUtilsEndretUtbetalingAndelTest.kt
@@ -37,6 +37,8 @@ internal class TilkjentYtelseUtilsEndretUtbetalingAndelTest {
 
     @Test
     fun `teste nye andeler tilkjent ytelse for to barn med endrete utbetalingsandeler`() {
+        // Arrange
+
         /**
          * Tidslinjer barn 1:
          * -------------[############]-----------[#########]---------- AndelTilkjentYtelse
@@ -105,6 +107,7 @@ internal class TilkjentYtelseUtilsEndretUtbetalingAndelTest {
                 )
             }
 
+        // Act
         val andelerTilkjentYtelserEtterEUA =
             AndelTilkjentYtelseMedEndretUtbetalingGenerator.lagAndelerMedEndretUtbetalingAndeler(
                 andelTilkjentYtelserUtenEndringer = (andelTilkjentytelseForBarn1 + andelTilkjentytelseForBarn2),
@@ -114,6 +117,7 @@ internal class TilkjentYtelseUtilsEndretUtbetalingAndelTest {
 
         val andelerTilkjentYtelserEtterEUAList = andelerTilkjentYtelserEtterEUA.map { it.andel }.toList()
 
+        // Assert
         assertEquals(8, andelerTilkjentYtelserEtterEUAList.size)
 
         verifiserAndelTilkjentYtelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdTest.kt
@@ -64,6 +64,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andeler får høyeste beløp når det utbetales til flere barn med ulike beløp`() {
+        // Arrange
         val søker =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 6, 15))
         val barnA =
@@ -125,6 +126,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -134,6 +136,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedWith(compareBy({ it.stønadFom }, { it.type }, { it.kalkulertUtbetalingsbeløp }))
 
+        // Assert
         assertEquals(4, andeler.size)
 
         val andelBarnA = andeler[0]
@@ -164,6 +167,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andeler får høyeste ordinærsats når søker har tillegg for barn under 6 år`() {
+        // Arrange
         val søker =
             OppfyltPeriode(fom = fødselsdatoUnder6År, tom = LocalDate.of(2021, 6, 15))
         val oppfyltBarn =
@@ -219,6 +223,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -228,6 +233,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedWith(compareBy({ it.stønadFom }, { it.type }, { it.kalkulertUtbetalingsbeløp }))
 
+        // Assert
         assertEquals(2, andeler.size)
 
         val andelBarn = andeler[0]
@@ -246,6 +252,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andeler får største prosent funnet blant andelene til barna som bor med søker`() {
+        // Arrange
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
         val søkerAktør = randomAktør()
@@ -287,6 +294,7 @@ internal class UtvidetBarnetrygdTest {
                 ),
             )
 
+        // Act
         val utvidetAndelerNårBarnMed100ProsentBorMedSøker =
             UtvidetBarnetrygdGenerator(
                 behandlingId = behandling.id,
@@ -313,12 +321,14 @@ internal class UtvidetBarnetrygdTest {
                         .mapValues { it.value.mapVerdi { andel -> andel?.prosent == BigDecimal(50) } },
             )
 
+        // Assert
         assertEquals(BigDecimal(100), utvidetAndelerNårBarnMed100ProsentBorMedSøker.minOf { it.prosent })
         assertEquals(BigDecimal(50), utvidetAndelerNårKunBarnMed50ProsentBorMedSøker.maxOf { it.prosent })
     }
 
     @Test
     fun `Utvidet andeler lages kun når vilkåret er innfridd`() {
+        // Arrange
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 6, 15))
         val søkerUtvidet =
@@ -377,6 +387,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -386,6 +397,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedBy { it.type }
 
+        // Assert
         assertEquals(2, andeler.size)
 
         val andelBarn = andeler[0]
@@ -402,6 +414,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andeler lages kun når det finnes andel for barn`() {
+        // Arrange
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 6, 15))
         val søkerUtvidet =
@@ -460,6 +473,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -469,6 +483,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedBy { it.type }
 
+        // Assert
         assertEquals(2, andeler.size)
 
         val andelBarn = andeler[0]
@@ -485,6 +500,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andeler slutter siste dag i  måneden som vilkår ikke er innfridd lenger`() {
+        // Arrange
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 6, 15))
         val søkerUtvidet =
@@ -543,6 +559,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -552,6 +569,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedBy { it.type }
 
+        // Assert
         assertEquals(2, andeler.size)
 
         val andelBarn = andeler[0]
@@ -566,6 +584,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andel blir IKKE splittet opp på endring i utvidet vilkåret ved back-to-back, men utbetalingsperiodene blir det`() {
+        // Arrange
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =
@@ -636,6 +655,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -646,6 +666,7 @@ internal class UtvidetBarnetrygdTest {
                 .sortedBy { it.type }
 
         // Én  andel for barnet og én andel for utvidet barnetrygd. Utvidet-andelen splittes IKKE
+        // Assert
         assertEquals(2, andeler.size)
 
         val andelBarn = andeler[0]
@@ -662,6 +683,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andel blir ikke splittet opp på endring i barnas vilkår som ikke er delt bosted`() {
+        // Arrange
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =
@@ -752,6 +774,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -761,6 +784,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedBy { it.type }
 
+        // Assert
         assertEquals(2, andeler.size)
 
         val andelBarn = andeler[0]
@@ -777,6 +801,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andel blir splittet opp på endring i barnas vilkår som er delt bosted`() {
+        // Arrange
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =
@@ -866,6 +891,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -875,6 +901,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedBy { it.type }
 
+        // Assert
         assertEquals(4, andeler.size)
 
         val andelBarn1 = andeler[0]
@@ -905,6 +932,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Utvidet andel starter og opphører riktig når det er to perioder som ikke er back2back`() {
+        // Arrange
         val søkerOrdinær =
             OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 10, 15))
         val barnOppfylt =
@@ -979,6 +1007,7 @@ internal class UtvidetBarnetrygdTest {
 
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -988,6 +1017,7 @@ internal class UtvidetBarnetrygdTest {
                 .toList()
                 .sortedBy { it.type }
 
+        // Assert
         assertEquals(3, andeler.size)
 
         val andelBarn = andeler[0]
@@ -1006,6 +1036,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Skal kaste feil hvis utvidet-andeler ikke overlapper med noen av barnas andeler`() {
+        // Arrange
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
         val søkerAktør = randomAktør()
@@ -1047,6 +1078,7 @@ internal class UtvidetBarnetrygdTest {
                 ),
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             UtvidetBarnetrygdGenerator(
                 behandlingId = behandling.id,
@@ -1062,6 +1094,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Skal dele opp utvidet-segment ved endring i sats`() {
+        // Arrange
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
         val søkerAktør = randomAktør()
@@ -1095,6 +1128,7 @@ internal class UtvidetBarnetrygdTest {
                 ),
             )
 
+        // Act
         val utvidetAndeler =
             UtvidetBarnetrygdGenerator(
                 behandlingId = behandling.id,
@@ -1108,6 +1142,7 @@ internal class UtvidetBarnetrygdTest {
                         .mapValues { it.value.mapVerdi { true } },
             ).sortedBy { it.stønadFom }
 
+        // Assert
         assertEquals(2, utvidetAndeler.size)
 
         val andelFørSatsendring = utvidetAndeler[0]
@@ -1128,6 +1163,7 @@ internal class UtvidetBarnetrygdTest {
 
     @Test
     fun `Skal endre utbetaling for søker og barn på endret utbetaling andel`() {
+        // Arrange
         val søker = OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 6, 15))
         val barn = OppfyltPeriode(fom = LocalDate.of(2019, 4, 1), tom = LocalDate.of(2020, 6, 15), rolle = PersonType.BARN)
 
@@ -1189,6 +1225,7 @@ internal class UtvidetBarnetrygdTest {
                 ),
             )
 
+        // Act
         val andeler =
             tilkjentYtelseGenerator
                 .genererTilkjentYtelse(
@@ -1197,6 +1234,7 @@ internal class UtvidetBarnetrygdTest {
                     endretUtbetalingAndeler = endretUtbetalingAndeler,
                 ).andelerTilkjentYtelse
 
+        // Assert
         assertThat(andeler)
             .anySatisfy {
                 assertThat(it.aktør).isEqualTo(søker.aktør)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/UtvidetBarnetrygdUtilTest.kt
@@ -23,6 +23,7 @@ import java.time.YearMonth
 class UtvidetBarnetrygdUtilTest {
     @Test
     fun `Valider utvidet vilkår - skal kaste feil hvis fom og tom er i samme kalendermåned uten etterfølgende periode`() {
+        // Arrange
         val vilkårResultat =
             lagVilkårResultat(
                 vilkårType = Vilkår.UTVIDET_BARNETRYGD,
@@ -31,6 +32,7 @@ class UtvidetBarnetrygdUtilTest {
                 resultat = Resultat.OPPFYLT,
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             validerUtvidetVilkårsresultat(
                 vilkårResultat = vilkårResultat,
@@ -41,6 +43,7 @@ class UtvidetBarnetrygdUtilTest {
 
     @Test
     fun `Valider utvidet vilkår - skal ikke kaste feil hvis fom og tom er i samme kalendermåned og har etterfølgende periode`() {
+        // Arrange
         val vilkårResultat =
             lagVilkårResultat(
                 vilkårType = Vilkår.UTVIDET_BARNETRYGD,
@@ -57,6 +60,7 @@ class UtvidetBarnetrygdUtilTest {
                 resultat = Resultat.OPPFYLT,
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             validerUtvidetVilkårsresultat(
                 vilkårResultat = vilkårResultat,
@@ -71,8 +75,10 @@ class UtvidetBarnetrygdUtilTest {
 
     @Test
     fun `Beregn utvidet - skal ikke gi rett til utvidet for perioder der barnet ikke bor med søker`() {
+        // Arrange
         val testBeregnUtvidet = TestBeregnTilkjentYtelseUtvidet()
 
+        // Act & Assert
         val feilmeldinger =
             assertThrows<FunksjonellFeil> {
                 testBeregnUtvidet.med(UtdypendeVilkårsvurdering.BARN_BOR_I_EØS_MED_ANNEN_FORELDER)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/VilkårTilTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/VilkårTilTilkjentYtelseTest.kt
@@ -77,6 +77,7 @@ class VilkårTilTilkjentYtelseTest {
         barn1Andel3Type: String?,
         erDeltBosted: Boolean?,
     ) {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = LocalDate.of(2021, 9, 1))
 
@@ -102,12 +103,14 @@ class VilkårTilTilkjentYtelseTest {
         every { overgangsstønadServiceMock.hentPerioderMedFullOvergangsstønad(any<Behandling>()) } answers { emptyList() }
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val faktiskTilkjentYtelse =
             tilkjentYtelseGenerator.genererTilkjentYtelse(
                 behandling = vilkårsvurdering.behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
 
+        // Assert
         Assertions.assertEquals(
             forventetTilkjentYtelse.andelerTilkjentYtelse,
             faktiskTilkjentYtelse.andelerTilkjentYtelse,
@@ -134,6 +137,7 @@ class VilkårTilTilkjentYtelseTest {
         barn1Andel1Periode: String?,
         barn1Andel1Type: String?,
     ) {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = LocalDate.of(2021, 9, 1))
 
@@ -182,12 +186,14 @@ class VilkårTilTilkjentYtelseTest {
         }
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val faktiskTilkjentYtelse =
             tilkjentYtelseGenerator.genererTilkjentYtelse(
                 behandling = vilkårsvurdering.behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
 
+        // Assert
         Assertions.assertEquals(
             forventetTilkjentYtelse.andelerTilkjentYtelse,
             faktiskTilkjentYtelse.andelerTilkjentYtelse,
@@ -225,6 +231,7 @@ class VilkårTilTilkjentYtelseTest {
         barn2Andel2Periode: String?,
         barn2Andel2Type: String?,
     ) {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = LocalDate.of(2020, 2, 1))
         val barn2 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = LocalDate.of(2022, 4, 1))
@@ -253,12 +260,14 @@ class VilkårTilTilkjentYtelseTest {
         every { overgangsstønadServiceMock.hentPerioderMedFullOvergangsstønad(any<Behandling>()) } answers { emptyList() }
         every { vilkårsvurderingServiceMock.hentAktivForBehandlingThrows(any()) } returns vilkårsvurdering
 
+        // Act
         val faktiskTilkjentYtelse =
             tilkjentYtelseGenerator.genererTilkjentYtelse(
                 behandling = vilkårsvurdering.behandling,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )
 
+        // Assert
         Assertions.assertEquals(
             forventetTilkjentYtelse.andelerTilkjentYtelse,
             faktiskTilkjentYtelse.andelerTilkjentYtelse,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/YtelseTypeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/domene/YtelseTypeTest.kt
@@ -48,47 +48,67 @@ class YtelseTypeTest {
     inner class TilSatsTypeTest {
         @Test
         fun `tilSatsType for ORDINÆR_BARNETRYGD for en som er under 6 år i august 2024 skal returnere TILLEGGS_ORBA og ORBA`() {
+            // Arrange
             val person = lagPerson(fødselsdato = LocalDate.of(2024, 8, 1).minusYears(6).plusMonths(1))
             val ytelseDatoFom = YearMonth.of(2024, 8)
 
+            // Act
             val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth())
+
+            // Assert
             assertThat(result).isEqualTo(setOf(SatsType.TILLEGG_ORBA, SatsType.ORBA))
         }
 
         @Test
         fun `tilSatsType for ORDINÆR_BARNETRYGD for en som er under 6 år i september 2024 skal returnere ORBA`() {
+            // Arrange
             val person = lagPerson(fødselsdato = LocalDate.of(2024, 9, 1).minusYears(6).plusMonths(1))
             val ytelseDatoFom = YearMonth.of(2024, 9)
 
+            // Act
             val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
+
+            // Assert
             assertThat(result).isEqualTo(SatsType.ORBA)
         }
 
         @Test
         fun `tilSatsType for ORDINÆR_BARNETRYGD etter 6 år`() {
+            // Arrange
             val person = mockk<Person>()
             val ytelseDatoFom = YearMonth.of(2026, 1)
             every { person.hentSeksårsdag() } returns LocalDate.of(2025, 1, 1)
 
+            // Act
             val result = YtelseType.ORDINÆR_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
+
+            // Assert
             assertThat(result).isEqualTo(SatsType.ORBA)
         }
 
         @Test
         fun `tilSatsType for UTVIDET_BARNETRYGD`() {
+            // Arrange
             val person = mockk<Person>()
             val ytelseDatoFom = YearMonth.of(2020, 1)
 
+            // Act
             val result = YtelseType.UTVIDET_BARNETRYGD.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
+
+            // Assert
             assertThat(result).isEqualTo(SatsType.UTVIDET_BARNETRYGD)
         }
 
         @Test
         fun `tilSatsType for SMÅBARNSTILLEGG`() {
+            // Arrange
             val person = mockk<Person>()
             val ytelseDatoFom = YearMonth.of(2020, 1)
 
+            // Act
             val result = YtelseType.SMÅBARNSTILLEGG.tilSatsType(person, ytelseDatoFom, TIDENES_ENDE.toYearMonth()).single()
+
+            // Assert
             assertThat(result).isEqualTo(SatsType.SMA)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevServiceTest.kt
@@ -80,23 +80,28 @@ class BrevServiceTest {
 
     @Test
     fun `Saksbehandler blir hentet fra sikkerhetscontext og beslutter viser placeholder tekst under behandling`() {
+        // Arrange
         val behandling = lagBehandling()
 
+        // Act
         val (saksbehandler, beslutter) =
             brevService.hentSaksbehandlerOgBeslutter(
                 behandling = behandling,
                 totrinnskontroll = null,
             )
 
+        // Assert
         Assertions.assertEquals("saksbehandlerNavn", saksbehandler)
         Assertions.assertEquals("Beslutter", beslutter)
     }
 
     @Test
     fun `Saksbehandler blir hentet og beslutter er hentet fra sikkerhetscontext under beslutning`() {
+        // Arrange
         val behandling = lagBehandling()
         behandling.leggTilBehandlingStegTilstand(StegType.BESLUTTE_VEDTAK)
 
+        // Act
         val (saksbehandler, beslutter) =
             brevService.hentSaksbehandlerOgBeslutter(
                 behandling = behandling,
@@ -108,15 +113,18 @@ class BrevServiceTest {
                     ),
             )
 
+        // Assert
         Assertions.assertEquals("Mock Saksbehandler", saksbehandler)
         Assertions.assertEquals("saksbehandlerNavn", beslutter)
     }
 
     @Test
     fun `Saksbehandler blir hentet og beslutter viser placeholder tekst under beslutning`() {
+        // Arrange
         val behandling = lagBehandling()
         behandling.leggTilBehandlingStegTilstand(StegType.BESLUTTE_VEDTAK)
 
+        // Act
         val (saksbehandler, beslutter) =
             brevService.hentSaksbehandlerOgBeslutter(
                 behandling = behandling,
@@ -128,15 +136,18 @@ class BrevServiceTest {
                     ),
             )
 
+        // Assert
         Assertions.assertEquals("System", saksbehandler)
         Assertions.assertEquals("saksbehandlerNavn", beslutter)
     }
 
     @Test
     fun `Saksbehandler og beslutter blir hentet etter at totrinnskontroll er besluttet`() {
+        // Arrange
         val behandling = lagBehandling()
         behandling.leggTilBehandlingStegTilstand(StegType.BESLUTTE_VEDTAK)
 
+        // Act
         val (saksbehandler, beslutter) =
             brevService.hentSaksbehandlerOgBeslutter(
                 behandling = behandling,
@@ -150,23 +161,28 @@ class BrevServiceTest {
                     ),
             )
 
+        // Assert
         Assertions.assertEquals("Mock Saksbehandler", saksbehandler)
         Assertions.assertEquals("Mock Beslutter", beslutter)
     }
 
     @Test
     fun `sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling skal returnere false dersom det ikke er noe andeler i behandlingen`() {
+        // Arrange
         val behandling = lagBehandling()
 
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns emptyList()
 
+        // Act
         val erLøpendeDifferanseUtbetalingPåBehandling = brevService.sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling(behandling)
 
+        // Assert
         assertThat(erLøpendeDifferanseUtbetalingPåBehandling).isFalse()
     }
 
     @Test
     fun `sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling skal returnere false dersom det ikke er noe løpende andeler i behandlingen`() {
+        // Arrange
         val behandling = lagBehandling()
         val andeler =
             listOf(
@@ -178,13 +194,16 @@ class BrevServiceTest {
 
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns andeler
 
+        // Act
         val erLøpendeDifferanseUtbetalingPåBehandling = brevService.sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling(behandling)
 
+        // Assert
         assertThat(erLøpendeDifferanseUtbetalingPåBehandling).isFalse()
     }
 
     @Test
     fun `sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling skal returnere false dersom det løpende andeler i behandlingen men ikke differanseberegnet`() {
+        // Arrange
         val behandling = lagBehandling()
         val andeler =
             listOf(
@@ -196,13 +215,16 @@ class BrevServiceTest {
 
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns andeler
 
+        // Act
         val erLøpendeDifferanseUtbetalingPåBehandling = brevService.sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling(behandling)
 
+        // Assert
         assertThat(erLøpendeDifferanseUtbetalingPåBehandling).isFalse()
     }
 
     @Test
     fun `sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling skal returnere true dersom det løpende andeler i behandlingen som er differanseberegnet`() {
+        // Arrange
         val behandling = lagBehandling()
         val andeler =
             listOf(
@@ -215,8 +237,10 @@ class BrevServiceTest {
 
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns andeler
 
+        // Act
         val erLøpendeDifferanseUtbetalingPåBehandling = brevService.sjekkOmDetErLøpendeDifferanseUtbetalingPåBehandling(behandling)
 
+        // Assert
         assertThat(erLøpendeDifferanseUtbetalingPåBehandling).isTrue()
     }
 
@@ -225,28 +249,35 @@ class BrevServiceTest {
     fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for alle behandlingsårsaker utenom ÅRLIG_KONTROLL`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2020, 1, 1)
 
         val behandling = lagBehandling(årsak = behandlingÅrsak)
 
+        // Act
         val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
 
+        // Assert
         assertThat(starttidspunkt).isEqualTo(LocalDate.of(2020, 1, 1))
     }
 
     @Test
     fun `finnStarttidspunktForUtbetalingstabell returnerer endringstidspunkt for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er tidligere enn 1 januar i fjor`() {
+        // Arrange
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2020, 1, 1)
 
         val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
 
+        // Act
         val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
 
+        // Assert
         assertThat(starttidspunkt).isEqualTo(LocalDate.of(2020, 1, 1))
     }
 
     @Test
     fun `finnStarttidspunktForUtbetalingstabell returnerer tidligst 1 januar året før for behandlingsårsak ÅRLIG_KONTROLL, dersom endringstidspunkt er TIDENES_ENDE`() {
+        // Arrange
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
@@ -259,13 +290,16 @@ class BrevServiceTest {
 
         val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
 
+        // Act
         val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
 
+        // Assert
         assertThat(starttidspunkt).isEqualTo(LocalDate.now(clockProvider.get()).minusYears(1).withDayOfYear(1))
     }
 
     @Test
     fun `finnStarttidspunktForUtbetalingstabell returnerer 1 januar året før for behandlingsårsak ÅRLIG_KONTROLL, selv om endringstidspunkt er senere`() {
+        // Arrange
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns LocalDate.of(2024, 1, 1)
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
@@ -278,13 +312,16 @@ class BrevServiceTest {
 
         val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
 
+        // Act
         val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
 
+        // Assert
         assertThat(starttidspunkt).isEqualTo(LocalDate.now(clockProvider.get()).minusYears(1).withDayOfYear(1))
     }
 
     @Test
     fun `finnStarttidspunktForUtbetalingstabell returnerer første utbetalingstidspunkt ved ÅRLIG_KONTROLL dersom endringstidspunkt er TIDENES_ENDE og første utbetaling er etter 1 januar i fjor`() {
+        // Arrange
         every { vedtaksperiodeService.finnEndringstidspunktForBehandling(any()) } returns TIDENES_ENDE
         every { endretUtbetalingAndelRepository.findByBehandlingId(any()) } returns emptyList()
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } returns
@@ -297,8 +334,10 @@ class BrevServiceTest {
 
         val behandling = lagBehandling(årsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
 
+        // Act
         val starttidspunkt = brevService.finnStarttidspunktForUtbetalingstabell(behandling)
 
+        // Assert
         assertThat(starttidspunkt).isEqualTo(LocalDate.of(2024, 5, 1))
     }
 
@@ -306,6 +345,7 @@ class BrevServiceTest {
     inner class HentBrevForTilbakekrevingsvedtakMotregningTest {
         @Test
         fun `Skal returnere brev med riktig genererte flettefelter`() {
+            // Arrange
             val behandling = lagBehandling()
             val arbeidsfordelingPåBehandling = lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
             val søker = lagPerson(type = PersonType.SØKER)
@@ -343,8 +383,10 @@ class BrevServiceTest {
             every { mockArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns arbeidsfordelingPåBehandling
             every { mockAvregningService.hentPerioderMedAvregning(behandlingId = behandling.id) } returns avregningperioder
 
+            // Act
             val brev = brevService.hentBrevForTilbakekrevingsvedtakMotregning(tilbakekrevingsvedtakMotregning)
 
+            // Assert
             assertThat(brev.data.flettefelter.aarsakTilFeilutbetaling).isEqualTo(listOf("Årsak til feilutbetaling"))
             assertThat(brev.data.flettefelter.vurderingAvSkyld).isEqualTo(listOf("Vurdering av skyld"))
             assertThat(brev.data.flettefelter.sumAvFeilutbetaling).isEqualTo(listOf("600"))
@@ -353,6 +395,7 @@ class BrevServiceTest {
 
         @Test
         fun `Skal returnere brev med riktig genererte flettefelter når periodene bare er på 1 måned`() {
+            // Arrange
             val behandling = lagBehandling()
             val arbeidsfordelingPåBehandling = lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
             val søker = lagPerson(type = PersonType.SØKER)
@@ -390,8 +433,10 @@ class BrevServiceTest {
             every { mockArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns arbeidsfordelingPåBehandling
             every { mockAvregningService.hentPerioderMedAvregning(behandlingId = behandling.id) } returns avregningperioder
 
+            // Act
             val brev = brevService.hentBrevForTilbakekrevingsvedtakMotregning(tilbakekrevingsvedtakMotregning)
 
+            // Assert
             assertThat(brev.data.flettefelter.aarsakTilFeilutbetaling).isEqualTo(listOf("Årsak til feilutbetaling"))
             assertThat(brev.data.flettefelter.vurderingAvSkyld).isEqualTo(listOf("Vurdering av skyld"))
             assertThat(brev.data.flettefelter.sumAvFeilutbetaling).isEqualTo(listOf("600"))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/BrevmalServiceTest.kt
@@ -32,16 +32,20 @@ internal class BrevmalServiceTest {
 
     @Test
     fun `hentBrevmal skal returnere VEDTAK_OPPHØR_DØDSFALL dersom behandlingårsak er DØDSFALL_BRUKER`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.DØDSFALL_BRUKER)
 
+        // Act & Assert
         assertThat(brevmalService.hentBrevmal(behandling), Is(Brevmal.VEDTAK_OPPHØR_DØDSFALL))
     }
 
     @Test
     fun `hentVedtaksbrevmal skal kaste feil dersom behandling har status IKKE_VURDERT`() {
+        // Arrange
         val behandling =
             lagBehandling(årsak = BehandlingÅrsak.KORREKSJON_VEDTAKSBREV, resultat = Behandlingsresultat.IKKE_VURDERT)
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             brevmalService.hentVedtaksbrevmal(behandling)
         }
@@ -53,6 +57,7 @@ internal class BrevmalServiceTest {
         names = ["INNVILGET", "INNVILGET_OG_ENDRET", "INNVILGET_OG_OPPHØRT", "INNVILGET_ENDRET_OG_OPPHØRT", "DELVIS_INNVILGET", "DELVIS_INNVILGET_OG_ENDRET", "DELVIS_INNVILGET_OG_OPPHØRT", "DELVIS_INNVILGET_ENDRET_OG_OPPHØRT", "AVSLÅTT_OG_ENDRET", "AVSLÅTT_OG_OPPHØRT", "AVSLÅTT_ENDRET_OG_OPPHØRT"],
     )
     fun `hentManuellVedtaksbrevtype skal returnere VEDTAK_FØRSTEGANGSVEDTAK_INSTITUSJON for førstegangsbehandling som er institusjon med gitte typer behandlingsresultat `(behandlingsresultat: Behandlingsresultat) {
+        // Arrange
         val behandling =
             mockk<Behandling>().apply {
                 every { resultat } returns behandlingsresultat
@@ -60,6 +65,7 @@ internal class BrevmalServiceTest {
                 every { type } returns BehandlingType.FØRSTEGANGSBEHANDLING
             }
 
+        // Act & Assert
         assertThat(brevmalService.hentManuellVedtaksbrevtype(behandling), Is(Brevmal.VEDTAK_FØRSTEGANGSVEDTAK_INSTITUSJON))
     }
 
@@ -69,6 +75,7 @@ internal class BrevmalServiceTest {
         names = ["INNVILGET", "INNVILGET_OG_ENDRET", "INNVILGET_OG_OPPHØRT", "INNVILGET_ENDRET_OG_OPPHØRT", "DELVIS_INNVILGET", "DELVIS_INNVILGET_OG_ENDRET", "DELVIS_INNVILGET_OG_OPPHØRT", "DELVIS_INNVILGET_ENDRET_OG_OPPHØRT", "AVSLÅTT_OG_ENDRET", "AVSLÅTT_OG_OPPHØRT", "AVSLÅTT_ENDRET_OG_OPPHØRT"],
     )
     fun `hentManuellVedtaksbrevtype skal returnere VEDTAK_FØRSTEGANGSVEDTAK for førstegangsbehandling med gitte behandlingsresultat `(behandlingsresultat: Behandlingsresultat) {
+        // Arrange
         val behandling =
             mockk<Behandling>().apply {
                 every { resultat } returns behandlingsresultat
@@ -76,6 +83,7 @@ internal class BrevmalServiceTest {
                 every { type } returns BehandlingType.FØRSTEGANGSBEHANDLING
             }
 
+        // Act & Assert
         assertThat(brevmalService.hentManuellVedtaksbrevtype(behandling), Is(Brevmal.VEDTAK_FØRSTEGANGSVEDTAK))
     }
 
@@ -85,6 +93,7 @@ internal class BrevmalServiceTest {
         names = ["INNVILGET", "INNVILGET_OG_ENDRET", "INNVILGET_OG_OPPHØRT", "INNVILGET_ENDRET_OG_OPPHØRT", "DELVIS_INNVILGET", "DELVIS_INNVILGET_OG_ENDRET", "DELVIS_INNVILGET_OG_OPPHØRT", "DELVIS_INNVILGET_ENDRET_OG_OPPHØRT", "AVSLÅTT_OG_ENDRET", "AVSLÅTT_OG_OPPHØRT", "AVSLÅTT_ENDRET_OG_OPPHØRT"],
     )
     fun `hentManuellVedtaksbrevtype skal returnere VEDTAK_OPPHØR_MED_ENDRING_INSTITUSJON for revurdering med ingen løpende ytelser som er institusjon med gitte behandlingsresultat `(behandlingsresultat: Behandlingsresultat) {
+        // Arrange
         val behandling =
             mockk<Behandling>(relaxed = true).apply {
                 every { resultat } returns behandlingsresultat
@@ -100,6 +109,7 @@ internal class BrevmalServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertThat(brevmalService.hentManuellVedtaksbrevtype(behandling), Is(Brevmal.VEDTAK_OPPHØR_MED_ENDRING_INSTITUSJON))
     }
 
@@ -109,6 +119,7 @@ internal class BrevmalServiceTest {
         names = ["INNVILGET", "INNVILGET_OG_ENDRET", "INNVILGET_OG_OPPHØRT", "INNVILGET_ENDRET_OG_OPPHØRT", "DELVIS_INNVILGET", "DELVIS_INNVILGET_OG_ENDRET", "DELVIS_INNVILGET_OG_OPPHØRT", "DELVIS_INNVILGET_ENDRET_OG_OPPHØRT", "AVSLÅTT_OG_ENDRET", "AVSLÅTT_OG_OPPHØRT", "AVSLÅTT_ENDRET_OG_OPPHØRT"],
     )
     fun `hentManuellVedtaksbrevtype skal returnere VEDTAK_ENDRING_INSTITUSJON for revurdering med løpende ytelser som er institusjon med gitte typer behandlingsresultat `(behandlingsresultat: Behandlingsresultat) {
+        // Arrange
         val behandling =
             mockk<Behandling>(relaxed = true).apply {
                 every { resultat } returns behandlingsresultat
@@ -124,6 +135,7 @@ internal class BrevmalServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertThat(brevmalService.hentManuellVedtaksbrevtype(behandling), Is(Brevmal.VEDTAK_ENDRING_INSTITUSJON))
     }
 
@@ -133,6 +145,7 @@ internal class BrevmalServiceTest {
         names = ["INNVILGET", "INNVILGET_OG_ENDRET", "INNVILGET_OG_OPPHØRT", "INNVILGET_ENDRET_OG_OPPHØRT", "DELVIS_INNVILGET", "DELVIS_INNVILGET_OG_ENDRET", "DELVIS_INNVILGET_OG_OPPHØRT", "DELVIS_INNVILGET_ENDRET_OG_OPPHØRT", "AVSLÅTT_OG_ENDRET", "AVSLÅTT_OG_OPPHØRT", "AVSLÅTT_ENDRET_OG_OPPHØRT"],
     )
     fun `hentManuellVedtaksbrevtype skal returnere VEDTAK_ENDRING for revurdering med løpende ytelser med gitte behandlingsresultat `(behandlingsresultat: Behandlingsresultat) {
+        // Arrange
         val behandling =
             mockk<Behandling>(relaxed = true).apply {
                 every { resultat } returns behandlingsresultat
@@ -148,6 +161,7 @@ internal class BrevmalServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertThat(brevmalService.hentManuellVedtaksbrevtype(behandling), Is(Brevmal.VEDTAK_ENDRING))
     }
 
@@ -157,6 +171,7 @@ internal class BrevmalServiceTest {
         names = ["INNVILGET", "INNVILGET_OG_ENDRET", "INNVILGET_OG_OPPHØRT", "INNVILGET_ENDRET_OG_OPPHØRT", "DELVIS_INNVILGET", "DELVIS_INNVILGET_OG_ENDRET", "DELVIS_INNVILGET_OG_OPPHØRT", "DELVIS_INNVILGET_ENDRET_OG_OPPHØRT", "AVSLÅTT_OG_ENDRET", "AVSLÅTT_OG_OPPHØRT", "AVSLÅTT_ENDRET_OG_OPPHØRT"],
     )
     fun `hentManuellVedtaksbrevtype skal returnere VEDTAK_OPPHØR_MED_ENDRING for revurdering med ingen løpende ytelser med gitte behandlingsresultat `(behandlingsresultat: Behandlingsresultat) {
+        // Arrange
         val behandling =
             mockk<Behandling>(relaxed = true).apply {
                 every { resultat } returns behandlingsresultat
@@ -172,11 +187,13 @@ internal class BrevmalServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertThat(brevmalService.hentManuellVedtaksbrevtype(behandling), Is(Brevmal.VEDTAK_OPPHØR_MED_ENDRING))
     }
 
     @Test
     fun `hentVedtaksbrevmal skal returnere AUTOVEDTAK_ENDRING for automatisk skjermet barn behandling omregning 18 år`() {
+        // Arrange
         val skjermetBarnFagsak =
             lagFagsak(
                 type = FagsakType.SKJERMET_BARN,
@@ -192,11 +209,13 @@ internal class BrevmalServiceTest {
                 resultat = Behandlingsresultat.ENDRET_OG_OPPHØRT,
             )
 
+        // Act & Assert
         assertThat(brevmalService.hentVedtaksbrevmal(behandling), Is(Brevmal.AUTOVEDTAK_ENDRING))
     }
 
     @Test
     fun `hentVedtaksbrevmal skal returnere AUTOVEDTAK_SATSENDRING_EØS for automatisk behandling med årsak SATSENDRING_EØS`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 årsak = BehandlingÅrsak.SATSENDRING_EØS,
@@ -205,6 +224,7 @@ internal class BrevmalServiceTest {
                 resultat = Behandlingsresultat.ENDRET_UTBETALING,
             )
 
+        // Act & Assert
         assertThat(brevmalService.hentVedtaksbrevmal(behandling), Is(Brevmal.AUTOVEDTAK_SATSENDRING_EØS))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentDistribueringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentDistribueringServiceTest.kt
@@ -28,29 +28,35 @@ internal class DokumentDistribueringServiceTest {
 
     @Test
     fun `Skal kalle 'loggBrevIkkeDistribuertUkjentAdresse' ved 400 kode og 'Mottaker har ukjent adresse' melding`() {
+        // Arrange
         every {
             integrasjonKlient.distribuerBrev(any())
         } throws HttpClientErrorException("Mottaker har ukjent adresse", HttpStatus.BAD_REQUEST, "", null, null, null)
 
+        // Act
         dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
             distribuerDokumentDTO = lagDistribuerDokumentDTO(),
             loggBehandlerRolle = BehandlerRolle.BESLUTTER,
         )
 
+        // Assert
         verify(exactly = 1) { loggService.opprettBrevIkkeDistribuertUkjentAdresseLogg(any(), any()) }
     }
 
     @Test
     fun `Skal kalle 'håndterMottakerDødIngenAdressePåBehandling' ved 410 Gone svar under distribuering`() {
+        // Arrange
         every {
             integrasjonKlient.distribuerBrev(any())
         } throws HttpClientErrorException("", HttpStatus.GONE, "", null, null, null)
 
+        // Act
         dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
             distribuerDokumentDTO = lagDistribuerDokumentDTO(),
             loggBehandlerRolle = BehandlerRolle.BESLUTTER,
         )
 
+        // Assert
         verify(exactly = 1) {
             loggService.opprettBrevIkkeDistribuertUkjentDødsboadresseLogg(any(), any())
         }
@@ -58,10 +64,12 @@ internal class DokumentDistribueringServiceTest {
 
     @Test
     fun `Skal hoppe over distribuering ved 409 Conflict mot dokdist`() {
+        // Arrange
         every {
             integrasjonKlient.distribuerBrev(any())
         } throws HttpClientErrorException("", HttpStatus.CONFLICT, "", null, null, null)
 
+        // Act & Assert
         assertDoesNotThrow {
             dokumentDistribueringService.prøvDistribuerBrevOgLoggHendelseFraBehandling(
                 distribuerDokumentDTO = lagDistribuerDokumentDTO(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevTypeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/BrevTypeTest.kt
@@ -40,11 +40,13 @@ class BrevTypeTest {
 
     @Test
     fun `Skal si om behandling settes på vent`() {
+        // Arrange
         val setterIkkeBehandlingPåVent =
             Brevmal
                 .entries
                 .filter { !førerTilAvventerDokumentasjon.contains(it) && it !in eøsDokumentMedAvventerDokumentasjon }
 
+        // Act & Assert
         setterIkkeBehandlingPåVent.forEach {
             Assertions.assertFalse(it.setterBehandlingPåVent())
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/ManueltBrevRequestTest.kt
@@ -28,11 +28,13 @@ class ManueltBrevRequestTest {
     inner class TilBrev {
         @Test
         fun `Forlenget svartidsbrev request skal gi forlenget svartid brevmal med riktig data`() {
+            // Act
             val brev =
                 baseRequest
                     .copy(brevmal = Brevmal.FORLENGET_SVARTIDSBREV)
                     .tilBrev("12345678910", "mottakerNavn", "saksbehandlerNavn") { emptyMap() }
 
+            // Assert
             assertThat(brev::class).isEqualTo(ForlengetSvartidsbrev::class)
             brev as ForlengetSvartidsbrev
 
@@ -47,7 +49,8 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `Forlenget svartidsbrev institusjon request skal gi forlenget svartid brevmal med riktig data`() {
-            val brev =
+            // Arrange
+            val brevRequest =
                 baseRequest
                     .copy(
                         brevmal = Brevmal.FORLENGET_SVARTIDSBREV_INSTITUSJON,
@@ -56,8 +59,12 @@ class ManueltBrevRequestTest {
                                 fødselsnummer = "testident",
                                 navn = "testnavn",
                             ),
-                    ).tilBrev("998765432", mottakerNavn = "Testorganisasjon", saksbehandlerNavn = "saksbehandlerNavn") { emptyMap() }
+                    )
 
+            // Act
+            val brev = brevRequest.tilBrev("998765432", mottakerNavn = "Testorganisasjon", saksbehandlerNavn = "saksbehandlerNavn") { emptyMap() }
+
+            // Assert
             assertThat(brev::class).isEqualTo(ForlengetSvartidsbrev::class)
             brev as ForlengetSvartidsbrev
 
@@ -76,6 +83,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `Innhente opplysninger brev institusjon skal fylle ut orgnummer og gjelder feltet`() {
+            // Arrange
             val fnr = "12345678910"
             val orgnr = "123456789"
             val brevRequestTilInstitusjon =
@@ -89,6 +97,8 @@ class ManueltBrevRequestTest {
                 )
 
             val mottakerNavn = "mottakerNavn"
+
+            // Act & Assert
             brevRequestTilInstitusjon.tilBrev(orgnr, mottakerNavn, "saksbehandlerNavn") { emptyMap() }.data.apply {
                 assertThat(flettefelter.organisasjonsnummer).containsExactly(orgnr)
                 assertThat(flettefelter.fodselsnummer).containsExactly(brevRequestTilInstitusjon.vedrørende?.fødselsnummer)
@@ -99,6 +109,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `Innhente opplysninger brevet skal ikke fylle ut org nummer og gjelder feltet selvom vedrørende er satt`() {
+            // Arrange
             val fnr = "12345678910"
 
             val brevRequestTilPerson =
@@ -112,6 +123,8 @@ class ManueltBrevRequestTest {
                 )
 
             val mottakerNavn = "mottakerNavn"
+
+            // Act & Assert
             brevRequestTilPerson.tilBrev(fnr, mottakerNavn, "saksbehandlerNavn") { emptyMap() }.data.apply {
                 assertThat(flettefelter.fodselsnummer).containsExactly(fnr)
                 assertThat(flettefelter.navn).containsExactly(mottakerNavn)
@@ -122,6 +135,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `tilBrev genererer 'Utbetaling etter KA-vedtak'-brev som forventet`() {
+            // Arrange
             val fnr = "12345678910"
             val brevRequestTilPerson =
                 baseRequest.copy(
@@ -129,7 +143,11 @@ class ManueltBrevRequestTest {
                     fritekstAvsnitt = "Fritekst avsnitt",
                 )
             val mottakerNavn = "mottakerNavn"
+
+            // Act
             val brev = brevRequestTilPerson.tilBrev(fnr, mottakerNavn, "Saks Behandlersen") { emptyMap() }.data as UtbetalingEtterKAVedtakData
+
+            // Assert
             with(brev.flettefelter) {
                 assertThat(fodselsnummer).containsExactly(fnr)
                 assertThat(navn).containsExactly(mottakerNavn)
@@ -142,6 +160,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `tilBrev genererer 'innhente opplysninger klage'-brev som forventet`() {
+            // Arrange
             val fnr = "12345678910"
             val mottakerNavn = "mottakerNavn"
             val brevRequestTilPerson =
@@ -154,7 +173,11 @@ class ManueltBrevRequestTest {
                             navn = "navn tilhørende $fnr",
                         ),
                 )
+
+            // Act
             val brev = brevRequestTilPerson.tilBrev(fnr, mottakerNavn, "Saks Behandlersen") { emptyMap() }.data as InformasjonsbrevInnhenteOpplysningerKlageData
+
+            // Assert
             with(brev.flettefelter) {
                 assertThat(fodselsnummer).containsExactly(fnr)
                 assertThat(navn).containsExactly(mottakerNavn)
@@ -167,6 +190,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `tilBrev genererer 'innhente opplysninger klage'-brev som forventet for institusjon`() {
+            // Arrange
             val fnr = "12345678910"
             val orgnr = "123456789"
             val mottakerNavn = "mottakerNavn"
@@ -180,7 +204,11 @@ class ManueltBrevRequestTest {
                             navn = "navn tilhørende $fnr",
                         ),
                 )
+
+            // Act
             val brev = brevRequestTilInstitusjon.tilBrev(orgnr, mottakerNavn, "Saks Behandlersen") { emptyMap() }.data as InformasjonsbrevInnhenteOpplysningerKlageData
+
+            // Assert
             with(brev.flettefelter) {
                 assertThat(fodselsnummer).containsExactly(fnr)
                 assertThat(navn).containsExactly(mottakerNavn)
@@ -193,6 +221,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `'innhente opplysninger klage'-brev krever at fritekst avsnitt har en verdi`() {
+            // Arrange
             val fnr = "12345678910"
             val mottakerNavn = "mottakerNavn"
             val brevRequestTilPerson =
@@ -200,6 +229,8 @@ class ManueltBrevRequestTest {
                     brevmal = Brevmal.INFORMASJONSBREV_INNHENTE_OPPLYSNINGER_KLAGE,
                     fritekstAvsnitt = "",
                 )
+
+            // Act & Assert
             val funksjonellFeil =
                 assertThrows<FunksjonellFeil> {
                     brevRequestTilPerson.tilBrev(fnr, mottakerNavn, "Saks Behandlersen") { emptyMap() }
@@ -209,6 +240,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `tilBrev genererer 'innhente opplysninger klage institusjon'-brev som forventet`() {
+            // Arrange
             val fnr = "12345678910"
             val orgnr = "123456789"
             val saksbehandler = "Saks Behandlersen"
@@ -225,8 +257,11 @@ class ManueltBrevRequestTest {
                         ),
                     fritekstAvsnitt = fritekstAvsnitt,
                 )
+
+            // Act
             val brev = brevRequestTilInstitusjon.tilBrev(orgnr, mottakerNavn, saksbehandler) { emptyMap() }.data as InformasjonsbrevInnhenteOpplysningerKlageData
 
+            // Assert
             with(brev.flettefelter) {
                 assertThat(organisasjonsnummer).containsExactly(orgnr)
                 assertThat(fodselsnummer).containsExactly(brevRequestTilInstitusjon.vedrørende?.fødselsnummer)
@@ -239,6 +274,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `'innhente opplysninger klage institusjon'-brev krever at fritekst avsnitt har en verdi`() {
+            // Arrange
             val orgnr = "123456789"
             val saksbehandler = "Saks Behandlersen"
             val mottakerNavn = "mottakerNavn"
@@ -248,6 +284,8 @@ class ManueltBrevRequestTest {
                     brevmal = Brevmal.INFORMASJONSBREV_INNHENTE_OPPLYSNINGER_KLAGE_INSTITUSJON,
                     fritekstAvsnitt = "",
                 )
+
+            // Act & Assert
             val funksjonellFeil =
                 assertThrows<FunksjonellFeil> {
                     brevRequestTilInstitusjon.tilBrev(orgnr, mottakerNavn, saksbehandler) { emptyMap() }
@@ -257,11 +295,13 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `Varsel årleg kontroll eøs request skal gi varsel årleg kontroll eøs brevmal med riktig data`() {
+            // Act
             val brev =
                 baseRequest
                     .copy(brevmal = Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS, mottakerlandSed = listOf("SE"))
                     .tilBrev("12345678910", "mottakerNavn", "saksbehandlerNavn") { mapOf(Pair("SE", "Sverige")) }
 
+            // Assert
             assertThat(brev::class).isEqualTo(VarselbrevÅrlegKontrollEøs::class)
             brev as VarselbrevÅrlegKontrollEøs
 
@@ -279,7 +319,10 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `Varsel årleg kontroll eøs med innhenting av opplysninger request skal gi varsel årleg kontroll eøs brevmal med riktig data`() {
+            // Arrange
             val dokumentliste = listOf("Dokument 1", "Dokument 2")
+
+            // Act
             val brev =
                 baseRequest
                     .copy(
@@ -288,6 +331,7 @@ class ManueltBrevRequestTest {
                         multiselectVerdier = dokumentliste,
                     ).tilBrev("12345678910", "mottakerNavn", "saksbehandlerNavn") { mapOf(Pair("SE", "Sverige")) }
 
+            // Assert
             assertThat(brev::class).isEqualTo(VarselbrevÅrlegKontrollEøs::class)
             brev as VarselbrevÅrlegKontrollEøs
 
@@ -306,6 +350,7 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `Varsel årleg kontroll EØS request med flere mottakerland skal gi riktig brevdata`() {
+            // Act
             val brev =
                 baseRequest
                     .copy(brevmal = Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS, mottakerlandSed = listOf("SE", "DK"))
@@ -313,6 +358,7 @@ class ManueltBrevRequestTest {
                         mapOf(Pair("SE", "Sverige"), Pair("DK", "Danmark"))
                     }
 
+            // Assert
             assertThat(brev::class).isEqualTo(VarselbrevÅrlegKontrollEøs::class)
             brev as VarselbrevÅrlegKontrollEøs
 
@@ -326,12 +372,14 @@ class ManueltBrevRequestTest {
 
         @Test
         fun `Varsel årleg kontroll EØS request skal validere mottakerland`() {
+            // Arrange
             val brevRequest =
                 baseRequest.copy(
                     brevmal = Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS,
                     mottakerlandSed = listOf("SE", "NO"),
                 )
 
+            // Act & Assert
             assertThrows<FunksjonellFeil> {
                 brevRequest.tilBrev("12345678910", "mottakerNavn", "saksbehandlerNavn") {
                     mapOf(Pair("SE", "Sverige"), Pair("NO", "Norge"))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/domene/SanityBegrunnelseTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 class SanityBegrunnelseTest {
     @Test
     fun `skal fjerne ugyldige enumverdier`() {
+        // Arrange
         val restSanityBegrunnelse =
             lagRestSanityBegrunnelse(
                 apiNavn = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET.sanityApiNavn,
@@ -17,6 +18,8 @@ class SanityBegrunnelseTest {
                         "IKKE_GYLDIG_ØVRIG_TRIGGER",
                     ),
             )
+
+        // Act & Assert
         Assertions.assertEquals(
             listOf(
                 ØvrigTrigger.BARN_MED_6_ÅRS_DAG,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
@@ -33,13 +33,17 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal lage mottakere når brevmottaker er FULLMEKTIG og bruker har norsk adresse`() {
+        // Arrange
         val brevmottakere = listOf(lagBrevMottakerDb(mottakerType = MottakerType.FULLMEKTIG))
         every { brevmottakerRepository.finnBrevMottakereForBehandling(any()) } returns brevmottakere
 
+        // Act
         val mottakerInfo =
             brevmottakerService.lagMottakereFraBrevMottakere(
                 brevmottakere.map { ManuellBrevmottaker(it) },
             )
+
+        // Assert
         assertTrue { mottakerInfo.size == 2 }
 
         assertTrue { mottakerInfo.first().manuellAdresseInfo == null }
@@ -50,6 +54,7 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal lage mottakere når brevmottaker er FULLMEKTIG og bruker har utenlandsk adresse`() {
+        // Arrange
         val brevmottakere =
             listOf(
                 lagBrevMottakerDb(mottakerType = MottakerType.FULLMEKTIG),
@@ -61,10 +66,13 @@ internal class BrevmottakerServiceTest {
             )
         every { brevmottakerRepository.finnBrevMottakereForBehandling(any()) } returns brevmottakere
 
+        // Act
         val mottakerInfo =
             brevmottakerService.lagMottakereFraBrevMottakere(
                 brevmottakere.map { ManuellBrevmottaker(it) },
             )
+
+        // Assert
         assertTrue { mottakerInfo.size == 2 }
 
         assertTrue { mottakerInfo.first().manuellAdresseInfo != null }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValideringTest.kt
@@ -75,6 +75,7 @@ class EndretUtbetalingAndelValideringTest {
     fun `skal sjekke at en endret periode ikke overlapper med eksisterende endringsperioder`(
         årsak: Årsak,
     ) {
+        // Arrange
         val barn1 = tilfeldigPerson()
         val barn2 = tilfeldigPerson()
         val endretUtbetalingAndel =
@@ -90,6 +91,7 @@ class EndretUtbetalingAndelValideringTest {
                 avtaletidspunktDeltBosted = LocalDate.now(),
             )
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 validerIngenOverlappendeEndring(
@@ -131,6 +133,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `skal sjekke at en endret periode ikke strekker seg utover ytterpunktene for tilkjent ytelse`() {
+        // Arrange
         val barn1 = tilfeldigPerson()
         val barn2 = tilfeldigPerson()
 
@@ -166,6 +169,7 @@ class EndretUtbetalingAndelValideringTest {
                 avtaletidspunktDeltBosted = LocalDate.now(),
             )
 
+        // Act & Assert
         var feil =
             assertThrows<FunksjonellFeil> {
                 validerPeriodeInnenforTilkjentytelse(endretUtbetalingAndel, emptyList())
@@ -205,6 +209,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `skal sjekke at en endret periode ikke strekker seg utover ytterpunktene for tilkjent ytelse for flere barn`() {
+        // Arrange
         val barn1 = tilfeldigPerson()
         val barn2 = tilfeldigPerson()
 
@@ -234,6 +239,7 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             validerPeriodeInnenforTilkjentytelse(gyldigEndretUtbetalingAndel, andelTilkjentYtelser)
         }
@@ -265,6 +271,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste feil hvis endringsperiode med årsak delt bosted ikke overlapper helt med delt bosted periode`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -277,6 +284,8 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
                 avtaletidspunktDeltBosted = LocalDate.now(),
             )
+
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             validerDeltBosted(
                 endretUtbetalingAndel = endretUtbetalingAndel,
@@ -306,6 +315,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste feil hvis endringsårsak er delt bosted og det ikke eksisterer delt bosted perioder`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -318,6 +328,8 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
                 avtaletidspunktDeltBosted = LocalDate.now(),
             )
+
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             validerDeltBosted(
                 endretUtbetalingAndel = endretUtbetalingAndel,
@@ -328,6 +340,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal ikke kaste feil hvis endringsperiode med årsak delt bosted overlapper helt med delt bosted periode`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -340,6 +353,8 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
                 avtaletidspunktDeltBosted = LocalDate.now(),
             )
+
+        // Act & Assert
         assertDoesNotThrow {
             validerDeltBosted(
                 endretUtbetalingAndel = endretUtbetalingAndel,
@@ -368,10 +383,14 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `sjekk at alle endrede utbetalingsandeler validerer`() {
+        // Arrange
         val endretUtbetalingAndel1 = lagEndretUtbetalingAndel(personer = setOf(tilfeldigPerson()))
         val endretUtbetalingAndel2 = lagEndretUtbetalingAndel(personer = setOf(tilfeldigPerson()))
+
+        // Act
         validerAtAlleOpprettedeEndringerErUtfylt(listOf(endretUtbetalingAndel1, endretUtbetalingAndel2))
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 validerAtAlleOpprettedeEndringerErUtfylt(
@@ -389,7 +408,10 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `sjekk at alle endrede utbetalingsandeler er tilknyttet andeltilkjentytelser`() {
+        // Arrange
         val endretUtbetalingAndel1 = lagEndretUtbetalingAndelMedAndelerTilkjentYtelse(personer = setOf(tilfeldigPerson()))
+
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 validerAtEndringerErTilknyttetAndelTilkjentYtelse(listOf(endretUtbetalingAndel1))
@@ -412,6 +434,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal finne riktige delt bosted perioder for barn, og slå sammen de som er sammenhengende`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val fom = LocalDate.now().minusMonths(5)
@@ -488,8 +511,10 @@ class EndretUtbetalingAndelValideringTest {
                 ),
             )
 
+        // Act
         val deltBostedPerioder = finnDeltBostedPerioderForPerson(person = barn, vilkårsvurdering = vilkårsvurdering)
 
+        // Assert
         assertTrue(deltBostedPerioder.size == 1)
         assertEquals(fom.plusMonths(1).førsteDagIInneværendeMåned().toYearMonth(), deltBostedPerioder.single().fom)
         assertEquals(tom.sisteDagIMåned().toYearMonth(), deltBostedPerioder.single().tom)
@@ -497,6 +522,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal finne riktige delt bosted perioder for barn og ikke slå de sammen når de ikke er sammenhengde`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn = lagPerson(type = PersonType.BARN)
         val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
@@ -573,8 +599,10 @@ class EndretUtbetalingAndelValideringTest {
                 ),
             )
 
+        // Act
         val deltBostedPerioder = finnDeltBostedPerioderForPerson(person = barn, vilkårsvurdering = vilkårsvurdering)
 
+        // Assert
         assertTrue(deltBostedPerioder.size == 2)
 
         val førstePeriode = deltBostedPerioder.get(0)
@@ -588,6 +616,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal finne riktige delt bosted perioder for søker, og slå sammen de som er sammenhengende`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn = lagPerson(type = PersonType.BARN)
         val søker = lagPerson(type = PersonType.SØKER)
@@ -664,8 +693,10 @@ class EndretUtbetalingAndelValideringTest {
                 ),
             )
 
+        // Act
         val deltBostedPerioder = finnDeltBostedPerioderForPerson(person = søker, vilkårsvurdering = vilkårsvurdering)
 
+        // Assert
         assertTrue(deltBostedPerioder.size == 1)
         assertEquals(fomBarn2.plusMonths(1).førsteDagIInneværendeMåned().toYearMonth(), deltBostedPerioder.single().fom)
         assertEquals(tomBarn1.sisteDagIMåned().toYearMonth(), deltBostedPerioder.single().tom)
@@ -673,6 +704,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal finne riktige delt bosted perioder for søker, og slå sammen de som overlapper`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn = lagPerson(type = PersonType.BARN)
         val søker = lagPerson(type = PersonType.SØKER)
@@ -749,8 +781,10 @@ class EndretUtbetalingAndelValideringTest {
                 ),
             )
 
+        // Act
         val deltBostedPerioder = finnDeltBostedPerioderForPerson(person = søker, vilkårsvurdering = vilkårsvurdering)
 
+        // Assert
         assertTrue(deltBostedPerioder.size == 1)
         assertEquals(fomBarn2.plusMonths(1).førsteDagIInneværendeMåned().toYearMonth(), deltBostedPerioder.single().fom)
         assertEquals(tomBarn1.sisteDagIMåned().toYearMonth(), deltBostedPerioder.single().tom)
@@ -758,6 +792,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal returnere tom liste hvis det ikke finnes noen delt bosted perioder på person`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn1 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(5))
         val barn2 = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.now().minusYears(4))
@@ -781,13 +816,16 @@ class EndretUtbetalingAndelValideringTest {
                 ),
             )
 
+        // Act
         val deltBostedPerioder = finnDeltBostedPerioderForPerson(person = barn1, vilkårsvurdering = vilkårsvurdering)
 
+        // Assert
         assertTrue(deltBostedPerioder.isEmpty())
     }
 
     @Test
     fun `skal ikke feile dersom det er en utvidet endring og delt bosted endring med samme periode og prosent`() {
+        // Act & Assert
         validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(
             listOf(endretUtbetalingAndelUtvidetNullutbetaling, endretUtbetalingAndelDeltBostedNullutbetaling),
         )
@@ -800,6 +838,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `skal ikke feile dersom det er en delt bosted endring som inneholder barn og søker`() {
+        // Arrange
         val andeler =
             lagEndretUtbetalingAndelMedAndelerTilkjentYtelse(
                 fom = inneværendeMåned().minusMonths(1),
@@ -821,6 +860,7 @@ class EndretUtbetalingAndelValideringTest {
                     ),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             validerAtDetFinnesDeltBostedEndringerMedSammeProsentForUtvidedeEndringer(listOf(andeler))
         }
@@ -921,6 +961,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste feil dersom endringsårsak er 'Allerede utbetalt' men tom dato er satt til etter inneværende måned`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -934,6 +975,7 @@ class EndretUtbetalingAndelValideringTest {
                 avtaletidspunktDeltBosted = LocalDate.now(),
             )
 
+        // Act & Assert
         val feilmelding =
             assertThrows<FunksjonellFeil> {
                 validerÅrsak(
@@ -950,6 +992,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste ikke feil dersom endringsårsak er 'Allerede utbetalt' og tom dato er satt til å være lik eller før inneværende måned`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -963,6 +1006,7 @@ class EndretUtbetalingAndelValideringTest {
                 avtaletidspunktDeltBosted = LocalDate.now(),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             validerÅrsak(
                 endretUtbetalingAndel = endretUtbetalingAndel,
@@ -973,6 +1017,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste feil dersom endringsårsak er 'Etterbetaling 3 år' og øker til hundre prosent utbetaling`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -983,6 +1028,7 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
             )
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 validerÅrsak(
@@ -996,6 +1042,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste feil dersom endringsårsak er 'Etterbetaling 3 år' og perioden er mindre er 3 år siden`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -1006,6 +1053,7 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
             )
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 validerÅrsak(
@@ -1019,6 +1067,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal ikke kaste feil dersom endringsårsak er 'Etterbetaling 3 år' og perioden er mer enn 3 år siden`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -1029,6 +1078,7 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             validerÅrsak(
                 endretUtbetalingAndel = endretUtbetalingAndel,
@@ -1039,6 +1089,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal kaste feil dersom endringsårsak er 'Etterbetaling 3 måneder' og perioden er mindre er 3 måneder siden`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -1049,6 +1100,7 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
             )
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 validerÅrsak(
@@ -1062,6 +1114,7 @@ class EndretUtbetalingAndelValideringTest {
 
     @Test
     fun `Skal ikke kaste feil dersom endringsårsak er 'Etterbetaling 3 måneder' og perioden er mer enn 3 måneder`() {
+        // Arrange
         val endretUtbetalingAndel =
             EndretUtbetalingAndel(
                 behandlingId = 1,
@@ -1072,6 +1125,7 @@ class EndretUtbetalingAndelValideringTest {
                 søknadstidspunkt = LocalDate.now(),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             validerÅrsak(
                 endretUtbetalingAndel = endretUtbetalingAndel,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelTest.kt
@@ -24,10 +24,12 @@ import java.time.YearMonth
 internal class EndretUtbetalingAndelTest {
     @Test
     fun `Sjekk validering med tomme felt`() {
+        // Arrange
         val behandling = lagBehandling()
         val endretUtbetalingAndel = EndretUtbetalingAndel(behandlingId = behandling.id)
         endretUtbetalingAndel.begrunnelse = ""
 
+        // Act & Assert
         assertThrows<RuntimeException> {
             endretUtbetalingAndel.validerUtfyltEndring()
         }
@@ -35,6 +37,7 @@ internal class EndretUtbetalingAndelTest {
 
     @Test
     fun `Sjekk validering for delt bosted med tomt felt avtaletidpunkt`() {
+        // Arrange
         val behandling = lagBehandling()
         val endretUtbetalingAndel = EndretUtbetalingAndel(behandlingId = behandling.id)
 
@@ -46,6 +49,7 @@ internal class EndretUtbetalingAndelTest {
         endretUtbetalingAndel.søknadstidspunkt = LocalDate.now()
         endretUtbetalingAndel.begrunnelse = "begrunnelse"
 
+        // Act & Assert
         assertThrows<RuntimeException> {
             endretUtbetalingAndel.validerUtfyltEndring()
         }
@@ -53,6 +57,7 @@ internal class EndretUtbetalingAndelTest {
 
     @Test
     fun `Sjekk validering for delt bosted med ikke tomt felt avtaletidpunkt`() {
+        // Arrange
         val behandling = lagBehandling()
         val endretUtbetalingAndel = EndretUtbetalingAndel(behandlingId = behandling.id)
 
@@ -65,11 +70,13 @@ internal class EndretUtbetalingAndelTest {
         endretUtbetalingAndel.avtaletidspunktDeltBosted = LocalDate.now()
         endretUtbetalingAndel.begrunnelse = "begrunnelse"
 
+        // Act & Assert
         assertTrue(endretUtbetalingAndel.validerUtfyltEndring())
     }
 
     @Test
     fun `Skal sette tom til siste måned med andel tilkjent ytelse hvis tom er null og det ikke finnes noen andre endringsperioder`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn1 = lagPerson(type = PersonType.BARN)
         val barn2 = lagPerson(type = PersonType.BARN)
@@ -108,6 +115,7 @@ internal class EndretUtbetalingAndelTest {
                 ),
             )
 
+        // Act
         val nyTom =
             beregnGyldigTom(
                 andelTilkjentYtelser = andelTilkjentYtelser,
@@ -115,12 +123,14 @@ internal class EndretUtbetalingAndelTest {
                 andreEndredeAndelerPåBehandling = emptyList(),
             )
 
+        // Assert
         val forventetTom = minOf(sisteTomPåAndelerBarn1, sisteTomPåAndelerBarn2)
         assertEquals(forventetTom, nyTom)
     }
 
     @Test
     fun `Skal sette tom til måneden før neste endringsperiode`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn1 = lagPerson(type = PersonType.BARN)
         val barn2 = lagPerson(type = PersonType.BARN)
@@ -177,6 +187,7 @@ internal class EndretUtbetalingAndelTest {
                 ),
             )
 
+        // Act
         val nyTom =
             beregnGyldigTom(
                 andelTilkjentYtelser = andelTilkjentYtelser,
@@ -184,12 +195,14 @@ internal class EndretUtbetalingAndelTest {
                 andreEndredeAndelerPåBehandling = andreEndretAndeler,
             )
 
+        // Assert
         val forventetTom = andreEndretAndeler.minOf { it.fom!! }.minusMonths(1)
         assertEquals(forventetTom, nyTom)
     }
 
     @Test
     fun `Skal sette tom til siste måned med andel tilkjent ytelse per aktør hvis tom er null og det ikke finnes noen andre endringsperioder`() {
+        // Arrange
         val behandling = lagBehandling()
         val barn1 = lagPerson(type = PersonType.BARN)
         val barn2 = lagPerson(type = PersonType.BARN)
@@ -228,6 +241,7 @@ internal class EndretUtbetalingAndelTest {
                 ),
             )
 
+        // Act
         val faktiskTomPerAktør =
             beregnGyldigTomPerAktør(
                 endretUtbetalingAndel = nyEndretUtbetalingAndel,
@@ -235,6 +249,7 @@ internal class EndretUtbetalingAndelTest {
                 andreEndredeAndelerPåBehandling = listOf(eksisterendeEndretUtbetalingAndel),
             )
 
+        // Assert
         val forventetTomPerAktør =
             mapOf(
                 barn1.aktør to eksisterendeEndretUtbetalingAndel.fom?.minusMonths(1),
@@ -249,8 +264,10 @@ internal class EndretUtbetalingAndelTest {
 
         @Test
         fun `skal returnere false hvis tom ikke er null`() {
+            // Arrange
             val endretUtbetalingAndel = endretUtbetalingAndel.copy(tom = YearMonth.of(2025, 12))
 
+            // Act & Assert
             assertThat(
                 skalSplitteEndretUtbetalingAndel(
                     endretUtbetalingAndel = endretUtbetalingAndel,
@@ -261,6 +278,7 @@ internal class EndretUtbetalingAndelTest {
 
         @Test
         fun `skal returnere false hvis begge personer har samme gyldigTomDato`() {
+            // Arrange
             val person1 = tilfeldigPerson()
             val person2 = tilfeldigPerson()
 
@@ -270,6 +288,7 @@ internal class EndretUtbetalingAndelTest {
                     person2.aktør to YearMonth.of(2025, 6),
                 )
 
+            // Act & Assert
             assertThat(
                 skalSplitteEndretUtbetalingAndel(
                     endretUtbetalingAndel = endretUtbetalingAndel,
@@ -280,6 +299,7 @@ internal class EndretUtbetalingAndelTest {
 
         @Test
         fun `skal returnere true hvis tom-dato er null og gyldigTomDato inneholder flere datoer`() {
+            // Arrange
             val person1 = tilfeldigPerson()
             val person2 = tilfeldigPerson()
 
@@ -289,6 +309,7 @@ internal class EndretUtbetalingAndelTest {
                     person2.aktør to YearMonth.of(2025, 7),
                 )
 
+            // Act & Assert
             assertThat(
                 skalSplitteEndretUtbetalingAndel(
                     endretUtbetalingAndel = endretUtbetalingAndel,
@@ -302,6 +323,7 @@ internal class EndretUtbetalingAndelTest {
     inner class SplittEndretUbetalingAndel {
         @Test
         fun `skal splitte andel med gyldig tom per aktør`() {
+            // Arrange
             val person1 = tilfeldigPerson()
             val person2 = tilfeldigPerson()
             val person3 = tilfeldigPerson()
@@ -327,12 +349,14 @@ internal class EndretUtbetalingAndelTest {
                     person3.aktør to YearMonth.of(2025, 12),
                 )
 
+            // Act
             val splittedeAndeler =
                 splittEndretUbetalingAndel(
                     endretUtbetalingAndel = endretUtbetalingAndel,
                     gyldigTomEtterDagensDatoPerAktør = gyldigTomEtterDagensDatoPerAktør,
                 )
 
+            // Assert
             assertThat(splittedeAndeler).hasSize(2)
 
             val (førsteAndel, andreAndel) = splittedeAndeler

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningSøkersYtelserTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test
 class DifferanseberegningSøkersYtelserTest {
     @Test
     fun `skal håndtere tre barn og utvidet barnetrygd og småbarnstillegg, der alle barna har underskudd i differanseberegning`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -70,6 +71,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -110,11 +112,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>", 100, { 1000 }, { -700 }) { 0 }
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `differanseberegnet ordinær barnetrygd uten at søker har ytelser, skal gi uendrete andeler for barna`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -153,6 +157,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -160,11 +165,13 @@ class DifferanseberegningSøkersYtelserTest {
                 personResultater = personResultater,
             )
 
+        // Assert
         assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `Ingen differranseberegning skal gi uendrete andeler`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -194,6 +201,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -201,13 +209,16 @@ class DifferanseberegningSøkersYtelserTest {
                 personResultater = personResultater,
             )
 
+        // Assert
         assertEquals(tilkjentYtelse.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `Tom tilkjent ytelse og ingen barn skal ikke gi feil`() {
+        // Arrange
         val tilkjentYtelse = lagInitiellTilkjentYtelse()
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse
                 .differanseberegnSøkersYtelser(
@@ -216,11 +227,13 @@ class DifferanseberegningSøkersYtelserTest {
                     personResultater = emptySet(),
                 )
 
+        // Assert
         assertEquals(emptyList<AndelTilkjentYtelse>(), nyeAndeler)
     }
 
     @Test
     fun `Søkers andel som har hatt differanseberegning, men ikke skal ha det lenger, skal fjerne differanseberegningen og slå sammen perioder som med sikkerhet kan slås sammen`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -269,6 +282,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -303,11 +317,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("                        $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$>") { 1000 }
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `Søkers andel som har differanseberegning, men underskuddet reduseres, skal få oppdatert differanseberegningen`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barna = listOf(barn1)
@@ -334,6 +350,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -350,11 +367,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$>", 100, { 1000 }, { -650 }) { 0 }
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `Skal tåle perioder der underskuddet på differanseberegning er større enn alle tilkjente ytelser`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barna = listOf(barn1)
@@ -381,6 +400,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -397,11 +417,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$>", 100, { 1000 }, { -2650 }) { 0 }
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `skal illustrere avrundingssproblematikk, der søker tjener`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -435,6 +457,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -452,11 +475,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `skal illustrere avrundingssproblematikk, der søker taper`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -490,6 +515,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val nyeAndeler =
             tilkjentYtelse.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -507,11 +533,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$$$$$$", 100, { 1054 }, { 554 }) { 554 }
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), nyeAndeler.sortert())
     }
 
     @Test
     fun `skal differanseberegne utvidet i perioder med sekundærlandsbarn og primærlandsbarn som bor i EØS land med annen forelder`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -549,6 +577,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
             tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -567,11 +596,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("            $$$$$$$$$$$$", nasjonalt = { 1000 }, kalkulert = { 1000 })
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker.sortert())
     }
 
     @Test
     fun `skal differanseberegne utvidet i perioder med sekundærlandsbarn og primærlandsbarn som bor i Storbritannia med annen forelder`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -609,6 +640,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
             tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -627,11 +659,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("            $$$$$$$$$$$$", nasjonalt = { 1000 }, kalkulert = { 1000 })
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker.sortert())
     }
 
     @Test
     fun `skal ikke differanseberegne utvidet i perioder med sekundærlandsbarn og primærlandsbarn uten EØS og Storbritannia krav`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -669,6 +703,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
             tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -688,11 +723,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("            $$$$$$$$$$$$", nasjonalt = { 1000 }, kalkulert = { 1000 })
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker.sortert())
     }
 
     @Test
     fun `skal ikke differanseberegne utvidet i perioder med sekundærlandsbarn, primærlandsbarn med EØS eller Storbritannia krav og vanlig primærlandsbarn`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -736,6 +773,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
             tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -756,11 +794,13 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("$$$$$$$$$$$$$$$$$$$$$$$$", nasjonalt = { 1000 }, kalkulert = { 1000 })
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker.sortert())
     }
 
     @Test
     fun `skal kun differanseberegne utvidet i rene sekundærlandperioder eller i kombinasjon med primærlandsbarn med EØS eller Storbritannia krav`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 13.des(2016)
         val barn2 = barn født 15.des(2017)
@@ -808,6 +848,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
             tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -836,6 +877,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("                   $$$$$", nasjonalt = { 1000 }, kalkulert = { 1000 })
                 .bygg()
 
+        // Assert
         assertThat(tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker.sortert()).containsExactlyInAnyOrderElementsOf(forventet.andelerTilkjentYtelse.sortert())
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker.sortert())
     }
@@ -843,6 +885,7 @@ class DifferanseberegningSøkersYtelserTest {
     // https://confluence.adeo.no/display/TFA/Differanseberegning
     @Test
     fun `eksempel-scenario fra confluence`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = barn født 1.jan(2016)
         val barn2 = barn født 1.jan(2019)
@@ -880,6 +923,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .byggVilkårsvurdering()
                 .personResultater
 
+        // Act
         val tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker =
             tilkjenteYtelserEtterDifferanseberegningForBarna.andelerTilkjentYtelse.differanseberegnSøkersYtelser(
                 barna = barna,
@@ -899,6 +943,7 @@ class DifferanseberegningSøkersYtelserTest {
                 .medOrdinær("                                     $$$$$$$$$$$", nasjonalt = { 1676 }, differanse = { 400 }, kalkulert = { 400 })
                 .bygg()
 
+        // Assert
         assertEquals(forventet.andelerTilkjentYtelse.sortert(), tilkjenteYtelserEtterDiffernanseberegningForBarnaOgSøker.sortert())
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
@@ -19,100 +19,120 @@ import java.time.YearMonth
 class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal multiplisere valutabeløp med valutakurs`() {
+        // Arrange
         val valutabeløp = 1200.i("EUR")
         val kurs = 9.731.kronerPer("EUR")
 
+        // Act & Assert
         Assertions.assertEquals(11_677.toBigDecimal(), (valutabeløp * kurs)?.round(MathContext(5)))
     }
 
     @Test
     fun `Skal ikke multiplisere valutabeløp med valutakurs når valuta er forskjellig, men returnere null`() {
+        // Arrange
         val valutabeløp = 1200.i("EUR")
         val kurs = 9.73.kronerPer("DKK")
 
+        // Act & Assert
         Assertions.assertNull(valutabeløp * kurs)
     }
 
     @Test
     fun `Skal konvertere årlig utenlandsk periodebeløp til månedlig`() {
+        // Act
         val månedligValutabeløp =
             1200
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(ÅRLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
 
     @Test
     fun `Skal konvertere kvartalsvis utenlandsk periodebeløp til månedlig`() {
+        // Act
         val månedligValutabeløp =
             300
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(KVARTALSVIS)
                 .tilMånedligValutabeløp()
 
+        // Assert
         Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
 
     @Test
     fun `Månedlig utenlandsk periodebeløp skal ikke endres`() {
+        // Act
         val månedligValutabeløp =
             100
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(MÅNEDLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         Assertions.assertEquals(100.i("EUR"), månedligValutabeløp)
     }
 
     @Test
     fun `Skal konvertere ukentlig utenlandsk periodebeløp til månedlig`() {
+        // Act
         val månedligValutabeløp =
             25
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(UKENTLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         Assertions.assertEquals(108.75.i("EUR"), månedligValutabeløp)
     }
 
     @Test
     fun `Skal ha presisjon i kronekonverteringen til norske kroner`() {
+        // Act
         val månedligValutabeløp =
             0.0123767453453
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(ÅRLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         Assertions.assertEquals(0.0010313954.i("EUR"), månedligValutabeløp)
     }
 
     @Test
     fun `Skal håndtere gjentakende endring og differanseberegning på andel tilkjent ytelse`() {
+        // Act
         val aty1 =
             lagVilkårligAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.toBigDecimal())
 
+        // Assert
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(-50, aty1?.differanseberegnetPeriodebeløp)
         Assertions.assertEquals(50, aty1?.nasjonaltPeriodebeløp)
         Assertions.assertEquals(50, aty1?.beløpUtenEndretUtbetaling)
 
+        // Act
         val aty2 =
             aty1
                 ?.copy(nasjonaltPeriodebeløp = 1, beløpUtenEndretUtbetaling = 1)
                 .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 75.toBigDecimal())
 
+        // Assert
         Assertions.assertEquals(0, aty2?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(-74, aty2?.differanseberegnetPeriodebeløp)
         Assertions.assertEquals(1, aty2?.nasjonaltPeriodebeløp)
         Assertions.assertEquals(1, aty2?.beløpUtenEndretUtbetaling)
 
+        // Act
         val aty3 =
             aty2
                 ?.copy(nasjonaltPeriodebeløp = 250, beløpUtenEndretUtbetaling = 250)
                 .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 75.toBigDecimal())
 
+        // Assert
         Assertions.assertEquals(175, aty3?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(175, aty3?.differanseberegnetPeriodebeløp)
         Assertions.assertEquals(250, aty3?.nasjonaltPeriodebeløp)
@@ -121,10 +141,12 @@ class DifferanseberegningsUtilsTest {
 
     @Test
     fun `Skal fjerne desimaler i utenlandskperiodebeløp, effektivt øke den norske ytelsen med inntil én krone`() {
+        // Act
         val aty1 =
             lagVilkårligAndelTilkjentYtelse(beløp = 50)
                 .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal()) // Blir til rundet til 100
 
+        // Assert
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
         Assertions.assertEquals(-50, aty1?.differanseberegnetPeriodebeløp)
         Assertions.assertEquals(50, aty1?.nasjonaltPeriodebeløp)
@@ -132,18 +154,24 @@ class DifferanseberegningsUtilsTest {
 
     @Test
     fun `Skal beholde originalt nasjonaltPeriodebeløp når vi oppdatererDifferanseberegning gjentatte ganger`() {
+        // Act
         var aty1 =
             lagVilkårligAndelTilkjentYtelse(beløp = 50)
                 .oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 100.987654.toBigDecimal())
 
+        // Assert
         Assertions.assertEquals(0, aty1?.kalkulertUtbetalingsbeløp)
 
+        // Act
         aty1 = aty1.oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 13.6.toBigDecimal())
 
+        // Assert
         Assertions.assertEquals(37, aty1?.kalkulertUtbetalingsbeløp)
 
+        // Act
         aty1 = aty1.oppdaterDifferanseberegning(utenlandskPeriodebeløpINorskeKroner = 49.2.toBigDecimal())
 
+        // Assert
         Assertions.assertEquals(1, aty1?.kalkulertUtbetalingsbeløp)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
@@ -24,6 +24,7 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
 
     @Test
     fun `skal ikke kaste exception hvis tilkjent ytelse oppdateres med gyldige andeler`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val forrigeTilkjentYtelse =
@@ -40,11 +41,13 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
 
         every { tilkjentYtelseRepository.saveAndFlush(any()) } returns nyTilkjentYtelse
 
+        // Act
         tilkjentYtelseRepository.oppdaterTilkjentYtelse(
             forrigeTilkjentYtelse,
             nyTilkjentYtelse.andelerTilkjentYtelse,
         )
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/OppdaterSkjemaTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/OppdaterSkjemaTest.kt
@@ -23,22 +23,31 @@ internal class OppdaterSkjemaTest {
 
     @Test
     fun `oppdatere med tom kompetanse skal ikke har noen effekt`() {
+        // Arrange
         val tomKompetanse = Kompetanse(null, null)
 
+        // Act
         val faktiskeKompetanser = oppdaterSkjemaerRekursivt(kompetanser, tomKompetanse)
+
+        // Assert
         assertEqualsUnordered(kompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun `oppdatere tom liste av kompetansr med en gyldig kompetanse skal gi tom liste`() {
+        // Arrange
         val kompetanse = kompetanse(jan(2020), "------", barn1, barn2, barn3)
 
+        // Act
         val faktiskeKompetanser = oppdaterSkjemaerRekursivt(emptyList(), kompetanse)
+
+        // Assert
         assertEqualsUnordered(emptyList(), faktiskeKompetanser)
     }
 
     @Test
     fun `oppdatere utenfor gjeldende kompetanser skal ikke ha effekt`() {
+        // Arrange
         val kompetanse =
             kompetanse(
                 jan(2019),
@@ -48,12 +57,16 @@ internal class OppdaterSkjemaTest {
                 barn3,
             )
 
+        // Act
         val faktiskeKompetanser = oppdaterSkjemaerRekursivt(kompetanser, kompetanse)
+
+        // Assert
         assertEqualsUnordered(kompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun `oppdatere mer enn gjeldende kompetanser skal bare påvirke eksisterende tidsperioder`() {
+        // Arrange
         val kompetanse = kompetanse(jan(2020), "PPPPPPPPPPPPPPPPPPPPPP", barn1, barn2, barn3)
 
         val forventedeKompetanser =
@@ -62,12 +75,16 @@ internal class OppdaterSkjemaTest {
                 .medKompetanse("  PP", barn2, barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = oppdaterSkjemaerRekursivt(kompetanser, kompetanse)
+
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun `oppdatere kompetanser som begynner uendret, skal likevel bli endret`() {
+        // Arrange
         val kompetanse = kompetanse(jan(2020), "    SSSSSSSSS", barn1)
 
         val forventedeKompetanser =
@@ -77,7 +94,10 @@ internal class OppdaterSkjemaTest {
                 .medKompetanse("             PP", barn1, barn2, barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = oppdaterSkjemaerRekursivt(kompetanser, kompetanse)
+
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SkjemaTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SkjemaTidslinjeTest.kt
@@ -14,6 +14,7 @@ import java.time.YearMonth
 internal class SkjemaTidslinjeTest {
     @Test
     fun `skal håndtere to påfølgende perioder i fremtiden`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val kompetanse1 =
             Kompetanse(
@@ -28,7 +29,10 @@ internal class SkjemaTidslinjeTest {
                 barnAktører = setOf(barn.aktør),
             )
 
+        // Act
         val kompetanseTidslinje = listOf(kompetanse1, kompetanse2).tilTidslinje()
+
+        // Assert
         assertEquals(1, kompetanseTidslinje.tilPerioder().size)
         assertEquals(1.feb(2437), kompetanseTidslinje.startsTidspunkt)
         assertEquals(PRAKTISK_SENESTE_DAG, kompetanseTidslinje.kalkulerSluttTidspunkt())
@@ -36,6 +40,7 @@ internal class SkjemaTidslinjeTest {
 
     @Test
     fun `skal håndtere kompetanse som mangler både fom og tom`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val kompetanse =
             Kompetanse(
@@ -44,7 +49,10 @@ internal class SkjemaTidslinjeTest {
                 barnAktører = setOf(barn.aktør),
             )
 
+        // Act
         val kompetanseTidslinje = kompetanse.tilTidslinje()
+
+        // Assert
         assertEquals(1, kompetanseTidslinje.tilPerioder().size)
         assertEquals(PRAKTISK_TIDLIGSTE_DAG, kompetanseTidslinje.startsTidspunkt)
         assertEquals(PRAKTISK_SENESTE_DAG, kompetanseTidslinje.kalkulerSluttTidspunkt())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SlåSammenSkjemaTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/SlåSammenSkjemaTest.kt
@@ -15,6 +15,7 @@ class SlåSammenSkjemaTest {
 
     @Test
     fun testSlåSammenPåfølgendePerioder() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("SSS", barn1)
@@ -26,12 +27,16 @@ class SlåSammenSkjemaTest {
                 .medKompetanse("SSSSSS", barn1)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = kompetanser.slåSammen()
+
+        // Assert
         Assertions.assertEquals(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun testSlåSammenForPerioderMedMellomrom() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("SSS", barn1, barn2, barn3)
@@ -43,12 +48,16 @@ class SlåSammenSkjemaTest {
                 .medKompetanse("SSS SSS", barn1, barn2, barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = kompetanser.slåSammen()
+
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun testSlåSammenForPerioderDerTidligstePeriodeHarÅpemTOM() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("->", barn1, barn2, barn3)
@@ -60,13 +69,17 @@ class SlåSammenSkjemaTest {
                 .medKompetanse("->", barn1, barn2, barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = kompetanser.slåSammen()
+
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
         Assertions.assertEquals(null, faktiskeKompetanser.first().tom)
     }
 
     @Test
     fun testSlåSammenForPerioderMedOverlapp() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("-----", barn1, barn2, barn3)
@@ -78,12 +91,16 @@ class SlåSammenSkjemaTest {
                 .medKompetanse("--------", barn1, barn2, barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = kompetanser.slåSammen()
+
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun testSlåSammneForPerioderDerSenestePeriodeHarÅpemTOM() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("------", barn1, barn2, barn3)
@@ -95,7 +112,10 @@ class SlåSammenSkjemaTest {
                 .medKompetanse("->", barn1, barn2, barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = kompetanser.slåSammen()
+
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
         Assertions.assertEquals(jan2020, faktiskeKompetanser.first().fom)
         Assertions.assertEquals(null, faktiskeKompetanser.first().tom)
@@ -103,6 +123,7 @@ class SlåSammenSkjemaTest {
 
     @Test
     fun komplekseSlåSammenKommpetanserTest() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("SSSSSSS", barn1)
@@ -121,13 +142,17 @@ class SlåSammenSkjemaTest {
                 .medKompetanse("-      ", barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = kompetanser.slåSammen()
+
+        // Assert
         Assertions.assertEquals(6, faktiskeKompetanser.size)
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun slåSammenEnkeltBarnSomSkillerSegHeltUt() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("SSS", barn1)
@@ -141,7 +166,10 @@ class SlåSammenSkjemaTest {
                 .medKompetanse("---------", barn2, barn3)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser = kompetanser.slåSammen()
+
+        // Assert
         Assertions.assertEquals(2, faktiskeKompetanser.size)
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/TrekkFraSkjemaTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/felles/beregning/TrekkFraSkjemaTest.kt
@@ -15,6 +15,7 @@ class TrekkFraSkjemaTest {
 
     @Test
     fun testRestSomIntrodusererHull() {
+        // Arrange
         val kompetanse =
             KompetanseBuilder(jan2020)
                 .medKompetanse("------", barn1, barn2, barn3)
@@ -33,14 +34,17 @@ class TrekkFraSkjemaTest {
                 .medKompetanse("--  --", barn1)
                 .byggKompetanser()
 
+        // Act
         val restKompetanser = kompetanse.trekkFra(oppdatertKompetanse)
 
+        // Assert
         Assertions.assertEquals(3, restKompetanser.size)
         assertEqualsUnordered(forventedeKompetanser, restKompetanser)
     }
 
     @Test
     fun testRestMedPeriodeOverEnEnkeltMåned() {
+        // Arrange
         val kompetanse =
             KompetanseBuilder(jan2020)
                 .medKompetanse("  --", barn1, barn2)
@@ -59,8 +63,10 @@ class TrekkFraSkjemaTest {
                 .medKompetanse("  --", barn2)
                 .byggKompetanser()
 
+        // Act
         val restKompetanser = kompetanse.trekkFra(fjernKompetanse)
 
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, restKompetanser)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -77,6 +77,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `bare reduksjon av periode skal ikke føre til endring i kompetansen`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
 
@@ -85,8 +86,11 @@ internal class KompetanseServiceTest {
                 .lagreTil(mockKompetanseRepository)
 
         val oppdatertKompetanse = kompetanse(jan(2020), "  SSSSS  ", barn1)
+
+        // Act
         kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
 
+        // Assert
         val forventedeKompetanser = listOf(lagretKompetanse)
 
         assertEqualsUnordered(forventedeKompetanser, kompetanseService.hentKompetanser(behandlingId))
@@ -94,6 +98,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `oppdatering som splitter kompetanse fulgt av sletting skal returnere til utgangspunktet`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
         val barn2 = tilfeldigPerson(personType = PersonType.BARN)
@@ -105,8 +110,10 @@ internal class KompetanseServiceTest {
 
         val oppdatertKompetanse = kompetanse(jan(2020), "  PP", barn2, barn3)
 
+        // Act
         kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
 
+        // Assert
         val forventedeKompetanser =
             KompetanseBuilder(jan(2020), behandlingId)
                 .medKompetanse("--", barn1, barn2, barn3)
@@ -125,6 +132,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `oppdatering som endrer deler av en kompetanse, skal resultarere i en splitt`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
         val barn2 = tilfeldigPerson(personType = PersonType.BARN)
@@ -137,8 +145,11 @@ internal class KompetanseServiceTest {
             .lagreTil(mockKompetanseRepository)
 
         val oppdatertKompetanse = kompetanse(jan(2020), "PP", barn1)
+
+        // Act
         kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
 
+        // Assert
         val forventedeKompetanser =
             KompetanseBuilder(jan(2020), behandlingId)
                 .medKompetanse("PP", barn1)
@@ -151,6 +162,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal kunne sende inn oppdatering som overlapper flere kompetanser`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
         val barn2 = tilfeldigPerson(personType = PersonType.BARN)
@@ -163,8 +175,11 @@ internal class KompetanseServiceTest {
             .lagreTil(mockKompetanseRepository)
 
         val oppdatertKompetanse = kompetanse(mar(2020), "PPP", barn1, barn2, barn3)
+
+        // Act
         kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
 
+        // Assert
         val forventedeKompetanser =
             KompetanseBuilder(jan(2020), behandlingId)
                 .medKompetanse("SS   SS", barn1)
@@ -178,6 +193,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal kunne lukke åpen kompetanse ved å sende inn identisk skjema med til-og-med-dato`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
         val barn2 = tilfeldigPerson(personType = PersonType.BARN)
@@ -190,8 +206,11 @@ internal class KompetanseServiceTest {
 
         // Endrer kun til-og-med dato fra uendelig (null) til en gitt dato
         val oppdatertKompetanse = kompetanse(jan(2020), "SSS", barn1, barn2, barn3)
+
+        // Act
         kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
 
+        // Assert
         // Forventer tomt skjema fra oppdatert dato og fremover
         val forventedeKompetanser =
             KompetanseBuilder(jan(2020), behandlingId)
@@ -204,6 +223,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal kunne forkorte til-og-med ved å sende inn identisk skjema med tidligere til-og-med-dato`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
         val barn2 = tilfeldigPerson(personType = PersonType.BARN)
@@ -216,8 +236,11 @@ internal class KompetanseServiceTest {
 
         // Endrer kun til-og-med dato til tidligere tidspunkt
         val oppdatertKompetanse = kompetanse(jan(2020), "SSS", barn1, barn2, barn3)
+
+        // Act
         kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
 
+        // Assert
         // Forventer tomt skjema fra oppdatert dato og fremover til orignal til-og-med
         val forventedeKompetanser =
             KompetanseBuilder(jan(2020), behandlingId)
@@ -230,6 +253,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal opprette tomt skjema for barn som fjernes fra ellers uendret skjema`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
         val barn2 = tilfeldigPerson(personType = PersonType.BARN)
@@ -242,8 +266,11 @@ internal class KompetanseServiceTest {
 
         // Fjerner ett barn fra gjeldende skjema, ellers likt
         val oppdatertKompetanse = kompetanse(jan(2020), "S>", barn1, barn2)
+
+        // Act
         kompetanseService.oppdaterKompetanse(behandlingId, oppdatertKompetanse)
 
+        // Assert
         // Forventer tomt skjema for samme periode for barnet som ble fjernet
         val forventedeKompetanser =
             KompetanseBuilder(jan(2020), behandlingId)
@@ -257,6 +284,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `kompetanse skal vare uendelig når til regelverk-tidslinjer fortsetter etter nåtidspunktet`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val treMånederSiden = YearMonth.now().minusMonths(3)
@@ -311,14 +339,17 @@ internal class KompetanseServiceTest {
         every { utbetalingTidslinjeService.hentEndredeUtbetalingsPerioderSomKreverKompetanseTidslinjer(behandlingId, emptyList()) } returns emptyMap()
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
 
+        // Act
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 
+        // Assert
         val faktiskeKompetanser = kompetanseService.hentKompetanser(behandlingId)
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun `kompetanse skal ha sluttdato når til regelverk-tidslinjer avsluttes før nåtidspunktet`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val seksMånederSiden = YearMonth.now().minusMonths(6)
@@ -374,14 +405,17 @@ internal class KompetanseServiceTest {
         every { utbetalingTidslinjeService.hentEndredeUtbetalingsPerioderSomKreverKompetanseTidslinjer(behandlingId, emptyList()) } returns emptyMap()
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
 
+        // Act
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 
+        // Assert
         val faktiskeKompetanser = kompetanseService.hentKompetanser(behandlingId)
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun `skal tilpasse kompetanser til endrede regelverk-tidslinjer`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
@@ -432,8 +466,10 @@ internal class KompetanseServiceTest {
         every { utbetalingTidslinjeService.hentEndredeUtbetalingsPerioderSomKreverKompetanseTidslinjer(behandlingId, emptyList()) } returns emptyMap()
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId.id) } returns tilkjentYtelse.andelerTilkjentYtelse.toList().map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) }
 
+        // Act
         tilpassKompetanserTilRegelverkService.tilpassKompetanserTilRegelverk(behandlingId)
 
+        // Assert
         val faktiskeKompetanser = kompetanseService.hentKompetanser(behandlingId)
 
         val forventedeKompetanser =
@@ -448,6 +484,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal kopiere over kompetanse-skjema fra forrige behandling til ny behandling`() {
+        // Arrange
         val behandlingId1 = BehandlingId(10L)
         val behandlingId2 = BehandlingId(11L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
@@ -474,8 +511,10 @@ internal class KompetanseServiceTest {
                     erAnnenForelderOmfattetAvNorskLovgivning = true,
                 ).lagreTil(mockKompetanseRepository)
 
+        // Act
         kompetanseService.kopierOgErstattKompetanser(behandlingId1, behandlingId2)
 
+        // Assert
         val kompetanserBehandling2 = kompetanseService.hentKompetanser(behandlingId2)
 
         assertEqualsUnordered(kompetanser, kompetanserBehandling2)
@@ -495,6 +534,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal kopiere kompetanser fra en behandling til en annen behandling, og overskrive eksisterende`() {
+        // Arrange
         val behandlingId1 = BehandlingId(10L)
         val behandlingId2 = BehandlingId(22L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
@@ -512,8 +552,10 @@ internal class KompetanseServiceTest {
             .medKompetanse("PPPSSSPPPPPPP", barn1, barn2, barn3)
             .lagreTil(mockKompetanseRepository)
 
+        // Act
         kompetanseService.kopierOgErstattKompetanser(behandlingId1, behandlingId2)
 
+        // Assert
         val kompetanserBehandling2EtterEndring = kompetanseService.hentKompetanser(behandlingId2)
 
         assertEqualsUnordered(kompetanser1, kompetanserBehandling2EtterEndring)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test
 class KompetanseTest {
     @Test
     fun `utbetalingsland - skal returnere landkode for utbetalingsland dersom kompetanse er utfylt`() {
+        // Arrange
         val kompetanse =
             lagKompetanse(
                 barnAktører = setOf(randomAktør()),
@@ -23,24 +24,30 @@ class KompetanseTest {
                 erAnnenForelderOmfattetAvNorskLovgivning = false,
             )
 
+        // Act
         val utbetalingsland = kompetanse.utbetalingsland()
 
+        // Assert
         assertThat(utbetalingsland).isNotNull
         assertThat(utbetalingsland).isEqualTo("SE")
     }
 
     @Test
     fun `utbetalingsland - skal returnere null for utbetalingsland dersom kompetanse ikke er utfylt`() {
+        // Arrange
         val kompetanse =
             lagKompetanse()
 
+        // Act
         val utbetalingsland = kompetanse.utbetalingsland()
 
+        // Assert
         assertThat(utbetalingsland).isNull()
     }
 
     @Test
     fun `utbetalingsland - skal returnere Norge for utbetalingsland dersom kompetanse er utfylt og resultatet er at norge er primærland`() {
+        // Arrange
         val kompetanse =
             lagKompetanse(
                 barnAktører = setOf(randomAktør()),
@@ -53,14 +60,17 @@ class KompetanseTest {
                 erAnnenForelderOmfattetAvNorskLovgivning = false,
             )
 
+        // Act
         val utbetalingsland = kompetanse.utbetalingsland()
 
+        // Assert
         assertThat(utbetalingsland).isNotNull
         assertThat(utbetalingsland).isEqualTo("NO")
     }
 
     @Test
     fun `utbetalingsland - skal returnere utbetalingsland ulikt Norge dersom kompetanse er utfylt og hovedregelen fortsatt gir Norge`() {
+        // Arrange
         val kompetanse =
             lagKompetanse(
                 barnAktører = setOf(randomAktør()),
@@ -73,8 +83,10 @@ class KompetanseTest {
                 erAnnenForelderOmfattetAvNorskLovgivning = false,
             )
 
+        // Act
         val utbetalingsland = kompetanse.utbetalingsland()
 
+        // Assert
         assertThat(utbetalingsland).isNotNull
         assertThat(utbetalingsland).isEqualTo("SE")
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/TilpassKompetanserTilRegelverkTest.kt
@@ -26,6 +26,7 @@ class TilpassKompetanserTilRegelverkTest {
 
     @Test
     fun testTilpassKompetanserUtenKompetanser() {
+        // Arrange
         val kompetanser: List<Kompetanse> = emptyList()
 
         val eøsPerioder =
@@ -49,6 +50,7 @@ class TilpassKompetanserTilRegelverkTest {
                     erAnnenForelderOmfattetAvNorskLovgivning = false,
                 ).byggKompetanser()
 
+        // Act
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
                 gjeldendeKompetanser = kompetanser,
@@ -58,11 +60,13 @@ class TilpassKompetanserTilRegelverkTest {
                 inneværendeMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun testTilpassKompetanserUtenEøsPerioder() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("SSSSSSS", barn1)
@@ -72,6 +76,7 @@ class TilpassKompetanserTilRegelverkTest {
 
         val forventedeKompetanser = emptyList<Kompetanse>()
 
+        // Act
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
                 gjeldendeKompetanser = kompetanser,
@@ -80,11 +85,13 @@ class TilpassKompetanserTilRegelverkTest {
                 inneværendeMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun testTilpassKompetanserMotEøsEttBarn() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("SSSSSSS", barn1)
@@ -100,6 +107,7 @@ class TilpassKompetanserTilRegelverkTest {
                 .medKompetanse("SSS  SS--", barn1)
                 .byggKompetanser()
 
+        // Act
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
                 gjeldendeKompetanser = kompetanser,
@@ -108,11 +116,13 @@ class TilpassKompetanserTilRegelverkTest {
                 inneværendeMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun testTilpassKompetanserMotEøsToBarn() {
+        // Arrange
         val kompetanser =
             KompetanseBuilder(jan2020)
                 .medKompetanse("SS--SSSS", barn1, barn2)
@@ -132,6 +142,7 @@ class TilpassKompetanserTilRegelverkTest {
                 .byggKompetanser()
                 .sortedBy { it.fom }
 
+        // Act
         val faktiskeKompetanser =
             tilpassKompetanserTilRegelverk(
                 gjeldendeKompetanser = kompetanser,
@@ -140,11 +151,13 @@ class TilpassKompetanserTilRegelverkTest {
                 inneværendeMåned = YearMonth.now(),
             ).sortedBy { it.fom }
 
+        // Assert
         assertEqualsUnordered(forventedeKompetanser, faktiskeKompetanser)
     }
 
     @Test
     fun testTilpassKompetanserMotEøsForFlereBarn() {
+        // Arrange
         // "SSSSSSS", barn1
         // "SSSPPSS", barn2
         // "-SSSSSS", barn3

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/KompetanseMappingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/domene/KompetanseMappingTest.kt
@@ -14,6 +14,7 @@ internal class KompetanseMappingTest {
 
     @Test
     fun sjekkAtMappingFremOgTilbakeGirSammeResultat() {
+        // Arrange
         val barnAktører = setOf(barn1.aktør, barn2.aktør, barn3.aktør)
         val kompetanse =
             Kompetanse(
@@ -27,8 +28,10 @@ internal class KompetanseMappingTest {
                 resultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
             )
 
+        // Act
         val restKompetanse = kompetanse.tilKompetanseDto()
 
+        // Assert
         assertEquals(kompetanse, restKompetanse.tilKompetanse(barnAktører.toList()))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserTest.kt
@@ -28,6 +28,7 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
 
     @Test
     fun `test tilpasning av utenlandske periodebeløp mot kompleks endring av kompetanse`() {
+        // Arrange
         val forrigeUtenlandskePeriodebeløp =
             UtenlandskPeriodebeløpBuilder(jan2020)
                 .medBeløp("--3456789-----", "EUR", "N", barn1, barn2)
@@ -47,14 +48,17 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .medBeløp(" -        ", null, "N", barn1, barn3)
                 .bygg()
 
+        // Act
         val faktiskeUtenlandskePeriodebeløp =
             tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser, inneværendeMåned)
 
+        // Assert
         assertEqualsUnordered(forventedeUtenlandskePeriodebeløp, faktiskeUtenlandskePeriodebeløp)
     }
 
     @Test
     fun `test at endret annennForeldersAktivitetsland i kompetanse fører til endring i utenlandsk periodebeløp`() {
+        // Arrange
         val forrigeUtenlandskePeriodebeløp =
             UtenlandskPeriodebeløpBuilder(jan2020)
                 .medBeløp("555555", "EUR", "N", barn1)
@@ -65,9 +69,11 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .medKompetanse("SSSSSS", barn1, annenForeldersAktivitetsland = "S")
                 .byggKompetanser()
 
+        // Act
         val faktiskeUtenlandskePeriodebeløp =
             tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser, inneværendeMåned)
 
+        // Assert
         val forventedeUtenlandskePeriodebeløp =
             UtenlandskPeriodebeløpBuilder(jan2020)
                 .medBeløp("------", null, "S", barn1)
@@ -78,6 +84,7 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
 
     @Test
     fun `test at ikke fremtidige utenlandske periodebeløp genereres`() {
+        // Arrange
         val gjeldendeUtenlandskePeriodeBeløp =
             UtenlandskPeriodebeløpBuilder(nov2020)
                 .medBeløp("12345", "PLN", "PL", barn1)
@@ -93,9 +100,11 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .medBeløp("123", "PLN", "PL", barn1)
                 .bygg()
 
+        // Act
         val faktiskeUtenlandskPeriodebeløp =
             tilpassUtenlandskePeriodebeløpTilKompetanser(gjeldendeUtenlandskePeriodeBeløp, kompetanser, inneværendeMåned)
 
+        // Assert
         assertThat(faktiskeUtenlandskPeriodebeløp).isEqualTo(forventedeUtenlandskePeriodebeløp)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
@@ -55,6 +55,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `skal tilpasse utenlandsk periodebeløp til endrede kompetanser`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).toLocalDate())
@@ -74,9 +75,11 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
         every { kompetanseRepository.finnFraBehandlingId(behandlingId.id) } returns kompetanser
 
+        // Act
         tilpassUtenlandskePeriodebeløpTilKompetanserService
             .tilpassUtenlandskPeriodebeløpTilKompetanser(behandlingId)
 
+        // Assert
         val faktiskeUtenlandskePeriodebeløp = utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId)
 
         val forventedeUtenlandskePeriodebeløp =
@@ -89,6 +92,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Slette et utenlandskPeriodebeløp-skjema skal resultere i et skjema uten innhold, men som fortsatt har utbetalingsland`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).toLocalDate())
@@ -99,8 +103,10 @@ internal class UtenlandskPeriodebeløpServiceTest {
                 .lagreTil(utenlandskPeriodebeløpRepository)
                 .single()
 
+        // Act
         utenlandskPeriodebeløpService.slettUtenlandskPeriodebeløp(behandlingId, lagretUtenlandskPeriodebeløp.id)
 
+        // Assert
         val faktiskUtenlandskPeriodebeløp =
             utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId).single()
 
@@ -116,6 +122,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kunne lukke åpen utenlandskPeriodebeløp-skjema ved å sende inn identisk skjema med satt tom-dato`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).toLocalDate())
@@ -133,8 +140,11 @@ internal class UtenlandskPeriodebeløpServiceTest {
                 .medIntervall(Intervall.UKENTLIG)
                 .bygg()
                 .first()
+
+        // Act
         utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(behandlingId, oppdatertUtenlandskPeriodebeløp)
 
+        // Assert
         // Forventer en liste på 2 elementer hvor det første dekker 2 mnd og det andre dekker fra mnd 3 og til uendelig (null). Det siste elementet skal ha beløp, valutakode og intervall satt til null, mens utbetalingsland skal være "SE".
         val faktiskUtenlandskPeriodebeløp = utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId)
 
@@ -150,6 +160,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kaste funksjonell feil dersom fom ikke er satt`() {
+        // Act & Assert
         val feilmelding =
             assertThrows<FunksjonellFeil> {
                 utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
@@ -168,6 +179,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kaste funksjonell feil dersom det forsøkes å settes fom fra og med 1 januar 2026 med valutakode BGN`() {
+        // Act & Assert
         val feilmelding =
             assertThrows<FunksjonellFeil> {
                 utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
@@ -186,6 +198,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kaste funksjonell feil dersom det forsøkes å settes tom fra og med 1 januar 2026 med valutakode BGN`() {
+        // Act & Assert
         val feilmelding =
             assertThrows<FunksjonellFeil> {
                 utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
@@ -204,6 +217,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal splitte utenlandskPeriodebeløp for Bulgarsk Lev til før og etter cut-off`() {
+        // Arrange
         val behandling = lagBehandling()
         val behandlingId = BehandlingId(behandling.id)
 
@@ -220,8 +234,10 @@ internal class UtenlandskPeriodebeløpServiceTest {
             .medIntervall(Intervall.MÅNEDLIG)
             .lagreTil(utenlandskPeriodebeløpRepository)
 
+        // Act
         utenlandskPeriodebeløpService.oppdaterBulgarskUtenlandskPeriodebeløpVedBehov(behandlingId)
 
+        // Assert
         val utenlandskPeriodebeløp = utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId)
 
         assertThat(utenlandskPeriodebeløp).hasSize(4)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/AutomatiskOppdaterValutakursUtilTest.kt
@@ -17,38 +17,48 @@ class AutomatiskOppdaterValutakursUtilTest {
 
     @Test
     fun `finnFørsteEndringIValutakurs skal returnere TIDENES_ENDE hvis begge er tomme`() {
+        // Arrange
         val valutakurserDenneBehandling = emptyList<Valutakurs>()
         val valutakurserForrigeBehandling = emptyList<Valutakurs>()
 
+        // Act
         val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
 
+        // Assert
         assertThat(actual).isEqualTo(TIDENES_ENDE.toYearMonth())
     }
 
     @Test
     fun `finnFørsteEndringIValutakurs skal returnere første endring`() {
+        // Arrange
         val fom = YearMonth.now()
         val valutakurserDenneBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(1)))
         val valutakurserForrigeBehandling = emptyList<Valutakurs>()
 
+        // Act
         val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
 
+        // Assert
         assertThat(actual).isEqualTo(fom)
     }
 
     @Test
     fun `finnFørsteEndringIValutakurs skal returnere TIDENES_ENDE hvis ingen endringer`() {
+        // Arrange
         val fom = YearMonth.now()
         val valutakurserDenneBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(1)))
         val valutakurserForrigeBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(1)))
 
+        // Act
         val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
 
+        // Assert
         assertThat(actual).isEqualTo(TIDENES_ENDE.toYearMonth())
     }
 
     @Test
     fun `finnFørsteEndringIValutakurs skal returnere første endring i tidslinje med endring`() {
+        // Arrange
         val fom = YearMonth.now()
         val valutakurserDenneBehandling = listOf(valutakurs(fom = fom, tom = fom.plusMonths(2), kurs = BigDecimal.ONE))
         val valutakurserForrigeBehandling =
@@ -58,8 +68,11 @@ class AutomatiskOppdaterValutakursUtilTest {
             )
 
         val expected = fom.plusMonths(2)
+
+        // Act
         val actual = finnFørsteEndringIValutakurs(valutakurserDenneBehandling, valutakurserForrigeBehandling)
 
+        // Assert
         assertThat(actual).isEqualTo(expected)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
@@ -28,6 +28,7 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
 
     @Test
     fun `test tilpasning av valutakurser mot kompleks endring av utenlandsk valutabeløp`() {
+        // Arrange
         val gjeldendeValutakurser =
             ValutakursBuilder(jan2020)
                 .medKurs("--3456789-----", "EUR", barn1, barn2)
@@ -48,14 +49,17 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .medKurs("      -    ", "DKK", barn1, barn3)
                 .bygg()
 
+        // Act
         val faktiskeValutakurser =
             tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, inneværendeMåned)
 
+        // Assert
         assertEqualsUnordered(forventedeValutakurser, faktiskeValutakurser)
     }
 
     @Test
     fun `test at endret valuta i utenlandsk periodebeløp fører til endring i valutakurs`() {
+        // Arrange
         val gjeldendeValutakurser =
             ValutakursBuilder(jan2020)
                 .medKurs("333333", "EUR", barn1)
@@ -71,14 +75,17 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .medKurs("$$$$$$", "DKK", barn1)
                 .bygg()
 
+        // Act
         val faktiskeValutakurser =
             tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, inneværendeMåned)
 
+        // Assert
         assertEqualsUnordered(forventedeValutakurser, faktiskeValutakurser)
     }
 
     @Test
     fun `test at ikke fremtidige valutakurser genereres`() {
+        // Arrange
         val gjeldendeValutakurser =
             ValutakursBuilder(nov2020)
                 .medKurs("12345", "PLN", barn1)
@@ -94,9 +101,11 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .medKurs("123", "PLN", barn1)
                 .bygg()
 
+        // Act
         val faktiskeValutakurser =
             tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp, inneværendeMåned)
 
+        // Assert
         assertThat(faktiskeValutakurser).isEqualTo(forventedeValutakurser)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursControllerTest.kt
@@ -55,66 +55,91 @@ class ValutakursControllerTest {
 
     @Test
     fun `Test at valutakurs hentes fra ECB dersom dato og valuta er satt`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
         val valuta = "SEK"
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
                 valutakursDto.copy(valutakursdato = valutakursDato, valutakode = valuta),
             )
         }
+
+        // Assert
         verify(exactly = 1) { ecbService.hentValutakurs("SEK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
     fun `Test at valutakurs ikke hentes fra ECB dersom dato ikke er satt`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
                 valutakursDto.copy(valutakode = "SEK"),
             )
         }
+
+        // Assert
         verify(exactly = 0) { ecbService.hentValutakurs("SEK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
     fun `Test at valutakurs ikke hentes fra ECB dersom valuta ikke er satt`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
                 valutakursDto.copy(valutakursdato = valutakursDato),
             )
         }
+
+        // Assert
         verify(exactly = 0) { ecbService.hentValutakurs("SEK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
     fun `Test at valutakurs ikke hentes fra ECB dersom ISK og før 1 feb 2018`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2018, 1, 31)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
                 valutakursDto.copy(valutakursdato = valutakursDato, valutakode = "ISK"),
             )
         }
+
+        // Assert
         verify(exactly = 0) { ecbService.hentValutakurs("ISK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
     fun `Test at valutakurs hentes fra ECB dersom ISK og etter 1 feb 2018`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2018, 2, 1)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
                 valutakursDto.copy(valutakursdato = valutakursDato, valutakode = "ISK"),
             )
         }
+
+        // Assert
         verify(exactly = 1) { ecbService.hentValutakurs("ISK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursServiceTest.kt
@@ -52,6 +52,7 @@ internal class ValutakursServiceTest {
 
     @Test
     fun `skal tilpasse utenlandsk periodebeløp til endrede kompetanser`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).toLocalDate())
@@ -69,8 +70,10 @@ internal class ValutakursServiceTest {
 
         every { utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId.id) } returns utenlandskePeriodebeløp
 
+        // Act
         tilpassValutakurserTilUtenlandskePeriodebeløpService.tilpassValutakursTilUtenlandskPeriodebeløp(behandlingId)
 
+        // Assert
         val faktiskeValutakurser = valutakursService.hentValutakurser(behandlingId)
 
         val forventedeValutakurser =
@@ -83,6 +86,7 @@ internal class ValutakursServiceTest {
 
     @Test
     fun `slette et valutakurs-skjema skal resultere i et skjema uten innhold, men som fortsatt har valutakoden`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val lagretValutakurs =
@@ -100,8 +104,10 @@ internal class ValutakursServiceTest {
                     ).medBehandlingId(behandlingId),
                 ).single()
 
+        // Act
         valutakursService.slettValutakurs(behandlingId, lagretValutakurs.id)
 
+        // Assert
         val faktiskValutakurs = valutakursService.hentValutakurser(behandlingId).single()
 
         assertEquals("EUR", faktiskValutakurs.valutakode)
@@ -115,6 +121,7 @@ internal class ValutakursServiceTest {
 
     @Test
     fun `skal kunne lukke åpen valutakurs ved å sende inn identisk skjema med til-og-med-dato`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
 
@@ -125,8 +132,11 @@ internal class ValutakursServiceTest {
 
         // Endrer kun til-og-med dato fra uendelig (null) til en gitt dato
         val oppdatertKompetanse = valutakurs(jan(2020), "444", "EUR", barn1)
+
+        // Act
         valutakursService.oppdaterValutakurs(behandlingId, oppdatertKompetanse)
 
+        // Assert
         // Forventer skjema uten innhold (MEN MED VALUTAKODE) fra oppdatert dato og fremover
         val forventedeValutakurser =
             ValutakursBuilder(jan(2020), behandlingId)
@@ -139,6 +149,7 @@ internal class ValutakursServiceTest {
 
     @Test
     fun `skal kunne oppdatere valutakurs sin vurderingsform fra manuel til automatisk`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
 
@@ -153,8 +164,11 @@ internal class ValutakursServiceTest {
                 .medVurderingsform(Vurderingsform.AUTOMATISK)
                 .bygg()
                 .single()
+
+        // Act
         valutakursService.oppdaterValutakurs(behandlingId, oppdatertKompetanse)
 
+        // Assert
         val forventedeValutakurser =
             ValutakursBuilder(jan(2020), behandlingId)
                 .medKurs("4", "EUR", barn1)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursTest.kt
@@ -15,13 +15,16 @@ class ValutakursTest {
     inner class `Valider at erObligatoriskeFelterSatt` {
         @Test
         fun `gir false ved tom valutakurs`() {
+            // Arrange
             val tomValutakurs = lagValutakurs()
 
+            // Act & Assert
             assertThat(tomValutakurs.erObligatoriskeFelterSatt()).isFalse()
         }
 
         @Test
         fun `gir false dersom fom ikke er satt`() {
+            // Arrange
             val valutakursUtenFom =
                 lagValutakurs(
                     valutakode = "NOK",
@@ -31,11 +34,13 @@ class ValutakursTest {
                     barnAktører = setOf(randomAktør()),
                 )
 
+            // Act & Assert
             assertThat(valutakursUtenFom.erObligatoriskeFelterSatt()).isFalse()
         }
 
         @Test
         fun `gir false dersom valutakode ikke er satt`() {
+            // Arrange
             val valutakursUtenValutakode =
                 lagValutakurs(
                     fom = LocalDate.now().toYearMonth(),
@@ -45,11 +50,13 @@ class ValutakursTest {
                     barnAktører = setOf(randomAktør()),
                 )
 
+            // Act & Assert
             assertThat(valutakursUtenValutakode.erObligatoriskeFelterSatt()).isFalse()
         }
 
         @Test
         fun `gir false dersom kurs ikke er satt`() {
+            // Arrange
             val valutakursUtenKurs =
                 lagValutakurs(
                     fom = LocalDate.now().toYearMonth(),
@@ -59,11 +66,13 @@ class ValutakursTest {
                     barnAktører = setOf(randomAktør()),
                 )
 
+            // Act & Assert
             assertThat(valutakursUtenKurs.erObligatoriskeFelterSatt()).isFalse()
         }
 
         @Test
         fun `gir false dersom valutakursdato ikke er satt`() {
+            // Arrange
             val valutakursUtenValutakursdato =
                 lagValutakurs(
                     fom = LocalDate.now().toYearMonth(),
@@ -73,11 +82,13 @@ class ValutakursTest {
                     barnAktører = setOf(randomAktør()),
                 )
 
+            // Act & Assert
             assertThat(valutakursUtenValutakursdato.erObligatoriskeFelterSatt()).isFalse()
         }
 
         @Test
         fun `gir false dersom vurderingsform ikke er satt`() {
+            // Arrange
             val valutakursUtenVurderingsform =
                 lagValutakurs(
                     fom = LocalDate.now().toYearMonth(),
@@ -88,11 +99,13 @@ class ValutakursTest {
                     vurderingsform = Vurderingsform.IKKE_VURDERT,
                 )
 
+            // Act & Assert
             assertThat(valutakursUtenVurderingsform.erObligatoriskeFelterSatt()).isFalse()
         }
 
         @Test
         fun `gir false dersom barnAktører er tomt sett`() {
+            // Arrange
             val valutakursUtenBarn =
                 lagValutakurs(
                     fom = LocalDate.now().toYearMonth(),
@@ -103,11 +116,13 @@ class ValutakursTest {
                     vurderingsform = Vurderingsform.MANUELL,
                 )
 
+            // Act & Assert
             assertThat(valutakursUtenBarn.erObligatoriskeFelterSatt()).isFalse()
         }
 
         @Test
         fun `gir true dersom obligatoriske felter er satt`() {
+            // Arrange
             val valutakursMedObligatoriskeFelter =
                 lagValutakurs(
                     fom = LocalDate.now().toYearMonth(),
@@ -118,6 +133,7 @@ class ValutakursTest {
                     vurderingsform = Vurderingsform.MANUELL,
                 )
 
+            // Act & Assert
             assertThat(valutakursMedObligatoriskeFelter.erObligatoriskeFelterSatt()).isTrue()
         }
     }
@@ -126,14 +142,17 @@ class ValutakursTest {
     inner class `Valider måValutakurserOppdateresForMåned` {
         @Test
         fun `gir true når det ikke er noen valutakurser`() {
+            // Arrange
             val måned = LocalDate.now().toYearMonth()
             val valutakurser = listOf<Valutakurs>()
 
+            // Act & Assert
             assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isTrue()
         }
 
         @Test
         fun `gir false når alle valutakurser er oppdatert for gitt måned`() {
+            // Arrange
             val måned = LocalDate.now().toYearMonth()
 
             val valutakurs1 =
@@ -154,11 +173,13 @@ class ValutakursTest {
 
             val valutakurser = listOf(valutakurs1, valutakurs2)
 
+            // Act & Assert
             assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isFalse()
         }
 
         @Test
         fun `gir true når minst én valutakurs ikke er oppdatert for gitt måned`() {
+            // Arrange
             val måned = LocalDate.now().toYearMonth()
 
             val valutakurs1 =
@@ -179,11 +200,13 @@ class ValutakursTest {
 
             val valutakurser = listOf(valutakurs1, valutakurs2)
 
+            // Act & Assert
             assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isTrue()
         }
 
         @Test
         fun `gir true når en valutakurs har feil valutakursdato for gitt måned`() {
+            // Arrange
             val måned = LocalDate.now().toYearMonth()
 
             val valutakurs =
@@ -196,6 +219,7 @@ class ValutakursTest {
 
             val valutakurser = listOf(valutakurs)
 
+            // Act & Assert
             assertThat(valutakurser.måValutakurserOppdateresForMåned(måned)).isTrue()
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/TidslinjerTest.kt
@@ -40,6 +40,7 @@ import java.time.YearMonth
 internal class TidslinjerTest {
     @Test
     fun `lag en søker med to barn og mye kompleksitet i vilkårsvurderingen`() {
+        // Arrange
         val barnsFødselsdato = 13.jan(2020)
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
@@ -77,12 +78,14 @@ internal class TidslinjerTest {
             .byggPerson()
         val barn2Result = "?EE!!!E!!EEEEEEEEEEE".tilRegelverkResultatTidslinje(startMånedRegelverk)
 
+        // Act
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingTidslinjer(
                 vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
                 søkerOgBarn = lagTestPersonopplysningGrunnlag(behandling.id, søker, barn1, barn2).tilPersonEnkelSøkerOgBarn(),
             )
 
+        // Assert
         assertEquals(søkerResult, vilkårsvurderingTidslinjer.søkersTidslinje().regelverkResultatTidslinje)
         assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
         assertEquals(barn2Result, vilkårsvurderingTidslinjer.forBarn(barn2).regelverkResultatTidslinje)
@@ -90,6 +93,7 @@ internal class TidslinjerTest {
 
     @Test
     fun `lag en søker med ett barn og søker går fra EØS-regelverk til nasjonalt`() {
+        // Arrange
         val barnsFødselsdato = 13.jan(2020)
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
@@ -116,18 +120,21 @@ internal class TidslinjerTest {
             .byggPerson()
         val barn1Result = "?????!!!!!EE!!!?????".tilRegelverkResultatTidslinje(startMånedRegelverk)
 
+        // Act
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingTidslinjer(
                 vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
                 søkerOgBarn = lagTestPersonopplysningGrunnlag(behandling.id, søker, barn1).tilPersonEnkelSøkerOgBarn(),
             )
 
+        // Assert
         assertEquals(søkerResult, vilkårsvurderingTidslinjer.søkersTidslinje().regelverkResultatTidslinje)
         assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
     }
 
     @Test
     fun `Virkningstidspunkt for vilkårsvurdering varer frem til måneden før barnet fyller 18 år`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019))
 
@@ -146,6 +153,7 @@ internal class TidslinjerTest {
                 .medVilkår("+>", GIFT_PARTNERSKAP)
                 .byggPerson()
 
+        // Act
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingTidslinjer(
                 vilkårsvurdering = vilkårsvurderingBygger.byggVilkårsvurdering(),
@@ -154,6 +162,7 @@ internal class TidslinjerTest {
                         .tilPersonEnkelSøkerOgBarn(),
             )
 
+        // Assert
         assertEquals(
             barn1.fødselsdato
                 .til18ÅrsVilkårsdato()
@@ -170,6 +179,7 @@ internal class TidslinjerTest {
 
     @Test
     fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS i månedsskiftet`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019))
 
@@ -191,6 +201,7 @@ internal class TidslinjerTest {
                 (1.mai(2020)..1.mai(2020)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, EØS_FORORDNINGEN) },
             )
 
+        // Act
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingBuilder()
                 .forPerson(søker, 30.apr(2020))
@@ -204,6 +215,7 @@ internal class TidslinjerTest {
                 .medVilkår(borMedSøker)
                 .byggVilkårsvurderingTidslinjer()
 
+        // Assert
         val barn1Result = "E".tilRegelverkResultatTidslinje(YearMonth.of(2020, 5))
 
         assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
@@ -211,6 +223,7 @@ internal class TidslinjerTest {
 
     @Test
     fun `Sjekk overgang fra oppfylt EØS til oppfylt nasjonalt i månedsskiftet`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019))
 
@@ -232,6 +245,7 @@ internal class TidslinjerTest {
                 (1.mai(2020)..1.mai(2020)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, NASJONALE_REGLER) },
             )
 
+        // Act
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingBuilder()
                 .forPerson(søker, 30.apr(2020))
@@ -245,6 +259,7 @@ internal class TidslinjerTest {
                 .medVilkår(borMedSøker)
                 .byggVilkårsvurderingTidslinjer()
 
+        // Assert
         val barn1Result = "N".tilRegelverkResultatTidslinje(YearMonth.of(2020, 5))
 
         assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
@@ -252,6 +267,7 @@ internal class TidslinjerTest {
 
     @Test
     fun `Sjekk overgang fra oppfylt EØS til oppfylt blandet i månedsskiftet`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019))
 
@@ -265,6 +281,7 @@ internal class TidslinjerTest {
                 (1.mai(2020)..1.mai(2020)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, NASJONALE_REGLER) },
             )
 
+        // Act
         val vilkårsvurderingTidslinjer =
             VilkårsvurderingBuilder()
                 .forPerson(søker, 30.apr(2020))
@@ -278,6 +295,7 @@ internal class TidslinjerTest {
                 .medVilkår(borMedSøker)
                 .byggVilkårsvurderingTidslinjer()
 
+        // Assert
         val barn1Result = "!".tilRegelverkResultatTidslinje(YearMonth.of(2020, 5))
 
         assertEquals(barn1Result, vilkårsvurderingTidslinjer.forBarn(barn1).regelverkResultatTidslinje)
@@ -285,6 +303,7 @@ internal class TidslinjerTest {
 
     @Test
     fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS dagen før siste dag i måneden`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019))
 
@@ -308,6 +327,7 @@ internal class TidslinjerTest {
                 (30.apr(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, EØS_FORORDNINGEN) },
             )
 
+        // Act
         val barnaRegelverkTidslinjer =
             VilkårsvurderingBuilder()
                 .forPerson(søker, 26.jan(2020))
@@ -330,6 +350,7 @@ internal class TidslinjerTest {
                 inneværendeMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(1, kompetanser.size)
         assertEquals(YearMonth.of(2021, 5), kompetanser.first().fom)
         assertEquals(YearMonth.of(2021, 11), kompetanser.first().tom)
@@ -337,6 +358,7 @@ internal class TidslinjerTest {
 
     @Test
     fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS dagen andre dag i måneden`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019))
 
@@ -360,6 +382,7 @@ internal class TidslinjerTest {
                 (2.mai(2021)..30.nov(2021)).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, EØS_FORORDNINGEN) },
             )
 
+        // Act
         val barnaRegelverkTidslinjer =
             VilkårsvurderingBuilder()
                 .forPerson(søker, 26.jan(2020))
@@ -382,6 +405,7 @@ internal class TidslinjerTest {
                 inneværendeMåned = YearMonth.now(),
             )
 
+        // Assert
         val forventetRegelverkResultat =
             "NNNNNNNNNNNNNNNNEEEEEE".tilRegelverkResultatTidslinje(feb(2020))
 
@@ -393,6 +417,7 @@ internal class TidslinjerTest {
 
     @Test
     fun `Sjekk overgang fra oppfylt nasjonalt til oppfylt EØS dagen før siste dag i måneden, der siste periode er uendelig`() {
+        // Arrange
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = 14.des(2019))
 
@@ -416,6 +441,7 @@ internal class TidslinjerTest {
                 (30.apr(2021)..uendelig).tilTidslinje { oppfyltVilkår(BOR_MED_SØKER, EØS_FORORDNINGEN) },
             )
 
+        // Act
         val barnaRegelverkTidslinjer =
             VilkårsvurderingBuilder()
                 .forPerson(søker, 26.jan(2020))
@@ -438,6 +464,7 @@ internal class TidslinjerTest {
                 inneværendeMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(1, kompetanser.size)
         assertEquals(YearMonth.of(2021, 5), kompetanser.first().fom)
         assertNull(kompetanser.first().tom)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsresultatMånedTidslinjeTest.kt
@@ -23,8 +23,13 @@ import org.junit.jupiter.api.Test
 class VilkårsresultatMånedTidslinjeTest {
     @Test
     fun `Virkningstidspunkt fra vilkårsvurdering er måneden etter at normalt vilkår er oppfylt`() {
+        // Arrange
         val dagTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), 15.apr(2022), 14.apr(2040)).tilTidslinje()
+
+        // Act
         val faktiskMånedTidslinje = dagTidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+
+        // Assert
         val forventetMånedTidslinje =
             periode(oppfyltVilkår(BOSATT_I_RIKET), mai(2022), apr(2040)).tilTidslinje().tilMåned { it.first() }
 
@@ -33,8 +38,11 @@ class VilkårsresultatMånedTidslinjeTest {
 
     @Test
     fun `Back to back perioder i månedsskiftet gir sammenhengende perioder`() {
+        // Arrange
         val periodeFom = 15.apr(2022)
         val periodeFom2 = 1.jul(2022)
+
+        // Act
         val faktiskMånedTidslinje =
             listOf(
                 lagVilkårResultat(
@@ -50,6 +58,7 @@ class VilkårsresultatMånedTidslinjeTest {
             ).tilVilkårRegelverkResultatTidslinje()
                 .tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
 
+        // Assert
         val forventetMånedTidslinje =
             periode(oppfyltVilkår(BOSATT_I_RIKET), mai(2022), null).tilTidslinje().tilMåned { it.first() }
 
@@ -58,8 +67,13 @@ class VilkårsresultatMånedTidslinjeTest {
 
     @Test
     fun `Siste dag fom-måned og første dag i tom-måned gir oppfylt fra neste måned`() {
+        // Arrange
         val dagTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), 29.feb(2020), 1.mai(2020)).tilTidslinje()
+
+        // Act
         val faktiskMånedstidslinje = dagTidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+
+        // Assert
         val forventetMånedTidslinje =
             periode(oppfyltVilkår(BOSATT_I_RIKET), mar(2020), mai(2020)).tilTidslinje().tilMåned { it.first() }
 
@@ -68,14 +82,17 @@ class VilkårsresultatMånedTidslinjeTest {
 
     @Test
     fun `Bytte av regelverk innen en måned skal gi kontinuerlig oppfylt tidslinje`() {
+        // Arrange
         val dagvilkårtidslinje =
             konkatenerTidslinjer(
                 periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), 26.feb(2020), 7.mar(2020)).tilTidslinje(),
                 periode(oppfyltVilkår(BOSATT_I_RIKET, NASJONALE_REGLER), 21.mar(2020), 13.mai(2020)).tilTidslinje(),
             )
 
+        // Act
         val faktiskMånedstidslinje = dagvilkårtidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
 
+        // Assert
         val forventetMånedstidslinje =
             konkatenerTidslinjer(
                 periode(oppfyltVilkår(BOSATT_I_RIKET, EØS_FORORDNINGEN), mar(2020), mar(2020)).tilTidslinje(),
@@ -87,8 +104,13 @@ class VilkårsresultatMånedTidslinjeTest {
 
     @Test
     fun `Hvis vilkåret er oppfylt siste dag i måneden, skal kun gi oppfylt frem til og med den måneden`() {
+        // Arrange
         val dagTidslinje = periode(oppfyltVilkår(BOSATT_I_RIKET), 15.apr(2022), 30.nov(2022)).tilTidslinje()
+
+        // Act
         val faktiskMånedTidslinje = dagTidslinje.tilMånedsbasertTidslinjeForVilkårRegelverkResultat()
+
+        // Assert
         val forventetMånedTidslinje =
             periode(oppfyltVilkår(BOSATT_I_RIKET), mai(2022), nov(2022)).tilTidslinje().tilMåned { it.first() }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -43,6 +43,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
 
     @Test
     fun `skal forskyve fom med 1 mnd for periode med erAnnenForelderOmfattetAvNorskLovgivning`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val barn = lagPerson(type = PersonType.BARN)
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -76,16 +77,19 @@ internal class VilkårsvurderingTidslinjeServiceTest {
             )
         every { vilkårsvurderingService.hentAktivForBehandlingThrows(behandlingId = behandling.id) } returns vilkårsvurdering
 
+        // Act
         val faktiskTidslinje =
             vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(
                 behandlingId = BehandlingId(behandling.id),
             )
+        // Assert
         val forventetTidslinje = "++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023))
         assertThat(faktiskTidslinje).isEqualTo(forventetTidslinje)
     }
 
     @Test
     fun `skal ikke gi noen oppfylte perioder hvis vilkår kun oppfylt innenfor én måned`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val barn = lagPerson(type = PersonType.BARN)
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -119,16 +123,19 @@ internal class VilkårsvurderingTidslinjeServiceTest {
             )
         every { vilkårsvurderingService.hentAktivForBehandlingThrows(behandlingId = behandling.id) } returns vilkårsvurdering
 
+        // Act
         val faktiskTidslinje =
             vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(
                 behandlingId = BehandlingId(behandling.id),
             )
 
+        // Assert
         assertThat(faktiskTidslinje.erTom()).isTrue
     }
 
     @Test
     fun `skal forskyve fom med 1 mnd for flere perioder med erAnnenForelderOmfattetAvNorskLovgivning`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val barn = lagPerson(type = PersonType.BARN)
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -170,10 +177,12 @@ internal class VilkårsvurderingTidslinjeServiceTest {
             )
         every { vilkårsvurderingService.hentAktivForBehandlingThrows(behandlingId = behandling.id) } returns vilkårsvurdering
 
+        // Act
         val faktiskTidslinje =
             vilkårsvurderingTidslinjeService
                 .hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId = BehandlingId(behandling.id))
 
+        // Assert
         val forventetTidslinje = "++ +++".tilAnnenForelderOmfattetAvNorskLovgivningTidslinje(feb(2023))
 
         assertThat(faktiskTidslinje).isEqualTo(forventetTidslinje)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjerTest.kt
@@ -21,6 +21,7 @@ import java.time.LocalDate
 internal class VilkårsvurderingTidslinjerTest {
     @Test
     fun `et vilkår kan ha overlappende vilkårsresultater hvis bare ett er oppfylt`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val barn2Fnr = randomFnr()
@@ -59,6 +60,7 @@ internal class VilkårsvurderingTidslinjerTest {
             )
         }
 
+        // Act & Assert
         assertDoesNotThrow {
             VilkårsvurderingTidslinjer(
                 vilkårsvurdering = vilkårsvurdering,
@@ -71,6 +73,7 @@ internal class VilkårsvurderingTidslinjerTest {
 
     @Test
     fun `kan ikke ha to overlappende vilkårsresultater hvis begge er oppfylt`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val barn2Fnr = randomFnr()
@@ -106,6 +109,7 @@ internal class VilkårsvurderingTidslinjerTest {
             )
         }
 
+        // Act & Assert
         assertThrows<IllegalStateException> {
             VilkårsvurderingTidslinjer(
                 vilkårsvurdering = vilkårsvurdering,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
@@ -21,6 +21,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
     @Test
     fun `Endring i endret utbetaling andel - skal ikke ha endret periode hvis årsak endres mellom etterbetaling 3 år og 3 mnd`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -34,6 +35,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         val nåværendeEndretAndel = forrigeEndretAndel.copy(årsak = Årsak.ETTERBETALING_3MND)
 
+        // Act
         val perioderMedEndring =
             EndringIEndretUtbetalingAndelUtil
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -42,11 +44,13 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i endret utbetaling andel - skal ha endret periode hvis årsak endres til noe annet enn etterbetaling`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -60,6 +64,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         val nåværendeEndretAndel = forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)
 
+        // Act
         val perioderMedEndring =
             EndringIEndretUtbetalingAndelUtil
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -68,6 +73,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(1, perioderMedEndring.size)
         assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
         assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
@@ -75,6 +81,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
     @Test
     fun `Endring i endret utbetaling andel - skal ikke ha noen endrede perioder hvis kun prosent er endret`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -89,6 +96,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         val nåværendeEndretAndel = forrigeEndretAndel.copy(prosent = BigDecimal(100))
 
+        // Act
         val perioderMedEndring =
             EndringIEndretUtbetalingAndelUtil
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -97,11 +105,13 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i endret utbetaling andel - skal ikke ha noen endrede perioder hvis kun søknadstidspunkt er endret og den var allerede satt før`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -116,6 +126,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         val nåværendeEndretAndel = forrigeEndretAndel.copy(søknadstidspunkt = jan22.førsteDagIInneværendeMåned())
 
+        // Act
         val perioderMedEndring =
             EndringIEndretUtbetalingAndelUtil
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -124,11 +135,13 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i endret utbetaling andel - skal ha noen endrede perioder hvis søknadstidspunkt ikke var satt tidligere men er nå satt`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -143,6 +156,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         val nåværendeEndretAndel = forrigeEndretAndel.copy(søknadstidspunkt = jan22.førsteDagIInneværendeMåned())
 
+        // Act
         val perioderMedEndring =
             EndringIEndretUtbetalingAndelUtil
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -151,6 +165,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(1, perioderMedEndring.size)
         assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
         assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
@@ -158,6 +173,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
     @Test
     fun `Endring i endret utbetaling andel - skal ikke returnere endret periode hvis et av to barn kun har endring mellom etterbetalingsårsaker`() {
+        // Arrange
         val barn1 = lagPerson(type = PersonType.BARN)
         val barn2 = lagPerson(type = PersonType.BARN)
 
@@ -182,6 +198,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
             )
 
+        // Act
         val perioderMedEndring =
             listOf(barn1, barn2)
                 .map { person ->
@@ -192,11 +209,13 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 }.flatMap { it.tilPerioder() }
                 .filter { it.verdi == true }
 
+        // Assert
         assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i endret utbetaling andel - skal returnere endret periode hvis et barn har reell endring selv om et annet barn kun har endring mellom etterbetalingsårsaker`() {
+        // Arrange
         val barn1 = lagPerson(type = PersonType.BARN)
         val barn2 = lagPerson(type = PersonType.BARN)
 
@@ -221,6 +240,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 søknadstidspunkt = des22.førsteDagIInneværendeMåned(),
             )
 
+        // Act
         val perioderMedEndring =
             listOf(barn1, barn2)
                 .map {
@@ -231,6 +251,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 }.flatMap { it.tilPerioder() }
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(1, perioderMedEndring.size)
         assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
         assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
@@ -238,6 +259,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
     @Test
     fun `Endring i endret utbetaling andel - skal noen endrede perioder hvis eneste endring er at perioden blir lenger`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -252,6 +274,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         val nåværendeEndretAndel = forrigeEndretAndel.copy(tom = des22)
 
+        // Act
         val perioderMedEndring =
             EndringIEndretUtbetalingAndelUtil
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -260,6 +283,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(1, perioderMedEndring.size)
         assertEquals(sep22, perioderMedEndring.single().fom?.toYearMonth())
         assertEquals(des22, perioderMedEndring.single().tom?.toYearMonth())
@@ -267,6 +291,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
     @Test
     fun `Endring i endret utbetaling andel - skal ha endrede perioder hvis endringsperiode oppstår i nåværende behandling`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN)
         val nåværendeEndretAndel =
             lagEndretUtbetalingAndel(
@@ -279,6 +304,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 avtaletidspunktDeltBosted = jan22.førsteDagIInneværendeMåned(),
             )
 
+        // Act
         val perioderMedEndring =
             EndringIEndretUtbetalingAndelUtil
                 .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -287,6 +313,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(1, perioderMedEndring.size)
         assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
         assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIKompetanseUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIKompetanseUtilTest.kt
@@ -18,6 +18,7 @@ class EndringIKompetanseUtilTest {
 
     @Test
     fun `Endring i kompetanse - skal ikke returnere noen endrede perioder når ingenting endrer seg`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
@@ -36,6 +37,7 @@ class EndringIKompetanseUtilTest {
 
         val nåværendeKompetanse = forrigeKompetanse.copy().apply { behandlingId = nåværendeBehandling.id }
 
+        // Act
         val perioderMedEndring =
             EndringIKompetanseUtil
                 .lagEndringIKompetanseForPersonTidslinje(
@@ -44,11 +46,13 @@ class EndringIKompetanseUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i kompetanse - skal returnere endret periode når søkers aktivitetsland endrer seg`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
@@ -68,6 +72,7 @@ class EndringIKompetanseUtilTest {
         val nåværendeKompetanse =
             forrigeKompetanse.copy(søkersAktivitetsland = "DK").apply { behandlingId = nåværendeBehandling.id }
 
+        // Act
         val perioderMedEndring =
             EndringIKompetanseUtil
                 .lagEndringIKompetanseForPersonTidslinje(
@@ -79,6 +84,7 @@ class EndringIKompetanseUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertEquals(1, perioderMedEndring.size)
         Assertions.assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
         Assertions.assertEquals(mai22, perioderMedEndring.single().tom?.toYearMonth())
@@ -86,6 +92,7 @@ class EndringIKompetanseUtilTest {
 
     @Test
     fun `Endring i kompetanse - skal ikke lage endret periode når det kun blir lagt på en ekstra kompetanseperiode`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
@@ -107,6 +114,7 @@ class EndringIKompetanseUtilTest {
                 .copy(fom = YearMonth.now().minusMonths(10))
                 .apply { behandlingId = nåværendeBehandling.id }
 
+        // Act
         val perioderMedEndring =
             EndringIKompetanseUtil
                 .lagEndringIKompetanseForPersonTidslinje(
@@ -118,11 +126,13 @@ class EndringIKompetanseUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i kompetanse - skal ikke lage endret periode når forrige kompetanse ikke er utfylt (pga migrering+ evt autovedtak)`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
@@ -153,6 +163,7 @@ class EndringIKompetanseUtilTest {
                 tom = null,
             )
 
+        // Act
         val perioderMedEndring =
             EndringIKompetanseUtil
                 .lagEndringIKompetanseForPersonTidslinje(
@@ -164,6 +175,7 @@ class EndringIKompetanseUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertTrue(perioderMedEndring.isEmpty())
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIUtbetalingUtilTest.kt
@@ -19,6 +19,7 @@ class EndringIUtbetalingUtilTest {
 
     @Test
     fun `Endring i beløp - Skal returnere periode med endring når ny andel med beløp større enn 0 er lagt til`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -53,6 +54,7 @@ class EndringIUtbetalingUtilTest {
                 ),
             )
 
+        // Act
         val perioderMedEndring =
             EndringIUtbetalingUtil
                 .lagEndringIUtbetalingTidslinje(
@@ -61,21 +63,25 @@ class EndringIUtbetalingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertEquals(1, perioderMedEndring.size)
         Assertions.assertEquals(sep22, perioderMedEndring.single().fom?.toYearMonth())
         Assertions.assertEquals(des22, perioderMedEndring.single().tom?.toYearMonth())
 
+        // Act
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                 nåværendeAndeler = nåværendeAndeler,
                 forrigeAndeler = forrigeAndeler,
             )
 
+        // Assert
         Assertions.assertEquals(sep22, endringstidspunkt)
     }
 
     @Test
     fun `Endring i beløp - Skal ikke gi noen perioder med endring hvis andelene er helt like forrige behandling og nå`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -95,6 +101,7 @@ class EndringIUtbetalingUtilTest {
                 ),
             )
 
+        // Act
         val perioderMedEndring =
             EndringIUtbetalingUtil
                 .lagEndringIUtbetalingTidslinje(
@@ -103,19 +110,23 @@ class EndringIUtbetalingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertTrue(perioderMedEndring.isEmpty())
 
+        // Act
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                 nåværendeAndeler = andeler,
                 forrigeAndeler = andeler,
             )
 
+        // Assert
         Assertions.assertNull(endringstidspunkt)
     }
 
     @Test
     fun `Endring i beløp - Skal returnere periode med endring hvis utvidet ikke er endret men småbarnstillegg kun er lagt på`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -159,6 +170,7 @@ class EndringIUtbetalingUtilTest {
                 ),
             )
 
+        // Act
         val perioderMedEndring =
             EndringIUtbetalingUtil
                 .lagEndringIUtbetalingTidslinje(
@@ -167,21 +179,25 @@ class EndringIUtbetalingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertEquals(1, perioderMedEndring.size)
         Assertions.assertEquals(mai22, perioderMedEndring.single().fom?.toYearMonth())
         Assertions.assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
 
+        // Act
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                 nåværendeAndeler = nåværendeAndeler,
                 forrigeAndeler = forrigeAndeler,
             )
 
+        // Assert
         Assertions.assertEquals(mai22, endringstidspunkt)
     }
 
     @Test
     fun `Endring i beløp - Skal returnere periode med endring hvis andel med beløp større enn 0 er fjernet`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -200,6 +216,7 @@ class EndringIUtbetalingUtilTest {
                 aktør = barn2Aktør,
             )
 
+        // Act
         val perioderMedEndring =
             EndringIUtbetalingUtil
                 .lagEndringIUtbetalingTidslinje(
@@ -208,21 +225,25 @@ class EndringIUtbetalingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertEquals(1, perioderMedEndring.size)
         Assertions.assertEquals(jan22, perioderMedEndring.single().fom?.toYearMonth())
         Assertions.assertEquals(aug22, perioderMedEndring.single().tom?.toYearMonth())
 
+        // Act
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                 nåværendeAndeler = listOf(andelBarn2),
                 forrigeAndeler = listOf(andelBarn2, andelBarn1),
             )
 
+        // Assert
         Assertions.assertEquals(jan22, endringstidspunkt)
     }
 
     @Test
     fun `Endring i beløp - Skal ikke returnere periode med endring hvis andel med 0 i beløp er fjernet`() {
+        // Arrange
         val barn1Aktør = lagPerson(type = PersonType.BARN).aktør
         val barn2Aktør = lagPerson(type = PersonType.BARN).aktør
 
@@ -241,6 +262,7 @@ class EndringIUtbetalingUtilTest {
                 aktør = barn2Aktør,
             )
 
+        // Act
         val perioderMedEndring =
             EndringIUtbetalingUtil
                 .lagEndringIUtbetalingTidslinje(
@@ -249,14 +271,17 @@ class EndringIUtbetalingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         Assertions.assertTrue(perioderMedEndring.isEmpty())
 
+        // Act
         val endringstidspunkt =
             EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                 nåværendeAndeler = listOf(andelBarn2),
                 forrigeAndeler = listOf(andelBarn2, andelBarn1),
             )
 
+        // Assert
         Assertions.assertNull(endringstidspunkt)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
@@ -28,6 +28,7 @@ import java.time.LocalDate
 class EndringIVilkårsvurderingUtilTest {
     @Test
     fun `Endring i vilkårsvurdering - skal ikke lage periode med endring dersom vilkårresultatene er helt like`() {
+        // Arrange
         val fødselsdato = LocalDate.of(2015, 1, 1)
         val vilkårResultater =
             setOf(
@@ -67,6 +68,7 @@ class EndringIVilkårsvurderingUtilTest {
 
         val person = lagPerson(aktør = aktør, type = PersonType.BARN, fødselsdato = fødselsdato)
 
+        // Act
         val perioderMedEndring =
             EndringIVilkårsvurderingUtil
                 .lagEndringIVilkårsvurderingTidslinje(
@@ -79,11 +81,13 @@ class EndringIVilkårsvurderingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere periode med endring dersom det har vært endringer i regelverk`() {
+        // Arrange
         val fødselsdato = 1.jan(2022)
         val nåværendeVilkårResultat =
             setOf(
@@ -126,6 +130,7 @@ class EndringIVilkårsvurderingUtilTest {
         val aktør = randomAktør()
         val person = lagPerson(aktør = aktør, type = PersonType.BARN, fødselsdato = fødselsdato)
 
+        // Act
         val perioderMedEndring =
             EndringIVilkårsvurderingUtil
                 .lagEndringIVilkårsvurderingTidslinje(
@@ -138,6 +143,7 @@ class EndringIVilkårsvurderingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(1, perioderMedEndring.size)
         assertEquals(1.feb(2022), perioderMedEndring.single().fom)
         assertEquals(31.mai(2022), perioderMedEndring.single().tom)
@@ -145,6 +151,7 @@ class EndringIVilkårsvurderingUtilTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal ikke bry seg om endringer utført før relevant fom dato`() {
+        // Arrange
         val fødselsdato = 1.jan(2022)
         val nåværendeVilkårResultat =
             setOf(
@@ -187,6 +194,7 @@ class EndringIVilkårsvurderingUtilTest {
         val aktør = randomAktør()
         val person = lagPerson(aktør = aktør, type = PersonType.BARN, fødselsdato = fødselsdato)
 
+        // Act
         val perioderMedEndring =
             EndringIVilkårsvurderingUtil
                 .lagEndringIVilkårsvurderingTidslinje(
@@ -199,11 +207,13 @@ class EndringIVilkårsvurderingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(0, perioderMedEndring.size)
     }
 
     @Test
     fun `Endring i vilkårsvurdering - skal returnere periode med endring dersom det har oppstått splitt i vilkårsvurderingen`() {
+        // Arrange
         val fødselsdato = 1.jan(2022)
         val forrigeVilkårResultat =
             setOf(
@@ -249,6 +259,7 @@ class EndringIVilkårsvurderingUtilTest {
         val aktør = randomAktør()
         val person = lagPerson(aktør = aktør, type = PersonType.BARN, fødselsdato = fødselsdato)
 
+        // Act
         val perioderMedEndring =
             EndringIVilkårsvurderingUtil
                 .lagEndringIVilkårsvurderingTidslinje(
@@ -261,6 +272,7 @@ class EndringIVilkårsvurderingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertEquals(1, perioderMedEndring.size)
         assertEquals(1.jun(2022), perioderMedEndring.single().fom)
         assertNull(perioderMedEndring.single().tom)
@@ -268,6 +280,7 @@ class EndringIVilkårsvurderingUtilTest {
 
     @Test
     fun `Endring i vilkårsvurdering - skal ikke lage periode med endring hvis det kun er opphørt`() {
+        // Arrange
         val fødselsdato = LocalDate.of(2015, 1, 1)
         val nåværendeVilkårResultat =
             setOf(
@@ -310,6 +323,7 @@ class EndringIVilkårsvurderingUtilTest {
         val aktør = randomAktør()
         val person = lagPerson(aktør = aktør, type = PersonType.BARN, fødselsdato = fødselsdato)
 
+        // Act
         val perioderMedEndring =
             EndringIVilkårsvurderingUtil
                 .lagEndringIVilkårsvurderingTidslinje(
@@ -322,11 +336,13 @@ class EndringIVilkårsvurderingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertTrue(perioderMedEndring.isEmpty())
     }
 
     @Test
     fun `Endring i vilkårsvurdering - skal ikke lage periode med endring hvis eneste endring er å sette obligatoriske utdypende vilkårsvurderinger`() {
+        // Arrange
         val fødselsdato = LocalDate.of(2015, 1, 1)
         val forrigeVilkårResultat =
             setOf(
@@ -364,6 +380,7 @@ class EndringIVilkårsvurderingUtilTest {
         val aktør = randomAktør()
         val person = lagPerson(aktør = aktør, type = PersonType.BARN, fødselsdato = fødselsdato)
 
+        // Act
         val perioderMedEndring =
             EndringIVilkårsvurderingUtil
                 .lagEndringIVilkårsvurderingTidslinje(
@@ -376,6 +393,7 @@ class EndringIVilkårsvurderingUtilTest {
                 ).tilPerioder()
                 .filter { it.verdi == true }
 
+        // Assert
         assertTrue(perioderMedEndring.isEmpty())
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadServiceTest.kt
@@ -59,6 +59,7 @@ class OvergangsstønadServiceTest {
     fun `Ved satsendring og månedlig valutajustering skal gamle perioder kopieres`(
         årsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val fagsak = Fagsak(aktør = søker.aktør)
         val forrigeBehandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD, fagsak = fagsak)
@@ -99,11 +100,13 @@ class OvergangsstønadServiceTest {
         val slot = slot<List<PeriodeOvergangsstønadGrunnlag>>()
         every { periodeOvergangsstønadGrunnlagRepository.saveAll(capture(slot)) } returnsArgument 0
 
+        // Act
         overgangsstønadService.hentOgLagrePerioderMedOvergangsstønadForBehandling(
             søkerAktør = søker.aktør,
             behandling = behandling,
         )
 
+        // Assert
         assertThat(slot.captured).containsAll(forventetNyePerioder)
         verify(exactly = 1) { periodeOvergangsstønadGrunnlagRepository.saveAll(forventetNyePerioder) }
         verify(exactly = 0) { efSakRestKlient.hentPerioderMedFullOvergangsstønad(any()) }
@@ -111,6 +114,7 @@ class OvergangsstønadServiceTest {
 
     @Test
     fun `Vanlige behandlinger skal hente perioder fra EF`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.NYE_OPPLYSNINGER)
         val søker = lagPerson(type = PersonType.SØKER)
 
@@ -138,11 +142,13 @@ class OvergangsstønadServiceTest {
         val slot = slot<List<PeriodeOvergangsstønadGrunnlag>>()
         every { periodeOvergangsstønadGrunnlagRepository.saveAll(capture(slot)) } returnsArgument 0
 
+        // Act
         overgangsstønadService.hentOgLagrePerioderMedOvergangsstønadForBehandling(
             søkerAktør = søker.aktør,
             behandling = behandling,
         )
 
+        // Assert
         verify(exactly = 1) { efSakRestKlient.hentPerioderMedFullOvergangsstønad(søker.aktør.aktivFødselsnummer()) }
         assertThat(slot.captured).containsExactly(
             forventetPeriode,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/overgangsstønad/OvergangsstønadUtilsTest.kt
@@ -35,9 +35,11 @@ class OvergangsstønadUtilsTest {
 
     @Test
     fun `Skal svare true om at nye perioder med full OS påvirker behandling`() {
+        // Arrange
         val personIdent = randomFnr()
         val barnAktør = lagAktør(randomFnr())
 
+        // Act
         val påvirkerFagsak =
             vedtakOmOvergangsstønadPåvirkerFagsak(
                 småbarnstilleggGenerator =
@@ -76,14 +78,17 @@ class OvergangsstønadUtilsTest {
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barnAktør, LocalDate.now().minusYears(2))),
             )
 
+        // Assert
         assertTrue(påvirkerFagsak)
     }
 
     @Test
     fun `Skal svare false om at nye perioder med full OS påvirker behandling`() {
+        // Arrange
         val personIdent = randomAktør()
         val barnIdent = randomAktør()
 
+        // Act
         val påvirkerFagsak =
             vedtakOmOvergangsstønadPåvirkerFagsak(
                 småbarnstilleggGenerator =
@@ -125,14 +130,17 @@ class OvergangsstønadUtilsTest {
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
             )
 
+        // Assert
         assertFalse(påvirkerFagsak)
     }
 
     @Test
     fun `Skal svare false om at nye perioder med full OS påvirker behandling ved flere perioder`() {
+        // Arrange
         val personIdent = randomAktør()
         val barnIdent = randomAktør()
 
+        // Act
         val påvirkerFagsak =
             vedtakOmOvergangsstønadPåvirkerFagsak(
                 småbarnstilleggGenerator =
@@ -193,14 +201,17 @@ class OvergangsstønadUtilsTest {
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
             )
 
+        // Assert
         assertFalse(påvirkerFagsak)
     }
 
     @Test
     fun `skal ikke behandle vedtak om overgangsstønad når vedtaket ikke fører til endring i utbetaling`() {
+        // Arrange
         val personIdent = randomAktør()
         val barnIdent = randomAktør()
 
+        // Act
         val påvirkerFagsak =
             vedtakOmOvergangsstønadPåvirkerFagsak(
                 småbarnstilleggGenerator =
@@ -247,14 +258,17 @@ class OvergangsstønadUtilsTest {
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
             )
 
+        // Assert
         assertFalse(påvirkerFagsak)
     }
 
     @Test
     fun `skal behandle vedtak om overgangsstønad når vedtaket fører til endring i utbetaling`() {
+        // Arrange
         val personIdent = randomAktør()
         val barnIdent = randomAktør()
 
+        // Act
         val påvirkerFagsak =
             vedtakOmOvergangsstønadPåvirkerFagsak(
                 småbarnstilleggGenerator =
@@ -301,6 +315,7 @@ class OvergangsstønadUtilsTest {
                 barnasAktørerOgFødselsdatoer = listOf(Pair(barnIdent, LocalDate.now().minusYears(2))),
             )
 
+        // Assert
         assertTrue(påvirkerFagsak)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/DødsfallTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/DødsfallTest.kt
@@ -21,43 +21,64 @@ class DødsfallTest {
     inner class Equals {
         @Test
         fun `skal returnere false hvis person er ulik`() {
+            // Arrange
             val annenDødsfall = dødsfall.copy(person = tilfeldigPerson())
+
+            // Act & Assert
             assert(dødsfall != annenDødsfall)
         }
 
         @Test
         fun `skal returnere false hvis dødsfallDato er ulik`() {
+            // Arrange
             val annenDødsfall = dødsfall.copy(dødsfallDato = LocalDate.now().minusDays(1))
+
+            // Act & Assert
             assert(dødsfall != annenDødsfall)
         }
 
         @Test
         fun `skal returnere false hvis dødsfallAdresse er ulik`() {
+            // Arrange
             val annenDødsfall = dødsfall.copy(dødsfallAdresse = "Testveien 2")
+
+            // Act & Assert
             assert(dødsfall != annenDødsfall)
         }
 
         @Test
         fun `skal returnere false hvis dødsfallPostnummer er ulik`() {
+            // Arrange
             val annenDødsfall = dødsfall.copy(dødsfallPostnummer = "4321")
+
+            // Act & Assert
             assert(dødsfall != annenDødsfall)
         }
 
         @Test
         fun `skal returnere false hvis dødsfallPoststed er ulik`() {
+            // Arrange
             val annenDødsfall = dødsfall.copy(dødsfallPoststed = "Ingensteds")
+
+            // Act & Assert
             assert(dødsfall != annenDødsfall)
         }
 
         @Test
         fun `skal returnere false hvis manuellRegistrert er ulik`() {
+            // Arrange
             val annenDødsfall = dødsfall.copy(manuellRegistrert = true)
+
+            // Act & Assert
             assert(dødsfall != annenDødsfall)
         }
 
         @Test
         fun `skal returnere true hvis alle felter er like`() {
+            // Arrange
             val annenDødsfall = dødsfall.copy(id = 1)
+
+            // Act & Assert
             assert(dødsfall == annenDødsfall)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/GrOppholdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/GrOppholdTest.kt
@@ -21,25 +21,37 @@ class GrOppholdTest {
     inner class Equals {
         @Test
         fun `skal returnere false hvis person er ulik`() {
+            // Arrange
             val annetOpphold = opphold.copy(person = tilfeldigPerson())
+
+            // Act & Assert
             assert(opphold != annetOpphold)
         }
 
         @Test
         fun `skal returnere false hvis periode er ulik`() {
+            // Arrange
             val annetOpphold = opphold.copy(gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2001, 1, 1), tom = LocalDate.of(2001, 12, 31)))
+
+            // Act & Assert
             assert(opphold != annetOpphold)
         }
 
         @Test
         fun `skal returnere false hvis type er ulik`() {
+            // Arrange
             val annetOpphold = opphold.copy(type = OPPHOLDSTILLATELSE.PERMANENT)
+
+            // Act & Assert
             assert(opphold != annetOpphold)
         }
 
         @Test
         fun `skal returnere true hvis alle felter er like`() {
+            // Arrange
             val annetOpphold = opphold.copy(id = 1)
+
+            // Act & Assert
             assert(opphold == annetOpphold)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/GrStatsborgerskapTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/GrStatsborgerskapTest.kt
@@ -21,31 +21,46 @@ class GrStatsborgerskapTest {
     inner class Equals {
         @Test
         fun `skal returnere false hvis person er ulik`() {
+            // Arrange
             val annetStatsborgerskap = statsborgerskap.copy(person = tilfeldigPerson())
+
+            // Act & Assert
             assert(statsborgerskap != annetStatsborgerskap)
         }
 
         @Test
         fun `skal returnere false hvis periode er ulik`() {
+            // Arrange
             val annetStatsborgerskap = statsborgerskap.copy(gyldigPeriode = DatoIntervallEntitet(fom = LocalDate.of(2001, 1, 1), tom = LocalDate.of(2001, 12, 31)))
+
+            // Act & Assert
             assert(statsborgerskap != annetStatsborgerskap)
         }
 
         @Test
         fun `skal returnere false hvis landkode er ulik`() {
+            // Arrange
             val annetStatsborgerskap = statsborgerskap.copy(landkode = "SE")
+
+            // Act & Assert
             assert(statsborgerskap != annetStatsborgerskap)
         }
 
         @Test
         fun `skal returnere false hvis medlemskap er ulik`() {
+            // Arrange
             val annetStatsborgerskap = statsborgerskap.copy(medlemskap = Medlemskap.EØS)
+
+            // Act & Assert
             assert(statsborgerskap != annetStatsborgerskap)
         }
 
         @Test
         fun `skal returnere true hvis alle felter er like`() {
+            // Arrange
             val annetStatsborgerskap = statsborgerskap.copy(id = 1)
+
+            // Act & Assert
             assert(statsborgerskap == annetStatsborgerskap)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonTest.kt
@@ -31,130 +31,160 @@ class PersonTest {
 
         @Test
         fun `skal returnere false når aktør er forskjellig`() {
+            // Arrange
             val nyPerson = personMedNyId().copy(aktør = randomAktør())
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når navn er forskjellig`() {
+            // Arrange
             val nyPerson = personMedNyId().copy(navn = "Annet Navn")
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når fødselsdato er forskjellig`() {
+            // Arrange
             val nyPerson = personMedNyId().copy(fødselsdato = LocalDate.now().minusYears(18))
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når kjønn er forskjellig`() {
+            // Arrange
             val nyPerson = personMedNyId().copy(kjønn = Kjønn.MANN)
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når målform er forskjellig`() {
+            // Arrange
             val nyPerson = personMedNyId().copy(målform = Målform.NN)
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når type er forskjellig`() {
+            // Arrange
             val nyPerson = personMedNyId().copy(type = PersonType.ANNENPART)
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når harFalskIdentitet er forskjellig`() {
+            // Arrange
             val nyPerson = personMedNyId().copy(harFalskIdentitet = true)
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når dødsfall er forskjellig`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     dødsfall = lagDødsfall(person = this, LocalDate.of(2020, 1, 1))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når opphold er forskjellige`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     opphold = mutableListOf(lagGrOpphold(person = this))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når bostedsadresser er forskjellige`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     bostedsadresser = mutableListOf(lagGrVegadresseBostedsadresse(person = this))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når oppholdsadresser er forskjellige`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     oppholdsadresser = mutableListOf(lagGrVegadresseOppholdsadresse(person = this))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når deltBosted er forskjellige`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     deltBosted = mutableListOf(lagGrVegadresseDeltBosted(person = this))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når sivilstander er forskjellige`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     sivilstander = mutableListOf(lagGrSivilstand(person = this))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når statsborgerskap er forskjellige`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     statsborgerskap = mutableListOf(lagGrStatsborgerskap(person = this))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
 
         @Test
         fun `skal returnere false når arbeidsforhold er forskjellige`() {
+            // Arrange
             val nyPerson =
                 personMedNyId().apply {
                     arbeidsforhold = mutableListOf(lagGrArbeidsforhold(person = this))
                 }
 
+            // Act & Assert
             assertThat(person.personopplysningerErLike(nyPerson)).isFalse()
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersongrunnlagTest.kt
@@ -14,6 +14,7 @@ class PersongrunnlagTest {
 
     @Test
     fun `Returnerer nytt barn fra personopplysningsgrunnlag`() {
+        // Arrange
         val søker = randomFnr()
         val barn = randomFnr()
         val nyttbarn = randomFnr()
@@ -38,14 +39,20 @@ class PersongrunnlagTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns grunnlag
         every { persongrunnlagService.finnNyeBarn(any(), any()) } answers { callOriginal() }
 
+        // Act
         val nye = persongrunnlagService.finnNyeBarn(forrigeBehandling = forrigeBehandling, behandling = behandling)
+
+        // Assert
         Assertions.assertEquals(nyttbarn, nye.singleOrNull()!!.aktør.aktivFødselsnummer())
     }
 
     @Test
     fun `Returnerer barnet som 'søker' når grunnlag kun består av ett barn (enslig mindreårig eller institusjonsbarn)`() {
+        // Arrange
         val barnet = lagPerson(type = PersonType.BARN)
         val persongrunnlag = lagTestPersonopplysningGrunnlag(1L, barnet)
+
+        // Assert
         Assertions.assertEquals(barnet, persongrunnlag.søker)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagTest.kt
@@ -14,33 +14,41 @@ class PersonopplysningGrunnlagTest {
 
         @Test
         fun `skal returnere false når det ikke er noen endringer`() {
+            // Arrange
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(id = 0) { setOf(søkerPerson) }
             val nyttPersonopplysningGrunnlag = personopplysningGrunnlag.copy(id = 1, personer = mutableSetOf(søkerPerson))
 
+            // Act & Assert
             assertThat(personopplysningGrunnlag.harRelevantEndring(nyttPersonopplysningGrunnlag)).isFalse()
         }
 
         @Test
         fun `skal returnere true når en person i personopplysninggrunnlaget er endret`() {
+            // Arrange
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(id = 0) { setOf(søkerPerson) }
             val nyttPersonopplysningGrunnlag = personopplysningGrunnlag.copy(id = 1, personer = mutableSetOf(søkerPerson.copy(navn = "Endret Navn")))
 
+            // Act & Assert
             assertThat(personopplysningGrunnlag.harRelevantEndring(nyttPersonopplysningGrunnlag)).isTrue()
         }
 
         @Test
         fun `skal returnere true når en person er lagt til i personopplysninggrunnlaget`() {
+            // Arrange
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(id = 0) { setOf(søkerPerson) }
             val nyttPersonopplysningGrunnlag = personopplysningGrunnlag.copy(id = 1, personer = mutableSetOf(søkerPerson, barnPerson))
 
+            // Act & Assert
             assertThat(personopplysningGrunnlag.harRelevantEndring(nyttPersonopplysningGrunnlag)).isTrue()
         }
 
         @Test
         fun `skal returnere true når en person er fjernet fra personopplysninggrunnlaget`() {
+            // Arrange
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(id = 0) { setOf(søkerPerson, barnPerson) }
             val nyttPersonopplysningGrunnlag = personopplysningGrunnlag.copy(id = 1, personer = mutableSetOf(søkerPerson))
 
+            // Act & Assert
             assertThat(personopplysningGrunnlag.harRelevantEndring(nyttPersonopplysningGrunnlag)).isTrue()
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/GrArbeidsforholdTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/arbeidsforhold/GrArbeidsforholdTest.kt
@@ -21,37 +21,55 @@ class GrArbeidsforholdTest {
     inner class Equals {
         @Test
         fun `skal returnere false hvis person er ulik`() {
+            // Arrange
             val annetArbeidsforhold = arbeidsforhold.copy(person = tilfeldigPerson())
+
+            // Act & Assert
             assert(arbeidsforhold != annetArbeidsforhold)
         }
 
         @Test
         fun `skal returnere false hvis periode er ulik`() {
+            // Arrange
             val annetArbeidsforhold = arbeidsforhold.copy(periode = DatoIntervallEntitet(fom = LocalDate.of(2001, 1, 1), tom = LocalDate.of(2001, 12, 31)))
+
+            // Act & Assert
             assert(arbeidsforhold != annetArbeidsforhold)
         }
 
         @Test
         fun `skal returnere false hvis arbeidsgiverId er ulik`() {
+            // Arrange
             val annetArbeidsforhold = arbeidsforhold.copy(arbeidsgiverId = "321321321")
+
+            // Act & Assert
             assert(arbeidsforhold != annetArbeidsforhold)
         }
 
         @Test
         fun `skal returnere false hvis arbeidsgiverType er ulik`() {
+            // Arrange
             val annetArbeidsforhold = arbeidsforhold.copy(arbeidsgiverType = "Person")
+
+            // Act & Assert
             assert(arbeidsforhold != annetArbeidsforhold)
         }
 
         @Test
         fun `skal returnere false hvis organisasjonNavn er ulik`() {
+            // Arrange
             val annetArbeidsforhold = arbeidsforhold.copy(organisasjonNavn = "Annet navn AS")
+
+            // Act & Assert
             assert(arbeidsforhold != annetArbeidsforhold)
         }
 
         @Test
         fun `skal returnere true hvis alle felter er like`() {
+            // Arrange
             val annetArbeidsforhold = arbeidsforhold.copy(id = 1)
+
+            // Act & Assert
             assert(arbeidsforhold == annetArbeidsforhold)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/søknad/SøknadGrunnlagServiceTest.kt
@@ -35,20 +35,24 @@ internal class SøknadGrunnlagServiceTest {
 
     @Test
     fun `finnPersonerFremstiltKravFor skal returnere tom liste dersom behandlingen ikke er søknad, fødselshendelse eller manuell migrering`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.DØDSFALL_BRUKER)
         every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns null
 
+        // Act
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 forrigeBehandling = null,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav, Is(emptyList()))
     }
 
     @Test
     fun `finnPersonerFremstiltKravFor skal returnere aktør som person framstilt krav for dersom det er søkt for utvidet barnetrygd`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
 
         val barnSomIkkeErKryssetAvFor =
@@ -69,17 +73,20 @@ internal class SøknadGrunnlagServiceTest {
 
         every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
+        // Act
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 forrigeBehandling = null,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.single(), Is(behandling.fagsak.aktør))
     }
 
     @Test
     fun `finnPersonerFremstiltKravFor skal returnere aktør som person framstilt krav for dersom det er søkt for utvidet barnetrygd og barn som er krysset for`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
         val barn = lagPerson(type = PersonType.BARN)
 
@@ -102,18 +109,21 @@ internal class SøknadGrunnlagServiceTest {
         every { personidentService.hentAktør(barn.aktør.aktivFødselsnummer()) } returns barn.aktør
         every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
+        // Act
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 forrigeBehandling = null,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.size, Is(2))
         assertThat(personerFramstiltForKrav, containsInAnyOrder(behandling.fagsak.aktør, barn.aktør))
     }
 
     @Test
     fun `finnPersonerFremstiltKravFor skal bare returnere barn som er folkeregistret og krysset av på søknad`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
         val barn1Fnr = randomFnr()
         val mocketAktør = mockk<Aktør>()
@@ -158,12 +168,14 @@ internal class SøknadGrunnlagServiceTest {
         every { personidentService.hentAktør(barn1Fnr) } returns mocketAktør
         every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
+        // Act
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 forrigeBehandling = null,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.single(), Is(mocketAktør))
 
         verify(exactly = 1) { personidentService.hentAktør(barn1Fnr) }
@@ -171,6 +183,7 @@ internal class SøknadGrunnlagServiceTest {
 
     @Test
     fun `finnPersonerFremstiltKravFor skal returnere nye barn dersom behandlingen har fødselshendelse som årsak`() {
+        // Arrange
         val forrigeBehandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
         val behandling = lagBehandling(årsak = BehandlingÅrsak.FØDSELSHENDELSE)
         val nyttBarn = lagPerson()
@@ -178,12 +191,14 @@ internal class SøknadGrunnlagServiceTest {
         every { persongrunnlagService.finnNyeBarn(behandling, forrigeBehandling) } returns listOf(nyttBarn)
         every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns null
 
+        // Act
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 forrigeBehandling = forrigeBehandling,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.single(), Is(nyttBarn.aktør))
 
         verify(exactly = 1) { persongrunnlagService.finnNyeBarn(behandling, forrigeBehandling) }
@@ -191,6 +206,7 @@ internal class SøknadGrunnlagServiceTest {
 
     @Test
     fun `finnPersonerFremstiltKravFor skal returnere eksisterende personer fra persongrunnlaget dersom behandlingen er en manuell migrering`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
@@ -203,12 +219,14 @@ internal class SøknadGrunnlagServiceTest {
         every { persongrunnlagService.hentAktivThrows(behandling.id) } returns eksisterendePersonpplysningGrunnlag
         every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns null
 
+        // Act
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 forrigeBehandling = null,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.single(), Is(eksisterendeBarn.aktør))
 
         verify(exactly = 1) { persongrunnlagService.hentAktivThrows(behandling.id) }
@@ -216,6 +234,7 @@ internal class SøknadGrunnlagServiceTest {
 
     @Test
     fun `finnPersonerFremstiltKravFor skal ikke returnere duplikater av personer`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.SØKNAD)
         val barn = lagPerson(type = PersonType.BARN)
 
@@ -246,12 +265,14 @@ internal class SøknadGrunnlagServiceTest {
         every { personidentService.hentAktør(barn.aktør.aktivFødselsnummer()) } returns barn.aktør
         every { søknadGrunnlagService.hentAktivSøknadDto(behandling.id) } returns søknadDto
 
+        // Act
         val personerFramstiltForKrav =
             søknadGrunnlagService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 forrigeBehandling = null,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.size, Is(1))
         assertThat(personerFramstiltForKrav.single(), Is(barn.aktør))
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/institusjon/SamhandlerControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/institusjon/SamhandlerControllerTest.kt
@@ -48,16 +48,21 @@ internal class SamhandlerControllerTest {
     inner class HentSamhandlerDataForOrganisasjonFraTssOgEreg {
         @Test
         fun `Skal hente samhandlerinformasjon med adresse fra TSS, hvis det ikke finnes adresse i ereg `() {
+            // Arrange
             every { samhandlerKlientMock.hentSamhandler(any()) } returns samhandlereInfoMock.first()
             every { organisasjonService.hentOrganisasjon(any()) } returns Organisasjon(samhandlereInfoMock.first().orgNummer!!, "Testinstitusjon")
 
+            // Act
             val samhandlerInfo = samhandlerController.hentSamhandlerDataForOrganisasjonFraTssOgEreg(samhandlereInfoMock.first().orgNummer!!)
+
+            // Assert
             assertThat(samhandlerInfo.data).isNotNull()
             assertThat(samhandlerInfo.data!!.tssEksternId).isEqualTo("80000999999")
         }
 
         @Test
         fun `Skal hente tss ekstern id fra samhandlerinformasjon til TSS, men bruke navn og adresse fra ereg `() {
+            // Arrange
             every { samhandlerKlientMock.hentSamhandler(any()) } returns samhandlereInfoMock.first()
             every { kodeverkService.hentPoststed(any()) } returns "Oslo"
             every { organisasjonService.hentOrganisasjon(any()) } returns
@@ -76,7 +81,10 @@ internal class SamhandlerControllerTest {
                         ),
                 )
 
+            // Act
             val samhandlerInfo = samhandlerController.hentSamhandlerDataForOrganisasjonFraTssOgEreg(samhandlereInfoMock.first().orgNummer!!)
+
+            // Assert
             assertThat(samhandlerInfo.data).isNotNull()
             assertThat(samhandlerInfo.data!!.tssEksternId).isEqualTo("80000999999")
             assertThat(samhandlerInfo.data!!.navn).isEqualTo("Et annet navn")
@@ -96,7 +104,10 @@ internal class SamhandlerControllerTest {
 
         @Test
         fun `Kaster feilmelding hvis det ikke fins organisasjon med gitt orgnr`() {
+            // Arrange
             every { samhandlerKlientMock.hentSamhandler(any()) } throws HttpClientErrorException(HttpStatus.NOT_FOUND)
+
+            // Act & Assert
             val feil =
                 assertThrows<FunksjonellFeil> {
                     samhandlerController.hentSamhandlerDataForOrganisasjonFraTssOgEreg("123456789")
@@ -109,14 +120,18 @@ internal class SamhandlerControllerTest {
     inner class SøkSamhandlerinfoFraNavn {
         @Test
         fun `Søk etter samhandlere skal returnere samhandlere på navn og ikke hente flere hvis det ikke finnes flere samhandlere`() {
+            // Arrange
             every { samhandlerKlientMock.søkSamhandlere("BUFETAT", null, null, 0) } returns
                 SøkSamhandlerInfo(
                     false,
                     samhandlereInfoMock,
                 )
 
+            // Act
             val samhandlerInfo =
                 samhandlerController.søkSamhandlerinfoFraNavn(SøkSamhandlerInfoRequest("Bufetat", null, null))
+
+            // Assert
             assertThat(samhandlerInfo.data).isNotNull()
             assertThat(samhandlerInfo.data).hasSize(2)
             assertThat(samhandlerInfo.data?.get(0)?.tssEksternId).isEqualTo("80000999999")
@@ -126,6 +141,7 @@ internal class SamhandlerControllerTest {
 
         @Test
         fun `Søk etter samhandlere skal returnere samhandlere på navn og slå sammen resultatene fra alle sidene ved mer enn 1 side`() {
+            // Arrange
             every { samhandlerKlientMock.søkSamhandlere("BUFETAT", null, null, 0) } returns
                 SøkSamhandlerInfo(
                     true,
@@ -138,8 +154,11 @@ internal class SamhandlerControllerTest {
                     listOf(samhandlereInfoMock.get(1)),
                 )
 
+            // Act
             val samhandlerInfo =
                 samhandlerController.søkSamhandlerinfoFraNavn(SøkSamhandlerInfoRequest("Bufetat", null, null))
+
+            // Assert
             assertThat(samhandlerInfo.data).isNotNull()
             assertThat(samhandlerInfo.data).hasSize(2)
             assertThat(samhandlerInfo.data?.get(0)?.tssEksternId).isEqualTo("80000999999")
@@ -152,6 +171,7 @@ internal class SamhandlerControllerTest {
     inner class HentSamhandlerDataForBehandling {
         @Test
         fun `skal returnere samhandlerdata fra institusjonsinfo for behandling`() {
+            // Arrange
             every { institusjonsinfoRepository.findByBehandlingId(any()) } returns
                 Institusjonsinfo(
                     id = 42,
@@ -167,7 +187,11 @@ internal class SamhandlerControllerTest {
                     kommunenummer = "0301",
                     gyldighetsperiode = DatoIntervallEntitet(LocalDate.now(), null),
                 )
+
+            // Act
             val samhandlerInfo = samhandlerController.hentSamhandlerDataForBehandling(42L)
+
+            // Assert
             assertThat(samhandlerInfo.data).isNotNull()
             assertThat(samhandlerInfo.data?.orgNummer).isEqualTo("123456789")
             assertThat(samhandlerInfo.data?.tssEksternId).isEqualTo("tssId")
@@ -183,21 +207,25 @@ internal class SamhandlerControllerTest {
 
         @Test
         fun `skal returnere samhandlerdata fra tss opg ereg hvis mangler for behandling`() {
+            // Arrange
             every { institusjonsinfoRepository.findByBehandlingId(any()) } returns null
             every { behandlingHentOgPersisterService.hent(42) } returns
                 lagBehandling(lagFagsak(institusjon = Institusjon(orgNummer = "123456789", tssEksternId = "tssIdFraFagsak")))
             every { samhandlerKlientMock.hentSamhandler(any()) } returns samhandlereInfoMock.first()
             every { organisasjonService.hentOrganisasjon(any()) } returns Organisasjon(samhandlereInfoMock.first().orgNummer!!, "Testinstitusjon")
 
+            // Act
             val samhandlerInfo = samhandlerController.hentSamhandlerDataForBehandling(42L)
         }
 
         @Test
         fun `skal kaste feil hvis ingen eksisterende institusjonsinfo og ingen institusjon fra fagsak`() {
+            // Arrange
             every { institusjonsinfoRepository.findByBehandlingId(any()) } returns null
             every { behandlingHentOgPersisterService.hent(42) } returns
                 lagBehandling(lagFagsak())
 
+            // Act & Assert
             assertThrows<FunksjonellFeil> { samhandlerController.hentSamhandlerDataForBehandling(42L) }
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingServiceTest.kt
@@ -18,15 +18,18 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `finnAktivtKorrigeringPåBehandling skal hente aktivt korrigering fra repository hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
 
         every { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id) } returns korrigertEtterbetaling
 
+        // Act
         val hentetKorrigertEtterbetaling =
             korrigertEtterbetalingService.finnAktivtKorrigeringPåBehandling(behandling.id)
                 ?: fail("etterbetaling korrigering ikke hentet riktig")
 
+        // Assert
         assertThat(hentetKorrigertEtterbetaling.behandling.id, Is(behandling.id))
         assertThat(hentetKorrigertEtterbetaling.aktiv, Is(true))
 
@@ -35,6 +38,7 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `finnAlleKorrigeringerPåBehandling skal hente alle korrigering fra repository hvis de finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
 
@@ -44,9 +48,11 @@ internal class KorrigertEtterbetalingServiceTest {
                 korrigertEtterbetaling,
             )
 
+        // Act
         val hentetKorrigertEtterbetaling =
             korrigertEtterbetalingService.finnAlleKorrigeringerPåBehandling(behandling.id)
 
+        // Assert
         assertThat(hentetKorrigertEtterbetaling.size, Is(2))
 
         verify(exactly = 1) { korrigertEtterbetalingRepository.finnAlleKorrigeringerPåBehandling(behandling.id) }
@@ -54,6 +60,7 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `lagreKorrigertEtterbetaling skal lagre korrigering på behandling og logg på dette`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
 
@@ -61,9 +68,11 @@ internal class KorrigertEtterbetalingServiceTest {
         every { korrigertEtterbetalingRepository.save(korrigertEtterbetaling) } returns korrigertEtterbetaling
         every { loggService.opprettKorrigertEtterbetalingLogg(behandling, any()) } returns Unit
 
+        // Act
         val lagretKorrigertEtterbetaling =
             korrigertEtterbetalingService.lagreKorrigertEtterbetaling(korrigertEtterbetaling)
 
+        // Assert
         assertThat(lagretKorrigertEtterbetaling.behandling.id, Is(behandling.id))
 
         verify(exactly = 1) { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id) }
@@ -78,6 +87,7 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `lagreKorrigertEtterbetaling skal sette og lagre forrige korrigering til inaktivt hvis det finnes tidligere korrigering`() {
+        // Arrange
         val behandling = lagBehandling()
         val forrigeKorrigering = mockk<KorrigertEtterbetaling>(relaxed = true)
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
@@ -87,8 +97,10 @@ internal class KorrigertEtterbetalingServiceTest {
         every { korrigertEtterbetalingRepository.save(korrigertEtterbetaling) } returns korrigertEtterbetaling
         every { loggService.opprettKorrigertEtterbetalingLogg(any(), any()) } returns Unit
 
+        // Act
         korrigertEtterbetalingService.lagreKorrigertEtterbetaling(korrigertEtterbetaling)
 
+        // Assert
         verify(exactly = 1) { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(any()) }
         verify(exactly = 1) { forrigeKorrigering setProperty "aktiv" value false }
         verify(exactly = 1) { korrigertEtterbetalingRepository.saveAndFlush(forrigeKorrigering) }
@@ -97,14 +109,17 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `settKorrigeringPåBehandlingTilInaktiv skal sette korrigering til inaktivt hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = mockk<KorrigertEtterbetaling>(relaxed = true)
 
         every { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(any()) } returns korrigertEtterbetaling
         every { loggService.opprettKorrigertEtterbetalingLogg(any(), any()) } returns Unit
 
+        // Act
         korrigertEtterbetalingService.settKorrigeringPåBehandlingTilInaktiv(behandling)
 
+        // Assert
         verify(exactly = 1) { korrigertEtterbetaling setProperty "aktiv" value false }
         verify(exactly = 1) {
             loggService.opprettKorrigertEtterbetalingLogg(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertvedtak/KorrigertVedtakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertvedtak/KorrigertVedtakServiceTest.kt
@@ -20,15 +20,18 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `finnAktivtKorrigertVedtakPåBehandling skal hente aktivt korrigert vedtak fra repository hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertVedtak = lagKorrigertVedtak(behandling)
 
         every { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id) } returns korrigertVedtak
 
+        // Act
         val hentetKorrigertVedtak =
             korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(behandling.id)
                 ?: fail("korrigert vedtak ikke hentet riktig")
 
+        // Assert
         MatcherAssert.assertThat(hentetKorrigertVedtak.behandling.id, CoreMatchers.`is`(behandling.id))
         MatcherAssert.assertThat(hentetKorrigertVedtak.aktiv, CoreMatchers.`is`(true))
 
@@ -37,6 +40,7 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `lagreKorrigertVedtak skal lagre korrigert vedtak på behandling og logg på dette`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertVedtak = lagKorrigertVedtak(behandling)
 
@@ -44,9 +48,11 @@ internal class KorrigertVedtakServiceTest {
         every { korrigertVedtakRepository.save(korrigertVedtak) } returns korrigertVedtak
         every { loggService.opprettKorrigertVedtakLogg(behandling, any()) } returns Unit
 
+        // Act
         val lagretKorrigertVedtak =
             korrigertVedtakService.lagreKorrigertVedtak(korrigertVedtak)
 
+        // Assert
         MatcherAssert.assertThat(lagretKorrigertVedtak.behandling.id, CoreMatchers.`is`(behandling.id))
 
         verify(exactly = 1) { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id) }
@@ -61,6 +67,7 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `lagreKorrigertVedtak skal sette og lagre forrige korrigert vedtak til inaktivt hvis det finnes tidligere korrigering`() {
+        // Arrange
         val behandling = lagBehandling()
         val forrigeKorrigering = mockk<KorrigertVedtak>(relaxed = true)
         val korrigertVedtak = lagKorrigertVedtak(behandling, vedtaksdato = LocalDate.now().minusDays(3))
@@ -70,8 +77,10 @@ internal class KorrigertVedtakServiceTest {
         every { korrigertVedtakRepository.save(korrigertVedtak) } returns korrigertVedtak
         every { loggService.opprettKorrigertVedtakLogg(any(), any()) } returns Unit
 
+        // Act
         korrigertVedtakService.lagreKorrigertVedtak(korrigertVedtak)
 
+        // Assert
         verify(exactly = 1) { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(any()) }
         verify(exactly = 1) { forrigeKorrigering setProperty "aktiv" value false }
         verify(exactly = 1) { korrigertVedtakRepository.saveAndFlush(forrigeKorrigering) }
@@ -80,14 +89,17 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `settKorrigertVedtakPåBehandlingTilInaktiv skal sette korrigert vedtak til inaktivt hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertVedtak = mockk<KorrigertVedtak>(relaxed = true)
 
         every { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(any()) } returns korrigertVedtak
         every { loggService.opprettKorrigertVedtakLogg(any(), any()) } returns Unit
 
+        // Act
         korrigertVedtakService.settKorrigertVedtakPåBehandlingTilInaktiv(behandling)
 
+        // Assert
         verify(exactly = 1) { korrigertVedtak setProperty "aktiv" value false }
         verify(exactly = 1) {
             loggService.opprettKorrigertVedtakLogg(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceEnhetTest.kt
@@ -13,38 +13,47 @@ internal class LoggServiceEnhetTest {
 
     @Test
     fun `loggSammensattKontrollsakLagtTil skal lagre ned logg på at sammensatt kontrollsak er opprettet`() {
+        // Arrange
         val behandling = lagBehandling(id = 1)
         val sammensattKontrollsak = SammensattKontrollsak(behandlingId = behandling.id, fritekst = "test")
 
         every { loggRepository.save(any()) } returnsArgument 0
 
+        // Act
         val opprettetLogg = loggService.loggSammensattKontrollsakLagtTil(sammensattKontrollsak)
 
+        // Assert
         assertThat(opprettetLogg.type).isEqualTo(LoggType.SAMMENSATT_KONTROLLSAK_LAGT_TIL)
         assertThat(opprettetLogg.behandlingId).isEqualTo(behandling.id)
     }
 
     @Test
     fun `loggSammensattKontrollsakEndret skal lagre ned logg på at sammensatt kontrollsak er endret`() {
+        // Arrange
         val behandling = lagBehandling(id = 1)
         val oppdatertSammensattKontrollsak = SammensattKontrollsak(behandlingId = behandling.id, fritekst = "test2")
 
         every { loggRepository.save(any()) } returnsArgument 0
 
+        // Act
         val opprettetLogg = loggService.loggSammensattKontrollsakEndret(oppdatertSammensattKontrollsak)
 
+        // Assert
         assertThat(opprettetLogg.type).isEqualTo(LoggType.SAMMENSATT_KONTROLLSAK_ENDRET)
         assertThat(opprettetLogg.behandlingId).isEqualTo(behandling.id)
     }
 
     @Test
     fun `loggSammensattKontrollsakFjernet skal lagre ned logg på at sammensatt kontrollsak er fjernet`() {
+        // Arrange
         val behandling = lagBehandling(id = 1)
 
         every { loggRepository.save(any()) } returnsArgument 0
 
+        // Act
         val opprettetLogg = loggService.loggSammensattKontrollsakFjernet(behandlingId = behandling.id)
 
+        // Assert
         assertThat(opprettetLogg.type).isEqualTo(LoggType.SAMMENSATT_KONTROLLSAK_FJERNET)
         assertThat(opprettetLogg.behandlingId).isEqualTo(behandling.id)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -297,6 +297,7 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
 
         @Test
         fun `Skal legge til ny ident på aktør som finnes i systemet`() {
+            // Arrange
             val personIdentSomFinnes = randomFnr()
             val personIdentSomSkalLeggesTil = randomFnr()
             val historiskIdent = randomFnr()
@@ -354,8 +355,10 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
                 null
             }
 
+            // Act
             val aktør = håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomSkalLeggesTil))
 
+            // Assert
             assertThat(aktør?.personidenter?.size).isEqualTo(2)
             assertThat(personIdentSomSkalLeggesTil).isEqualTo(aktør!!.aktivFødselsnummer())
             assertThat(
@@ -375,6 +378,7 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
 
         @Test
         fun `Skal legge til ny ident på aktør som finnes i systemet, og som kun har fagsak og ingen behandling`() {
+            // Arrange
             val personIdentSomFinnes = randomFnr()
             val personIdentSomSkalLeggesTil = randomFnr()
             val historiskIdent = randomFnr()
@@ -435,8 +439,10 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
                 null
             }
 
+            // Act
             val aktør = håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomSkalLeggesTil))
 
+            // Assert
             assertThat(aktør?.personidenter?.size).isEqualTo(2)
             assertThat(personIdentSomSkalLeggesTil).isEqualTo(aktør!!.aktivFødselsnummer())
             assertThat(
@@ -456,6 +462,7 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
 
         @Test
         fun `Skal kaste feil når vi prøver legge til ny ident på aktør som finnes i systemet og som har endret fødselsdato`() {
+            // Arrange
             val personIdentSomFinnes = randomFnr()
             val personIdentSomSkalLeggesTil = randomFnr()
             val historiskIdent = randomFnr()
@@ -499,6 +506,7 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
                 null
             }
 
+            // Act & Assert
             val exception =
                 assertThrows<Feil> {
                     håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomSkalLeggesTil))
@@ -509,6 +517,7 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
 
         @Test
         fun `Skal ikke legge til ny ident på aktør som allerede har denne identen registert i systemet`() {
+            // Arrange
             val personIdentSomFinnes = randomFnr()
             val aktørIdSomFinnes = lagAktør(personIdentSomFinnes)
 
@@ -526,8 +535,10 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
                 ).personidenter.first()
             }
 
+            // Act
             val aktør = håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomFinnes))
 
+            // Assert
             assertThat(aktørIdSomFinnes.aktørId).isEqualTo(aktør?.aktørId)
             assertThat(aktør?.personidenter?.size).isEqualTo(1)
             assertThat(personIdentSomFinnes).isEqualTo(aktør?.personidenter?.single()?.fødselsnummer)
@@ -537,6 +548,7 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
 
         @Test
         fun `Hendelse på en ident hvor gammel ident1 er merget med ny ident2 skal ikke kaste feil når bruker har alt bruker ny ident`() {
+            // Arrange
             val fnrIdent1 = randomFnr()
             val aktørIdent1 = lagAktør(fnrIdent1)
             val aktivFnrIdent2 = randomFnr()
@@ -560,7 +572,10 @@ Se https://github.com/navikt/familie/blob/main/doc/ba-sak/manuellt-patche-akt%C3
                 null
             }
 
+            // Act
             val aktør = håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(aktivFnrIdent2))
+
+            // Assert
             assertThat(aktivAktørIdent2.aktørId).isEqualTo(aktør?.aktørId)
             assertThat(aktør?.personidenter?.size).isEqualTo(1)
             assertThat(aktivFnrIdent2).isEqualTo(aktør?.personidenter?.single()?.fødselsnummer)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdentHendelseTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/IdentHendelseTaskTest.kt
@@ -14,14 +14,21 @@ internal class IdentHendelseTaskTest {
 
     @Test
     fun opprettTask() {
+        // Arrange
         val nyPersonIdent = PersonIdent("123")
+
+        // Act
         val task = IdentHendelseTask.opprettTask(nyPersonIdent)
+
+        // Assert
         assertEquals(nyPersonIdent, jsonMapper.readValue(task.payload, PersonIdent::class.java))
         assertEquals("123", task.metadata["nyPersonIdent"])
         assertEquals("IdentHendelseTask", task.type)
 
+        // Act
         identHendelseTask.doTask(task)
 
+        // Assert
         val slot = slot<PersonIdent>()
         verify(exactly = 1) { håndterNyIdentService.håndterNyIdent(capture(slot)) }
         assertEquals(nyPersonIdent, slot.captured)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/personident/PersonidentTest.kt
@@ -11,29 +11,41 @@ internal class PersonidentTest {
 
     @Test
     fun `To personidenter er like hvis de har samme fødselsnummer og aktiv`() {
+        // Arrange
         val p1 = Personident(fnr1, aktiv = true, aktør = mockk())
         val p2 = Personident(fnr1, aktiv = true, aktør = mockk())
+
+        // Act & Assert
         assertEquals(p1, p2)
     }
 
     @Test
     fun `To personidenter er ulike hvis de har samme fødselsnummer, men kun en er aktiv`() {
+        // Arrange
         val p1 = Personident(fnr1, aktiv = true, aktør = mockk())
         val p2 = Personident(fnr1, aktiv = false, aktør = mockk())
+
+        // Act & Assert
         assertNotEquals(p1, p2)
     }
 
     @Test
     fun `To personidenter er like hvis de har samme fødselsnummer og begge er inaktive`() {
+        // Arrange
         val p1 = Personident(fnr1, aktiv = false, aktør = mockk())
         val p2 = Personident(fnr1, aktiv = false, aktør = mockk())
+
+        // Act & Assert
         assertEquals(p1, p2)
     }
 
     @Test
     fun `To personidenter er ulike hvis de har forskjellige fødselsnummer og begge er aktive`() {
+        // Arrange
         val p1 = Personident(fnr1, aktiv = true, aktør = mockk())
         val p2 = Personident(fnr2, aktiv = true, aktør = mockk())
+
+        // Act & Assert
         assertNotEquals(p1, p2)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceEnhetTest.kt
@@ -67,6 +67,7 @@ internal class SimuleringServiceEnhetTest {
     fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal returnere true dersom det finnes avvik i form av etterbetaling som er innenfor beløpsgrense`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling: Behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -94,9 +95,11 @@ internal class SimuleringServiceEnhetTest {
                 lagPerson(type = PersonType.BARN).tilPersonEnkel(),
             )
 
+        // Act
         val behandlingHarAvvikInnenforBeløpsgrenser =
             simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
 
+        // Assert
         assertThat(behandlingHarAvvikInnenforBeløpsgrenser).isTrue
     }
 
@@ -105,6 +108,7 @@ internal class SimuleringServiceEnhetTest {
     fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal returnere true dersom det finnes avvik i form av feilutbetaling som er innenfor beløpsgrense`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling: Behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -145,9 +149,11 @@ internal class SimuleringServiceEnhetTest {
                 lagPerson(type = PersonType.BARN).tilPersonEnkel(),
             )
 
+        // Act
         val behandlingHarAvvikInnenforBeløpsgrenser =
             simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
 
+        // Assert
         assertThat(behandlingHarAvvikInnenforBeløpsgrenser).isTrue
     }
 
@@ -156,6 +162,7 @@ internal class SimuleringServiceEnhetTest {
     fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal returnere false dersom det finnes avvik i form av feilutbetaling som er utenfor beløpsgrense`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling: Behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -181,9 +188,11 @@ internal class SimuleringServiceEnhetTest {
                 lagPerson(type = PersonType.BARN).tilPersonEnkel(),
             )
 
+        // Act
         val behandlingHarAvvikInnenforBeløpsgrenser =
             simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling)
 
+        // Assert
         assertThat(behandlingHarAvvikInnenforBeløpsgrenser).isFalse
     }
 
@@ -196,6 +205,7 @@ internal class SimuleringServiceEnhetTest {
     fun `harMigreringsbehandlingAvvikInnenforBeløpsgrenser skal kaste feil dersom behandlingen ikke er en manuell migrering`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling: Behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -203,6 +213,7 @@ internal class SimuleringServiceEnhetTest {
                 førsteSteg = StegType.VURDER_TILBAKEKREVING,
             )
 
+        // Act & Assert
         assertThrows<Feil> { simuleringService.harMigreringsbehandlingAvvikInnenforBeløpsgrenser(behandling) }
     }
 
@@ -211,6 +222,7 @@ internal class SimuleringServiceEnhetTest {
     fun `harMigreringsbehandlingManuellePosteringer skal returnere true dersom det finnes manuelle posteringer i simuleringsresultat`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling: Behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -235,9 +247,11 @@ internal class SimuleringServiceEnhetTest {
 
         every { økonomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
 
+        // Act
         val behandlingHarManuellePosteringer =
             simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
 
+        // Assert
         assertThat(behandlingHarManuellePosteringer).isTrue
     }
 
@@ -249,6 +263,7 @@ internal class SimuleringServiceEnhetTest {
     fun `harMigreringsbehandlingManuellePosteringer skal returnere false dersom det ikke finnes manuelle posteringer i simuleringsresultat`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling: Behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -269,9 +284,11 @@ internal class SimuleringServiceEnhetTest {
 
         every { økonomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns simuleringMottaker
 
+        // Act
         val behandlingHarManuellePosteringer =
             simuleringService.harMigreringsbehandlingManuellePosteringer(behandling)
 
+        // Assert
         assertThat(behandlingHarManuellePosteringer).isFalse
     }
 
@@ -284,6 +301,7 @@ internal class SimuleringServiceEnhetTest {
     fun `harMigreringsbehandlingManuellePosteringer skal kaste feil dersom behandlingen ikke er en manuell migrering`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling: Behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
@@ -291,6 +309,7 @@ internal class SimuleringServiceEnhetTest {
                 førsteSteg = StegType.VURDER_TILBAKEKREVING,
             )
 
+        // Act & Assert
         assertThrows<Feil> { simuleringService.harMigreringsbehandlingManuellePosteringer(behandling) }
     }
 
@@ -298,6 +317,7 @@ internal class SimuleringServiceEnhetTest {
     inner class SimuleringErUtdatert {
         @Test
         fun `simulering er utdatert når tidSimuleringHentet er null`() {
+            // Act
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
@@ -305,11 +325,14 @@ internal class SimuleringServiceEnhetTest {
                         forfallsdatoNestePeriode = now(),
                     ),
                 )
+
+            // Assert
             assertThat(erUtdatert).isTrue()
         }
 
         @Test
         fun `simulering er utdatert når forfallsdato har passert og simulering ble hentet før forfallsdato`() {
+            // Act
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
@@ -317,11 +340,14 @@ internal class SimuleringServiceEnhetTest {
                         forfallsdatoNestePeriode = now().minusDays(5),
                     ),
                 )
+
+            // Assert
             assertThat(erUtdatert).isTrue()
         }
 
         @Test
         fun `simulering er ikke utdatert når forfallsdatoNestePeriode er null`() {
+            // Act
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
@@ -329,11 +355,14 @@ internal class SimuleringServiceEnhetTest {
                         forfallsdatoNestePeriode = null,
                     ),
                 )
+
+            // Assert
             assertThat(erUtdatert).isFalse()
         }
 
         @Test
         fun `simulering er ikke utdatert når tidSimuleringHentet og forfallsdatoNestePeriode er nåværende dato`() {
+            // Act
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
@@ -341,11 +370,14 @@ internal class SimuleringServiceEnhetTest {
                         forfallsdatoNestePeriode = now(),
                     ),
                 )
+
+            // Assert
             assertThat(erUtdatert).isFalse()
         }
 
         @Test
         fun `simulering er ikke utdatert når forfallsdato ikke har passert enda`() {
+            // Act
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
@@ -353,11 +385,14 @@ internal class SimuleringServiceEnhetTest {
                         forfallsdatoNestePeriode = now().plusDays(5),
                     ),
                 )
+
+            // Assert
             assertThat(erUtdatert).isFalse()
         }
 
         @Test
         fun `simulering er ikke utdatert når tidSimuleringHentet er lik forfallsdatoNestePeriode og forfallsdato har passert`() {
+            // Act
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
@@ -365,11 +400,14 @@ internal class SimuleringServiceEnhetTest {
                         forfallsdatoNestePeriode = now().minusDays(5),
                     ),
                 )
+
+            // Assert
             assertThat(erUtdatert).isFalse()
         }
 
         @Test
         fun `simulering er ikke utdatert når simulering ble hentet etter forfallsdato`() {
+            // Act
             val erUtdatert =
                 simuleringService.simuleringErUtdatert(
                     lagForenkletSimulering(
@@ -377,6 +415,8 @@ internal class SimuleringServiceEnhetTest {
                         forfallsdatoNestePeriode = now().minusDays(5),
                     ),
                 )
+
+            // Assert
             assertThat(erUtdatert).isFalse()
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstillegg/SmåbarnstilleggKorrigeringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstillegg/SmåbarnstilleggKorrigeringServiceTest.kt
@@ -26,14 +26,17 @@ internal class SmåbarnstilleggKorrigeringServiceTest {
 
     @Test
     fun `leggTilSmåbarnstilleggPåBehandling skal legge til småbarnstillegg på behandling som en AndelTilkjentYtelse`() {
+        // Arrange
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
 
         every { tilkjentYtelseRepository.findByBehandling(behandling.id) } returns tilkjentYtelse
 
+        // Act
         val småbarnsTillegg =
             småbarnstilleggKorrigeringService.leggTilSmåbarnstilleggPåBehandling(YearMonth.of(2020, 10), behandling)
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.findByBehandling(behandling.id) }
         verify(exactly = 1) {
             loggService.opprettSmåbarnstilleggLogg(
@@ -50,6 +53,7 @@ internal class SmåbarnstilleggKorrigeringServiceTest {
 
     @Test
     fun `leggTilSmåbarnstilleggPåBehandling skal kaste feil hvis småbarnstillegg allerede finnes for periode`() {
+        // Arrange
         val behandling = lagBehandling()
         val tilkjentYtelseMock = mockk<TilkjentYtelse>()
 
@@ -63,6 +67,7 @@ internal class SmåbarnstilleggKorrigeringServiceTest {
         every { tilkjentYtelseRepository.findByBehandling(behandling.id) } returns tilkjentYtelseMock
         every { tilkjentYtelseMock.andelerTilkjentYtelse } returns mutableSetOf(andelTilkjentYtelse)
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 småbarnstilleggKorrigeringService.leggTilSmåbarnstilleggPåBehandling(YearMonth.of(2020, 10), behandling)
@@ -76,6 +81,7 @@ internal class SmåbarnstilleggKorrigeringServiceTest {
 
     @Test
     fun `fjernSmåbarnstilleggPåBehandling skal splitte eksisterende overlappende småbarnstilleggsperiode`() {
+        // Arrange
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
 
@@ -90,9 +96,11 @@ internal class SmåbarnstilleggKorrigeringServiceTest {
         every { tilkjentYtelseRepository.findByBehandling(behandling.id) } returns tilkjentYtelse
         every { tilkjentYtelseRepository.saveAndFlush(any()) } returns tilkjentYtelse
 
+        // Act
         val oppsplittetSmåbarnstillegg =
             småbarnstilleggKorrigeringService.fjernSmåbarnstilleggPåBehandling(YearMonth.of(2020, 5), behandling)
 
+        // Assert
         verify(exactly = 1) {
             loggService.opprettSmåbarnstilleggLogg(
                 behandling,
@@ -111,6 +119,7 @@ internal class SmåbarnstilleggKorrigeringServiceTest {
 
     @Test
     fun `fjernSmåbarnstilleggPåBehandling skal kaste feil hvis småbarnstillegg ikke finnes for periode`() {
+        // Arrange
         val behandling = lagBehandling()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(behandling = behandling)
 
@@ -124,6 +133,7 @@ internal class SmåbarnstilleggKorrigeringServiceTest {
 
         every { tilkjentYtelseRepository.findByBehandling(behandling.id) } returns tilkjentYtelse
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 småbarnstilleggKorrigeringService.fjernSmåbarnstilleggPåBehandling(YearMonth.of(2025, 5), behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstillegg/SmåbarnstilleggUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/småbarnstillegg/SmåbarnstilleggUtilsTest.kt
@@ -11,6 +11,7 @@ import java.time.YearMonth
 class SmåbarnstilleggUtilsTest {
     @Test
     fun `Skal kunne automatisk iverksette småbarnstillegg når endringer i OS kun er frem i tid`() {
+        // Arrange
         val forrigeAndeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -30,12 +31,14 @@ class SmåbarnstilleggUtilsTest {
                     ),
                 )
 
+        // Act
         val (innvilgedeMånedPerioder, reduserteMånedPerioder) =
             hentInnvilgedeOgReduserteAndelerSmåbarnstillegg(
                 forrigeSmåbarnstilleggAndeler = forrigeAndeler,
                 nyeSmåbarnstilleggAndeler = nyeAndeler,
             )
 
+        // Assert
         assertTrue(
             kanAutomatiskIverksetteSmåbarnstillegg(
                 innvilgedeMånedPerioder = innvilgedeMånedPerioder,
@@ -46,6 +49,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal ikke kunne automatisk iverksette småbarnstillegg når endringer i OS er tilbake og frem i tid`() {
+        // Arrange
         val forrigeAndeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -69,12 +73,14 @@ class SmåbarnstilleggUtilsTest {
                 ),
             )
 
+        // Act
         val (innvilgedeMånedPerioder, reduserteMånedPerioder) =
             hentInnvilgedeOgReduserteAndelerSmåbarnstillegg(
                 forrigeSmåbarnstilleggAndeler = forrigeAndeler,
                 nyeSmåbarnstilleggAndeler = nyeAndeler,
             )
 
+        // Assert
         assertFalse(
             kanAutomatiskIverksetteSmåbarnstillegg(
                 innvilgedeMånedPerioder = innvilgedeMånedPerioder,
@@ -85,6 +91,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal ikke kunne automatisk iverksette småbarnstillegg når endringer i OS er 2 måneder frem i tid`() {
+        // Arrange
         val forrigeAndeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -108,12 +115,14 @@ class SmåbarnstilleggUtilsTest {
                 ),
             )
 
+        // Act
         val (innvilgedeMånedPerioder, reduserteMånedPerioder) =
             hentInnvilgedeOgReduserteAndelerSmåbarnstillegg(
                 forrigeSmåbarnstilleggAndeler = forrigeAndeler,
                 nyeSmåbarnstilleggAndeler = nyeAndeler,
             )
 
+        // Assert
         assertFalse(
             kanAutomatiskIverksetteSmåbarnstillegg(
                 innvilgedeMånedPerioder = innvilgedeMånedPerioder,
@@ -124,6 +133,7 @@ class SmåbarnstilleggUtilsTest {
 
     @Test
     fun `Skal ikke kunne automatisk iverksette småbarnstillegg når reduksjon i OS kun tilbake i tid`() {
+        // Arrange
         val forrigeAndeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -135,12 +145,14 @@ class SmåbarnstilleggUtilsTest {
 
         val nyeAndeler = emptyList<AndelTilkjentYtelse>()
 
+        // Act
         val (innvilgedeMånedPerioder, reduserteMånedPerioder) =
             hentInnvilgedeOgReduserteAndelerSmåbarnstillegg(
                 forrigeSmåbarnstilleggAndeler = forrigeAndeler,
                 nyeSmåbarnstilleggAndeler = nyeAndeler,
             )
 
+        // Assert
         assertFalse(
             kanAutomatiskIverksetteSmåbarnstillegg(
                 innvilgedeMånedPerioder = innvilgedeMånedPerioder,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerInstitusjonStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerInstitusjonStegTest.kt
@@ -109,6 +109,7 @@ class RegistrerInstitusjonStegTest {
 
     @Test
     fun `utførStegOgAngiNeste() skal lagre institusjon og verge`() {
+        // Arrange
         val behandling = lagBehandling(fagsak = defaultFagsak().copy(type = FagsakType.INSTITUSJON))
         val fagsakSlot = slot<Fagsak>()
         every { fagsakRepositoryMock.finnFagsak(any()) } returns behandling.fagsak
@@ -124,11 +125,13 @@ class RegistrerInstitusjonStegTest {
 
         val institusjon = Institusjon(orgNummer = "12345", tssEksternId = "cool tsr")
 
+        // Act
         registrerInstitusjon.utførStegOgAngiNeste(
             behandling,
             institusjon,
         )
 
+        // Assert
         assertThat(fagsakSlot.captured.institusjon!!.orgNummer).isEqualTo(institusjon.orgNummer)
         verify(exactly = 1) {
             loggServiceMock.opprettRegistrerInstitusjonLogg(any())
@@ -137,6 +140,7 @@ class RegistrerInstitusjonStegTest {
 
     @Test
     fun `utførStegOgAngiNeste() skal returnere REGISTRERE_SØKNAD som neste steg`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 fagsak =
@@ -153,12 +157,14 @@ class RegistrerInstitusjonStegTest {
 
         val institusjon = Institusjon(orgNummer = "12345", tssEksternId = "cool tsr")
 
+        // Act
         val nesteSteg =
             registrerInstitusjon.utførStegOgAngiNeste(
                 behandling,
                 institusjon,
             )
 
+        // Assert
         assertThat(nesteSteg).isEqualTo(StegType.REGISTRERE_SØKNAD)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlagEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlagEnhetTest.kt
@@ -44,6 +44,7 @@ class RegistrerPersongrunnlagEnhetTest {
 
     @Test
     fun `Kopierer kompetanser, valutakurser og utenlandsk periodebeløp til ny behandling`() {
+        // Arrange
         val mor = lagPerson(type = PersonType.SØKER)
         val barn1 = lagPerson(type = PersonType.BARN)
         val barn2 = lagPerson(type = PersonType.BARN)
@@ -88,6 +89,7 @@ class RegistrerPersongrunnlagEnhetTest {
             )
         } just runs
 
+        // Act
         registrerPersongrunnlagSteg.utførStegOgAngiNeste(
             behandling = behandling2,
             data =
@@ -97,6 +99,7 @@ class RegistrerPersongrunnlagEnhetTest {
                 ),
         )
 
+        // Assert
         verify(exactly = 1) {
             kompetanseService.kopierOgErstattKompetanser(
                 BehandlingId(behandling1.id),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingForNyBehandlingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingForNyBehandlingUtilsTest.kt
@@ -24,6 +24,7 @@ import java.time.YearMonth
 class VilkårsvurderingForNyBehandlingUtilsTest {
     @Test
     fun `Skal kun ta med aktører som hadde andeler med utvidet barnetrygd`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val barn = lagPerson(type = PersonType.BARN)
 
@@ -43,16 +44,19 @@ class VilkårsvurderingForNyBehandlingUtilsTest {
                 ),
             )
 
+        // Act
         val aktørerMedUtvidet =
             finnAktørerMedUtvidetFraAndeler(
                 andeler = andeler,
             )
 
+        // Assert
         Assertions.assertThat(aktørerMedUtvidet).containsExactly(søker.aktør)
     }
 
     @Test
     fun `Skal lage vilkårsvurdering med søkers vilkår satt med tom=dødsdato`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER).also { it.dødsfall = Dødsfall(person = it, dødsfallDato = LocalDate.now(), dødsfallAdresse = "Adresse 1", dødsfallPostnummer = "1234", dødsfallPoststed = "Oslo") }
         val barn = lagPerson(type = PersonType.BARN)
         val behandling = lagBehandling()
@@ -100,10 +104,13 @@ class VilkårsvurderingForNyBehandlingUtilsTest {
 
         vilkårsvurdering.personResultater = setOf(søkerPersonResultat, barnPersonResultat)
 
+        // Act
         val nyVilkårsvurdering =
             VilkårsvurderingForNyBehandlingUtils(personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = behandling.id, personer = mutableSetOf(barn, søker))).hentVilkårsvurderingMedDødsdatoSomTomDato(
                 vilkårsvurdering = vilkårsvurdering,
             )
+
+        // Assert
         val søkersVilkårResultater = nyVilkårsvurdering.personResultater.find { it.erSøkersResultater() }?.vilkårResultater
         val søkersUtvidetVilkår = søkersVilkårResultater?.filter { it.vilkårType == Vilkår.UTVIDET_BARNETRYGD }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VurderTilbakekrevingStegTest.kt
@@ -50,6 +50,7 @@ class VurderTilbakekrevingStegTest {
 
     @Test
     fun `skal utføre steg for vanlig behandling uten åpen tilbakekreving`() {
+        // Act
         val stegType =
             assertDoesNotThrow {
                 vurderTilbakekrevingSteg.utførStegOgAngiNeste(
@@ -57,6 +58,8 @@ class VurderTilbakekrevingStegTest {
                     tilbakekrevingDto,
                 )
             }
+
+        // Assert
         assertTrue { stegType == StegType.SEND_TIL_BESLUTTER }
         verify(exactly = 1) { tilbakekrevingService.validerRestTilbakekreving(tilbakekrevingDto, behandling.id) }
         verify(exactly = 1) { tilbakekrevingService.lagreTilbakekreving(tilbakekrevingDto, behandling.id) }
@@ -64,7 +67,10 @@ class VurderTilbakekrevingStegTest {
 
     @Test
     fun `skal utføre steg for vanlig behandling med åpen tilbakekreving`() {
+        // Arrange
         every { tilbakekrevingService.søkerHarÅpenTilbakekreving(any()) } returns true
+
+        // Act
         val stegType =
             assertDoesNotThrow {
                 vurderTilbakekrevingSteg.utførStegOgAngiNeste(
@@ -72,6 +78,8 @@ class VurderTilbakekrevingStegTest {
                     tilbakekrevingDto,
                 )
             }
+
+        // Assert
         assertTrue { stegType == StegType.SEND_TIL_BESLUTTER }
         verify(exactly = 0) { tilbakekrevingService.validerRestTilbakekreving(tilbakekrevingDto, behandling.id) }
         verify(exactly = 0) { tilbakekrevingService.lagreTilbakekreving(tilbakekrevingDto, behandling.id) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/komposisjon/TidslinjeUtilTest.kt
@@ -14,9 +14,11 @@ class TidslinjeUtilTest {
 
     @Test
     fun erUnder18ÅrVilkårTidslinje() {
+        // Act
         val erUnder18ÅrVilkårTidslinje = erUnder18ÅrVilkårTidslinje(person.fødselsdato)
         val perioder = erUnder18ÅrVilkårTidslinje.tilPerioder()
 
+        // Assert
         assertThat(perioder).hasSize(1)
         assertThat(perioder[0].verdi).isTrue()
         assertThat(perioder[0].fom).isEqualTo(1.feb(2020))
@@ -25,9 +27,11 @@ class TidslinjeUtilTest {
 
     @Test
     fun erUnder6ÅrTidslinje() {
+        // Act
         val erUnder6ÅrTidslinje = erUnder6ÅrTidslinje(person)
         val perioder = erUnder6ÅrTidslinje.tilPerioder()
 
+        // Assert
         assertThat(perioder).hasSize(1)
         assertThat(perioder[0].verdi).isTrue()
         assertThat(perioder[0].fom).isEqualTo(1.jan(2020))
@@ -36,9 +40,11 @@ class TidslinjeUtilTest {
 
     @Test
     fun erTilogMed3ÅrTidslinje() {
+        // Act
         val erUnder6ÅrTidslinje = erTilogMed3ÅrTidslinje(person.fødselsdato)
         val perioder = erUnder6ÅrTidslinje.tilPerioder()
 
+        // Assert
         assertThat(perioder).hasSize(1)
         assertThat(perioder[0].verdi).isTrue()
         assertThat(perioder[0].fom).isEqualTo(1.feb(2020))
@@ -47,9 +53,11 @@ class TidslinjeUtilTest {
 
     @Test
     fun opprettBooleanTidslinjeYearMonth() {
+        // Act
         val tidslinje = opprettBooleanTidslinje(jan(2020), mar(2020))
         val perioder = tidslinje.tilPerioder()
 
+        // Assert
         assertThat(perioder).hasSize(1)
         assertThat(perioder[0].verdi).isTrue()
         assertThat(perioder[0].fom).isEqualTo(1.jan(2020))
@@ -58,9 +66,11 @@ class TidslinjeUtilTest {
 
     @Test
     fun opprettBooleanTidslinjeLocalDate() {
+        // Act
         val tidslinje = opprettBooleanTidslinje(15.jan(2020), 15.mar(2020))
         val perioder = tidslinje.tilPerioder()
 
+        // Assert
         assertThat(perioder).hasSize(1)
         assertThat(perioder[0].verdi).isTrue()
         assertThat(perioder[0].fom).isEqualTo(15.jan(2020))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/util/CharTidslinjeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tidslinje/util/CharTidslinjeTest.kt
@@ -11,9 +11,13 @@ import org.junit.jupiter.api.Test
 class CharTidslinjeTest {
     @Test
     fun testEnkelCharTidsline() {
+        // Arrange
         val tegn = "---------------"
+
+        // Act
         val charTidslinje = tegn.tilCharTidslinje(jan(2020)).tilMåned { it.single() }
 
+        // Assert
         assertEquals(1.jan(2020), charTidslinje.startsTidspunkt)
         assertEquals(tegn.length.toLong(), charTidslinje.innhold.sumOf { it.lengde })
 
@@ -26,9 +30,13 @@ class CharTidslinjeTest {
 
     @Test
     fun testUendeligCharTidslinje() {
+        // Arrange
         val tegn = "<--->"
+
+        // Act
         val charTidslinje = tegn.tilCharTidslinje(jan(2020))
 
+        // Assert
         assertEquals(PRAKTISK_TIDLIGSTE_DAG, charTidslinje.startsTidspunkt)
 
         val periode = charTidslinje.tilPerioder().single()
@@ -40,9 +48,13 @@ class CharTidslinjeTest {
 
     @Test
     fun testSammensattTidsline() {
+        // Arrange
         val tegn = "aabbbbcdddddda"
+
+        // Act
         val charTidslinje = tegn.tilCharTidslinje(jan(2020)).tilMåned { it.single() }
 
+        // Assert
         assertEquals(1.jan(2020), charTidslinje.startsTidspunkt)
         assertEquals(tegn.length.toLong(), charTidslinje.innhold.sumOf { it.lengde })
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/tilbakekreving/TilbakekrevingUtilTest.kt
@@ -20,6 +20,7 @@ class TilbakekrevingUtilTest {
 
     @Test
     fun `test validerVerdierPåRestTilbakekreving kaster feil ved tilbakekreving uten feilutbetaling`() {
+        // Act & Assert
         assertThrows<Exception> {
             validerVerdierPåRestTilbakekreving(
                 tilbakekrevingDto =
@@ -34,6 +35,7 @@ class TilbakekrevingUtilTest {
 
     @Test
     fun `test validerVerdierPåRestTilbakekreving kaster feil ved ingen tilbakekreving når det er en feilutbetaling`() {
+        // Act & Assert
         assertThrows<Exception> {
             validerVerdierPåRestTilbakekreving(
                 tilbakekrevingDto = null,
@@ -44,6 +46,7 @@ class TilbakekrevingUtilTest {
 
     @Test
     fun `test sammenslåing av feilutbetalingsperioder med ensom siste periode`() {
+        // Arrange
         val simuleringsPerioder =
             listOf(
                 opprettSimuleringsPeriode(
@@ -68,8 +71,10 @@ class TilbakekrevingUtilTest {
                 ),
             )
 
+        // Act
         val sammenslåttePerioder = slåsammenNærliggendeFeilutbtalingPerioder(simuleringsPerioder)
 
+        // Assert
         Assertions.assertEquals(2, sammenslåttePerioder.size)
         Assertions.assertEquals(fom1, sammenslåttePerioder[0].fom)
         Assertions.assertEquals(tom2, sammenslåttePerioder[0].tom)
@@ -79,6 +84,7 @@ class TilbakekrevingUtilTest {
 
     @Test
     fun `test sammenslåing av feilutbetalingsperioder med ensom første periode`() {
+        // Arrange
         val simuleringsPerioder =
             listOf(
                 opprettSimuleringsPeriode(
@@ -103,8 +109,10 @@ class TilbakekrevingUtilTest {
                 ),
             )
 
+        // Act
         val sammenslåttePerioder = slåsammenNærliggendeFeilutbtalingPerioder(simuleringsPerioder)
 
+        // Assert
         Assertions.assertEquals(2, sammenslåttePerioder.size)
         Assertions.assertEquals(fom1, sammenslåttePerioder[0].fom)
         Assertions.assertEquals(tom1, sammenslåttePerioder[0].tom)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VilkårUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VilkårUtilsTest.kt
@@ -16,6 +16,7 @@ class VilkårUtilsTest {
      */
     @Test
     fun `vedtaksperioder sorteres korrekt til brev`() {
+        // Arrange
         val avslagMedTomDatoInneværendeMåned =
             lagUtvidetVedtaksperiodeMedBegrunnelser(
                 fom = LocalDate.now().minusMonths(6),
@@ -54,6 +55,7 @@ class VilkårUtilsTest {
                 utbetalingsperiodeDetaljer = listOf(lagUtbetalingsperiodeDetalj()),
             )
 
+        // Act
         val sorterteVedtaksperioder =
             listOf(
                 utbetalingsperiode,
@@ -63,6 +65,7 @@ class VilkårUtilsTest {
                 avslagUtenTomDato,
             ).shuffled().sorter()
 
+        // Assert
         // Utbetalingsperiode, opphørspersiode og avslagsperiode med fom-dato sorteres kronologisk
         Assertions.assertEquals(avslagMedTomDatoInneværendeMåned, sorterteVedtaksperioder[0])
         Assertions.assertEquals(avslagUtenTomDato, sorterteVedtaksperioder[1])

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/IVedtakBegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/begrunnelser/IVedtakBegrunnelseTest.kt
@@ -11,15 +11,21 @@ import org.junit.jupiter.params.provider.EnumSource
 internal class IVedtakBegrunnelseTest {
     @Test
     fun `Skal serialiseres med prefix`() {
+        // Act
         val serialisertStandardbegrunnelse =
             jsonMapper.writeValueAsString(Standardbegrunnelse.INNVILGET_BOR_HOS_SØKER)
+
+        // Assert
         Assertions.assertEquals(
             jsonMapper.readValue(serialisertStandardbegrunnelse, Standardbegrunnelse::class.java),
             Standardbegrunnelse.INNVILGET_BOR_HOS_SØKER,
         )
 
+        // Act
         val serialisertEØSStandardbegrunnelse =
             jsonMapper.writeValueAsString(EØSStandardbegrunnelse.AVSLAG_EØS_IKKE_EØS_BORGER)
+
+        // Assert
         Assertions.assertEquals(
             jsonMapper.readValue(serialisertEØSStandardbegrunnelse, EØSStandardbegrunnelse::class.java),
             EØSStandardbegrunnelse.AVSLAG_EØS_IKKE_EØS_BORGER,
@@ -45,6 +51,7 @@ internal class IVedtakBegrunnelseTest {
         mode = EnumSource.Mode.INCLUDE,
     )
     fun `Finnmark og Svalbard-begrunnelser blir sortert nederst`(standardbegrunnelse: Standardbegrunnelse) {
+        // Arrange
         val borHosSøker = lagBegrunnelseData(Standardbegrunnelse.INNVILGET_BOR_HOS_SØKER)
         val avslagGift = lagBegrunnelseData(Standardbegrunnelse.AVSLAG_GIFT)
 
@@ -52,8 +59,11 @@ internal class IVedtakBegrunnelseTest {
             lagBegrunnelseData(standardbegrunnelse)
 
         val usortertListe = listOf(avslagGift, begrunnelseMedFinnmarkEllerSvalbard, borHosSøker)
+
+        // Act
         val sortertListe = usortertListe.sorted()
 
+        // Assert
         assertThat(sortertListe.last()).isEqualTo(begrunnelseMedFinnmarkEllerSvalbard)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtvidetVedtaksperiodeMedBegrunnelserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/UtvidetVedtaksperiodeMedBegrunnelserTest.kt
@@ -24,6 +24,7 @@ class UtvidetVedtaksperiodeMedBegrunnelserTest {
 
     @Test
     fun `Skal kun legge på utbetalingsdetaljer som gjelder riktig andeler tilkjent ytelse for fortsatt innvilget`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val personopplysningGrunnlag =
@@ -78,12 +79,14 @@ class UtvidetVedtaksperiodeMedBegrunnelserTest {
                 type = Vedtaksperiodetype.FORTSATT_INNVILGET,
             )
 
+        // Act
         val utvidetVedtaksperiodeMedBegrunnelser =
             vedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 andelerTilkjentYtelse = andelerTilkjentYtelse,
             )
 
+        // Assert
         Assertions.assertEquals(1, utvidetVedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.size)
         Assertions.assertEquals(
             barn1.tilPersonDto().personIdent,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeMedBegrunnelseTest.kt
@@ -15,6 +15,7 @@ import java.time.YearMonth
 class VedtaksperiodeMedBegrunnelseTest {
     @Test
     fun `Skal finne begrunnelse på tidligere vedtaksperiode for samme fra- og med dato`() {
+        // Arrange
         val fom = YearMonth.now().minusMonths(3)
         val vedtak = lagVedtak()
 
@@ -39,6 +40,7 @@ class VedtaksperiodeMedBegrunnelseTest {
                 },
             )
 
+        // Act
         val fagsakErBegrunnet =
             vedtaksperioder.erAlleredeBegrunnetMedBegrunnelse(
                 standardbegrunnelser =
@@ -49,11 +51,13 @@ class VedtaksperiodeMedBegrunnelseTest {
                 måned = fom,
             )
 
+        // Assert
         assertTrue(fagsakErBegrunnet)
     }
 
     @Test
     fun `Skal ikke finne begrunnelse på tidligere vedtaksperiode når den er begrunnet for 1 år siden`() {
+        // Arrange
         val fom = YearMonth.now().minusMonths(3)
         val vedtak = lagVedtak()
 
@@ -78,17 +82,20 @@ class VedtaksperiodeMedBegrunnelseTest {
                 },
             )
 
+        // Act
         val fagsakErBegrunnet =
             vedtaksperioder.erAlleredeBegrunnetMedBegrunnelse(
                 standardbegrunnelser = listOf(Standardbegrunnelse.REDUKSJON_UNDER_6_ÅR_AUTOVEDTAK),
                 måned = fom,
             )
 
+        // Assert
         assertFalse(fagsakErBegrunnet)
     }
 
     @Test
     fun `Skal ikke finne begrunnelse på tidligere vedtaksperiode når den ikke har begrunnelsen i det hele tatt`() {
+        // Arrange
         val fom = YearMonth.now().minusMonths(3)
         val vedtak = lagVedtak()
 
@@ -112,17 +119,20 @@ class VedtaksperiodeMedBegrunnelseTest {
                 },
             )
 
+        // Act
         val fagsakErBegrunnet =
             vedtaksperioder.erAlleredeBegrunnetMedBegrunnelse(
                 standardbegrunnelser = listOf(Standardbegrunnelse.REDUKSJON_UNDER_6_ÅR_AUTOVEDTAK),
                 måned = fom,
             )
 
+        // Assert
         assertFalse(fagsakErBegrunnet)
     }
 
     @Test
     fun `Skal være begrunnet med reduksjon 3 år småbarnstillegg fra før`() {
+        // Arrange
         val vedtak = lagVedtak()
 
         val vedtaksperioder =
@@ -145,17 +155,20 @@ class VedtaksperiodeMedBegrunnelseTest {
                 },
             )
 
+        // Act
         val fagsakErBegrunnet =
             vedtaksperioder.erAlleredeBegrunnetMedBegrunnelse(
                 standardbegrunnelser = listOf(Standardbegrunnelse.REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_BARN_UNDER_TRE_ÅR),
                 måned = YearMonth.now(),
             )
 
+        // Assert
         assertTrue(fagsakErBegrunnet)
     }
 
     @Test
     fun `Skal være begrunnet med reduksjon 3 år småbarnstillegg for 1 år siden, men sende ut brev for neste barn som fyller 3 år`() {
+        // Arrange
         val vedtak = lagVedtak()
 
         val vedtaksperioder =
@@ -178,17 +191,20 @@ class VedtaksperiodeMedBegrunnelseTest {
                 },
             )
 
+        // Act
         val fagsakErBegrunnet =
             vedtaksperioder.erAlleredeBegrunnetMedBegrunnelse(
                 standardbegrunnelser = listOf(Standardbegrunnelse.REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_BARN_UNDER_TRE_ÅR),
                 måned = YearMonth.now(),
             )
 
+        // Assert
         assertFalse(fagsakErBegrunnet)
     }
 
     @Test
     fun `Skal være begrunnet med reduksjon ikke lenger full OS`() {
+        // Arrange
         val vedtak = lagVedtak()
 
         val vedtaksperioder =
@@ -211,12 +227,14 @@ class VedtaksperiodeMedBegrunnelseTest {
                 },
             )
 
+        // Act
         val fagsakErBegrunnet =
             vedtaksperioder.erAlleredeBegrunnetMedBegrunnelse(
                 standardbegrunnelser = listOf(Standardbegrunnelse.REDUKSJON_SMÅBARNSTILLEGG_IKKE_LENGER_FULL_OVERGANGSSTØNAD),
                 måned = YearMonth.now(),
             )
 
+        // Assert
         assertTrue(fagsakErBegrunnet)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -120,15 +120,19 @@ class VedtaksperiodeServiceTest {
 
     @Test
     fun `nasjonal sak skal ikke ha årlig kontroll`() {
+        // Arrange
         val behandling = lagBehandling(behandlingKategori = BehandlingKategori.NASJONAL)
         val vedtak = Vedtak(behandling = behandling)
 
         every { kompetanseRepository.finnFraBehandlingId(behandlingId = behandling.id) } returns emptyList()
+
+        // Act & Assert
         assertFalse { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }
 
     @Test
     fun `EØS med periode med utløpt tom skal ikke ha årlig kontroll`() {
+        // Arrange
         val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
 
         every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns
@@ -139,11 +143,13 @@ class VedtaksperiodeServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertFalse { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }
 
     @Test
     fun `EØS med periode med løpende tom skal ha årlig kontroll`() {
+        // Arrange
         val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
 
         every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns
@@ -154,11 +160,13 @@ class VedtaksperiodeServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertTrue { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }
 
     @Test
     fun `EØS med periode uten tom skal ha årlig kontroll`() {
+        // Arrange
         val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
 
         every { kompetanseRepository.finnFraBehandlingId(behandlingId = vedtak.behandling.id) } returns
@@ -169,17 +177,21 @@ class VedtaksperiodeServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertTrue { vedtaksperiodeService.skalHaÅrligKontroll(vedtak) }
     }
 
     @Test
     fun `skal beskrive perioder med for mye utbetalt for behandling med feilutbetalt valuta`() {
+        // Arrange
         val vedtak = Vedtak(behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS))
         val perioder =
             listOf(
                 LocalDate.now() to LocalDate.now().plusYears(1),
                 LocalDate.now().plusYears(2) to LocalDate.now().plusYears(3),
             )
+
+        // Act & Assert
         assertThat(vedtaksperiodeService.beskrivPerioderMedFeilutbetaltValuta(vedtak)).isNull()
 
         every {
@@ -188,8 +200,11 @@ class VedtaksperiodeServiceTest {
             perioder.map {
                 FeilutbetaltValuta(1L, fom = it.first, tom = it.second, 200, true)
             }
+
+        // Act
         val periodebeskrivelser = vedtaksperiodeService.beskrivPerioderMedFeilutbetaltValuta(vedtak)
 
+        // Assert
         perioder.forEach { periode ->
             assertThat(periodebeskrivelser!!.find { it.contains("${periode.first.year}") })
                 .contains("Fra", "til", "${periode.second.year}", "er det utbetalt 200 kroner for mye per måned.")
@@ -198,7 +213,10 @@ class VedtaksperiodeServiceTest {
 
     @Test
     fun `skal beskrive perioder med eøs refusjoner for behandlinger med avklarte refusjon eøs`() {
+        // Arrange
         val behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS)
+
+        // Act & Assert
         assertThat(
             vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(
                 behandling = behandling,
@@ -218,15 +236,20 @@ class VedtaksperiodeServiceTest {
                 ),
             )
 
+        // Act
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = true)
 
+        // Assert
         assertThat(perioder?.size).isEqualTo(1)
         assertThat(perioder?.single()).isEqualTo("Fra januar 2020 til januar 2022 blir etterbetaling på 200 kroner per måned utbetalt til myndighetene i Norge.")
     }
 
     @Test
     fun `skal beskrive perioder med eøs refusjoner for behandlinger med uavklarte refusjon eøs`() {
+        // Arrange
         val behandling = lagBehandling(behandlingKategori = BehandlingKategori.EØS)
+
+        // Act & Assert
         assertThat(
             vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(
                 behandling = behandling,
@@ -246,8 +269,10 @@ class VedtaksperiodeServiceTest {
                 ),
             )
 
+        // Act
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = false)
 
+        // Assert
         assertThat(perioder?.size).isEqualTo(1)
         assertThat(perioder?.single()).isEqualTo("Fra januar 2020 til januar 2022 blir ikke etterbetaling på 200 kroner per måned utbetalt nå siden det er utbetalt barnetrygd i Norge.")
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/AndelForVedtaksperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/vedtaksperiode/vedtaksperiodeProdusent/AndelForVedtaksperiodeTest.kt
@@ -8,6 +8,7 @@ import java.math.BigDecimal
 class AndelForVedtaksperiodeTest {
     @Test
     fun `equals blir true for like objekter`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 1000,
@@ -28,12 +29,14 @@ class AndelForVedtaksperiodeTest {
                 sats = 100,
             )
 
+        // Assert
         assertThat(andel1).isEqualTo(andel2)
         assertThat(andel1.hashCode()).isEqualTo(andel2.hashCode())
     }
 
     @Test
     fun `equals skal bli false for andeler med forskjellig type`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 1000,
@@ -54,11 +57,13 @@ class AndelForVedtaksperiodeTest {
                 sats = 100,
             )
 
+        // Assert
         assertThat(andel1).isNotEqualTo(andel2)
     }
 
     @Test
     fun `equals skal bli false for andeler med forskjellig prosent`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 1000,
@@ -79,11 +84,13 @@ class AndelForVedtaksperiodeTest {
                 sats = 100,
             )
 
+        // Assert
         assertThat(andel1).isNotEqualTo(andel2)
     }
 
     @Test
     fun `equals skal bli true for nullutbetalinger når satsen endrer seg og differanseberegnet periodebeløp er større enn 0`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 0,
@@ -104,12 +111,14 @@ class AndelForVedtaksperiodeTest {
                 sats = 200,
             )
 
+        // Assert
         assertThat(andel1).isEqualTo(andel2)
         assertThat(andel1.hashCode()).isEqualTo(andel2.hashCode())
     }
 
     @Test
     fun `equals skal bli false for nullutbetalinger når satsen endrer seg og differanseberegnet periodebeløp er mindre enn 0`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 0,
@@ -130,11 +139,13 @@ class AndelForVedtaksperiodeTest {
                 sats = 200,
             )
 
+        // Assert
         assertThat(andel1).isNotEqualTo(andel2)
     }
 
     @Test
     fun `equals skal bli false dersom ene kalkulerte utbetalingsbeløpet er null, og det andre ikke er null`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 0,
@@ -155,11 +166,13 @@ class AndelForVedtaksperiodeTest {
                 sats = 100,
             )
 
+        // Assert
         assertThat(andel1).isNotEqualTo(andel2)
     }
 
     @Test
     fun `equals skal bli false dersom ingen kalkulerte utbetalingsbeløp er null og satsene er ulike`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 1000,
@@ -180,11 +193,13 @@ class AndelForVedtaksperiodeTest {
                 sats = 200,
             )
 
+        // Assert
         assertThat(andel1).isNotEqualTo(andel2)
     }
 
     @Test
     fun `equals skal bli true dersom ingen kalkulerte utbetalingsbeløp er null og satsene er like`() {
+        // Arrange
         val andel1 =
             AndelForVedtaksperiode(
                 kalkulertUtbetalingsbeløp = 2000,
@@ -205,6 +220,7 @@ class AndelForVedtaksperiodeTest {
                 sats = 100,
             )
 
+        // Assert
         assertThat(andel1).isEqualTo(andel2)
         assertThat(andel1.hashCode()).isEqualTo(andel2.hashCode())
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/AnnenVurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/AnnenVurderingServiceTest.kt
@@ -41,6 +41,7 @@ class AnnenVurderingServiceTest {
 
     @Test
     fun `Verifiser endreAnnenVurdering`() {
+        // Arrange
         every { annenVurderingRepository.findById(any()) } returns
             Optional.of(
                 AnnenVurdering(
@@ -60,6 +61,7 @@ class AnnenVurderingServiceTest {
 
         every { annenVurderingRepository.save(any()) } returns nyAnnenVurering
 
+        // Act
         annenVurderingService.endreAnnenVurdering(
             personResultat.vilkårsvurdering.behandling.id,
             123L,
@@ -71,6 +73,7 @@ class AnnenVurderingServiceTest {
             ),
         )
 
+        // Assert
         verify(exactly = 1) {
             annenVurderingRepository.save(any())
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -26,13 +26,17 @@ import java.time.LocalDate
 class OppdaterVilkårsvurderingTest {
     @Test
     fun `Skal legge til nytt vilkår`() {
+        // Arrange
         val fnr1 = randomFnr()
         val aktørId1 = randomAktør()
         val behandling = lagBehandling()
         val resA = lagVilkårsvurdering(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
         val resB = lagVilkårsvurderingResultatB(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
 
+        // Act
         val (oppdatert, gammelt) = flyttResultaterTilInitielt(resB, resA)
+
+        // Assert
         Assertions.assertEquals(
             3,
             oppdatert.personResultater
@@ -52,13 +56,17 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal fjerne vilkår`() {
+        // Arrange
         val fnr1 = randomFnr()
         val aktørId1 = randomAktør()
         val behandling = lagBehandling()
         val resA = lagVilkårsvurderingResultatB(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
         val resB = lagVilkårsvurdering(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
 
+        // Act
         val (oppdatert, gammelt) = flyttResultaterTilInitielt(resB, resA)
+
+        // Assert
         Assertions.assertEquals(
             2,
             oppdatert.personResultater
@@ -84,6 +92,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal legge til person på vilkårsvurdering`() {
+        // Arrange
         val fnr1 = randomFnr()
         val fnr2 = randomFnr()
         val aktørId1 = randomAktør()
@@ -96,13 +105,17 @@ class OppdaterVilkårsvurderingTest {
                 fnrAktør = listOf(Pair(fnr1, aktørId1), Pair(fnr2, aktørId2)),
             )
 
+        // Act
         val (oppdatert, gammelt) = flyttResultaterTilInitielt(resB, resA)
+
+        // Assert
         Assertions.assertEquals(2, oppdatert.personResultater.size)
         Assertions.assertEquals(0, gammelt.personResultater.size)
     }
 
     @Test
     fun `Skal fjerne person på vilkårsvurdering`() {
+        // Arrange
         val fnr1 = randomFnr()
         val fnr2 = randomFnr()
         val aktørId1 = randomAktør()
@@ -115,13 +128,17 @@ class OppdaterVilkårsvurderingTest {
             )
         val resB = lagVilkårsvurdering(behandling = behandling, fnrAktør = listOf(Pair(fnr1, aktørId1)))
 
+        // Act
         val (oppdatert, gammelt) = flyttResultaterTilInitielt(resB, resA)
+
+        // Assert
         Assertions.assertEquals(1, oppdatert.personResultater.size)
         Assertions.assertEquals(1, gammelt.personResultater.size)
     }
 
     @Test
     fun `Skal lage advarsel tekst`() {
+        // Arrange
         val fnr1 = randomFnr()
         val fnr2 = randomFnr()
         val aktørId1 = lagAktør(fnr1)
@@ -140,8 +157,11 @@ class OppdaterVilkårsvurderingTest {
                 .first()
                 .vilkårResultater
                 .toList()
+
+        // Act
         val generertAdvarsel = lagFjernAdvarsel(resterende.personResultater)
 
+        // Assert
         Assertions.assertEquals(
             "Du har gjort endringer i behandlingsgrunnlaget. Dersom du går videre vil vilkår for følgende personer fjernes:\n" +
                 fnr1 + ":\n" +
@@ -153,6 +173,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal ha med tomt vilkår på person hvis vilkåret ble avslått forrige behandling`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
@@ -185,12 +206,14 @@ class OppdaterVilkårsvurderingTest {
         personResultat.setSortedVilkårResultater(bosattIRiketVilkårResultater)
         aktivMedBosattIRiketIkkeOppfylt.personResultater = setOf(personResultat)
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = init,
                 aktivVilkårsvurdering = aktivMedBosattIRiketIkkeOppfylt,
             )
 
+        // Assert
         val nyInitBosattIRiketVilkår =
             nyInit.personResultater
                 .find { it.aktør == søkerAktørId }
@@ -205,6 +228,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal ha med oppfylte perioder fra vilkår på person hvis vilkåret ble både avslått og innvilget forrige behandling`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
@@ -244,12 +268,14 @@ class OppdaterVilkårsvurderingTest {
         personResultat.setSortedVilkårResultater(bosattIRiketVilkårResultater)
         aktivMedBosattIRiketDelvisIkkeOppfylt.personResultater = setOf(personResultat)
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = init,
                 aktivVilkårsvurdering = aktivMedBosattIRiketDelvisIkkeOppfylt,
             )
 
+        // Assert
         val nyInitBosattIRiketVilkår =
             nyInit.personResultater
                 .find { it.aktør == søkerAktørId }
@@ -264,6 +290,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal beholde vilkår om utvidet barnetrygd når forrige behandling inneholdt utvidet-vilkåret, men inneværende behandling er ordinær`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
@@ -276,6 +303,7 @@ class OppdaterVilkårsvurderingTest {
                 listOf(Vilkår.UTVIDET_BARNETRYGD),
             )
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initUtenUtvidetVilkår,
@@ -284,6 +312,7 @@ class OppdaterVilkårsvurderingTest {
                 løpendeUnderkategori = BehandlingUnderkategori.UTVIDET,
             )
 
+        // Assert
         val nyInitInnholderUtvidetVilkår =
             nyInit.personResultater
                 .first()
@@ -296,6 +325,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal beholde vilkår om utvidet barnetrygd når det eksisterer løpende sak med utvidet, men inneværende behandling er ordinær`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
@@ -308,6 +338,7 @@ class OppdaterVilkårsvurderingTest {
                 listOf(Vilkår.UTVIDET_BARNETRYGD),
             )
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initUtenUtvidetVilkår,
@@ -315,6 +346,7 @@ class OppdaterVilkårsvurderingTest {
                 løpendeUnderkategori = BehandlingUnderkategori.UTVIDET,
             )
 
+        // Assert
         val nyInitInnholderUtvidetVilkår =
             nyInit.personResultater
                 .first()
@@ -327,6 +359,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal fjerne vilkår om utvidet barnetrygd når den inneværende behandlingen gjelder ordinær, og det ikke eksisterer løpende sak med utvidet, eller utvidet-vilkåret var på forrige behandling`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
@@ -339,6 +372,7 @@ class OppdaterVilkårsvurderingTest {
                 listOf(Vilkår.UTVIDET_BARNETRYGD),
             )
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initUtenUtvidetVilkår,
@@ -347,6 +381,7 @@ class OppdaterVilkårsvurderingTest {
                 aktørerMedUtvidetAndelerIForrigeBehandling = emptyList(),
             )
 
+        // Assert
         val nyInitInnholderIkkeUtvidetVilkår =
             nyInit.personResultater
                 .first()
@@ -364,6 +399,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal kun kopiere over oppfylte utvidet-vilkår ved opprettelse av ny behandling, men slette alle fra aktiv`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
@@ -397,6 +433,7 @@ class OppdaterVilkårsvurderingTest {
         personResultat.setSortedVilkårResultater(utvidetVilkårResultater)
         aktivVilkårsvurderingMedUtvidet.personResultater = setOf(personResultat)
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initUtenUtvidetVilkår,
@@ -405,6 +442,7 @@ class OppdaterVilkårsvurderingTest {
                 aktørerMedUtvidetAndelerIForrigeBehandling = listOf(søkerAktørId),
             )
 
+        // Assert
         val nyInitUtvidetVilkår =
             nyInit.personResultater
                 .first()
@@ -417,6 +455,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal kopiere over alle utvidet-vilkår fra aktiv vilkårsvurdering hvis den aktive vilkårsvurderingen er fra den inneværende behandlingen`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
@@ -449,6 +488,7 @@ class OppdaterVilkårsvurderingTest {
         personResultat.setSortedVilkårResultater(utvidetVilkårResultater)
         aktivVilkårsvurderingMedUtvidet.personResultater = setOf(personResultat)
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initUtenUtvidetVilkår,
@@ -457,6 +497,7 @@ class OppdaterVilkårsvurderingTest {
                 aktørerMedUtvidetAndelerIForrigeBehandling = listOf(søkerAktørId),
             )
 
+        // Assert
         val nyInitUtvidetVilkår =
             nyInit.personResultater
                 .first()
@@ -469,6 +510,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal ikke legge til utvidet vilkåret hvis det kun eksisterer ikke-oppfylte perioder, men fortsatt slette fra aktiv`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
         val forrigeBehandling = lagBehandling()
@@ -502,6 +544,7 @@ class OppdaterVilkårsvurderingTest {
         personResultat.setSortedVilkårResultater(utvidetVilkårResultater)
         aktivVilkårsvurderingMedUtvidetIkkeOppfylt.personResultater = setOf(personResultat)
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initUtenUtvidetVilkår,
@@ -510,6 +553,7 @@ class OppdaterVilkårsvurderingTest {
                 aktørerMedUtvidetAndelerIForrigeBehandling = emptyList(),
             )
 
+        // Assert
         val nyInitInneholderIkkeUtvidetVilkår =
             nyInit.personResultater
                 .first()
@@ -522,6 +566,7 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `Skal beholde andreVurderinger lagt til på inneværende behandling`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
 
@@ -539,12 +584,14 @@ class OppdaterVilkårsvurderingTest {
             .find { it.erSøkersResultater() }!!
             .leggTilBlankAnnenVurdering(AnnenVurderingType.OPPLYSNINGSPLIKT)
 
+        // Act
         val (nyInit, nyAktiv) =
             flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initiellVilkårsvurderingUtenAndreVurderinger,
                 aktivVilkårsvurdering = aktivVilkårsvurdering,
             )
 
+        // Assert
         val nyInitInnholderOpplysningspliktVilkår =
             nyInit.personResultater
                 .find { it.erSøkersResultater() }!!

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårTest.kt
@@ -13,12 +13,15 @@ class VilkårTest {
     inner class `Hent relevante vilkår for persontype BARN` {
         @Test
         fun `For ordinær nasjonal sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.BARN,
                     fagsakType = FagsakType.NORMAL,
                     behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.UNDER_18_ÅR,
@@ -32,12 +35,15 @@ class VilkårTest {
 
         @Test
         fun `For utvidet nasjonal sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.BARN,
                     fagsakType = FagsakType.NORMAL,
                     behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.UNDER_18_ÅR,
@@ -51,12 +57,15 @@ class VilkårTest {
 
         @Test
         fun `For ordinær institusjonssak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.BARN,
                     fagsakType = FagsakType.INSTITUSJON,
                     behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.UNDER_18_ÅR,
@@ -70,12 +79,15 @@ class VilkårTest {
 
         @Test
         fun `For utvidet institusjonssak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.BARN,
                     fagsakType = FagsakType.INSTITUSJON,
                     behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.UNDER_18_ÅR,
@@ -89,12 +101,15 @@ class VilkårTest {
 
         @Test
         fun `For ordinær enslig mindreårig sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.BARN,
                     fagsakType = FagsakType.BARN_ENSLIG_MINDREÅRIG,
                     behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.UNDER_18_ÅR,
@@ -108,12 +123,15 @@ class VilkårTest {
 
         @Test
         fun `For utvidet enslig mindreårig sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.BARN,
                     fagsakType = FagsakType.BARN_ENSLIG_MINDREÅRIG,
                     behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.UNDER_18_ÅR,
@@ -131,12 +149,15 @@ class VilkårTest {
     inner class `Hent relevante vilkår for persontype SØKER` {
         @Test
         fun `For ordinær nasjonal sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.SØKER,
                     fagsakType = FagsakType.NORMAL,
                     behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.BOSATT_I_RIKET,
@@ -147,12 +168,15 @@ class VilkårTest {
 
         @Test
         fun `For utvidet nasjonal sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.SØKER,
                     fagsakType = FagsakType.NORMAL,
                     behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
                 )
+
+            // Assert
             val vilkårForBarn =
                 setOf(
                     Vilkår.BOSATT_I_RIKET,
@@ -164,48 +188,60 @@ class VilkårTest {
 
         @Test
         fun `For ordinær institusjonssak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.SØKER,
                     fagsakType = FagsakType.INSTITUSJON,
                     behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 )
+
+            // Assert
             val vilkårForBarn = emptySet<Vilkår>()
             Assertions.assertEquals(vilkårForBarn, relevanteVilkår)
         }
 
         @Test
         fun `For utvidet institusjonssak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.SØKER,
                     fagsakType = FagsakType.INSTITUSJON,
                     behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
                 )
+
+            // Assert
             val vilkårForBarn = emptySet<Vilkår>()
             Assertions.assertEquals(vilkårForBarn, relevanteVilkår)
         }
 
         @Test
         fun `For ordinær enslig mindreårig sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.SØKER,
                     fagsakType = FagsakType.BARN_ENSLIG_MINDREÅRIG,
                     behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR,
                 )
+
+            // Assert
             val vilkårForBarn = emptySet<Vilkår>()
             Assertions.assertEquals(vilkårForBarn, relevanteVilkår)
         }
 
         @Test
         fun `For utvidet enslig mindreårig sak`() {
+            // Act
             val relevanteVilkår =
                 Vilkår.hentVilkårFor(
                     personType = PersonType.SØKER,
                     fagsakType = FagsakType.BARN_ENSLIG_MINDREÅRIG,
                     behandlingUnderkategori = BehandlingUnderkategori.UTVIDET,
                 )
+
+            // Assert
             val vilkårForBarn = emptySet<Vilkår>()
             Assertions.assertEquals(vilkårForBarn, relevanteVilkår)
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingForskyvningUtilsTest.kt
@@ -30,6 +30,7 @@ import java.time.Month
 class VilkårsvurderingForskyvningUtilsTest {
     @Test
     fun `Skal lage riktig splitt når bor med søker går fra delt bosted til fullt`() {
+        // Arrange
         val fom = LocalDate.now().minusMonths(7).førsteDagIInneværendeMåned()
         val deltBostedTom = LocalDate.now().minusMonths(1).sisteDagIMåned()
         val barnets18årsdag = LocalDate.now().plusYears(14)
@@ -57,8 +58,10 @@ class VilkårsvurderingForskyvningUtilsTest {
                 maksTom = barnets18årsdag,
             )
 
+        // Act
         val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
+        // Assert
         assertEquals(5, tidslinjer.size)
 
         val borMedSøkerTidslinje = tidslinjer.first()
@@ -84,6 +87,7 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `Skal lage riktig splitt når bor med søker går fra fullt til delt bosted`() {
+        // Arrange
         val fom = LocalDate.now().minusMonths(7).førsteDagIInneværendeMåned()
         val deltBostedTom = LocalDate.now().minusMonths(1).sisteDagIMåned()
         val barnets18årsdag = LocalDate.now().plusYears(14)
@@ -111,8 +115,10 @@ class VilkårsvurderingForskyvningUtilsTest {
                 maksTom = barnets18årsdag,
             )
 
+        // Act
         val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
+        // Assert
         assertEquals(5, tidslinjer.size)
 
         val borMedSøkerTidslinje = tidslinjer.first()
@@ -138,6 +144,7 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `Skal lage riktig splitt når bor med søker er oppfylt i to back2back-perioder uten utdypende vilkårsvurdering`() {
+        // Arrange
         val fom = LocalDate.now().minusMonths(7).førsteDagIInneværendeMåned()
         val b2bTom = LocalDate.now().minusMonths(1).sisteDagIMåned()
         val barnets18årsdag = LocalDate.now().plusYears(14)
@@ -164,8 +171,10 @@ class VilkårsvurderingForskyvningUtilsTest {
                 maksTom = barnets18årsdag,
             )
 
+        // Act
         val tidslinjer = vilkårResultater.tilForskjøvetTidslinjerForHvertOppfylteVilkår(barnets18årsdag.minusYears(18))
 
+        // Assert
         assertEquals(5, tidslinjer.size)
 
         val borMedSøkerTidslinje = tidslinjer.first()
@@ -191,6 +200,7 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `Skal forskyve UNDER_18 tidslinjen og beskjære den måneden før 18-årsdag`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val under18VilkårResultat =
@@ -203,9 +213,11 @@ class VilkårsvurderingForskyvningUtilsTest {
                 ),
             )
 
+        // Act
         val forskjøvetTidslinje =
             under18VilkårResultat.tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = Vilkår.UNDER_18_ÅR, barn.fødselsdato)
 
+        // Assert
         val forskjøvedePerioder = forskjøvetTidslinje.tilPerioder()
 
         assertEquals(1, forskjøvedePerioder.size)
@@ -224,6 +236,7 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `Skal forskyve UNDER_18 tidslinjen, men ikke kutte den måneden før hvis til og med dato ikke er i måneden hen fyller 18`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val tomDato = barn.fødselsdato.plusYears(7)
@@ -238,9 +251,11 @@ class VilkårsvurderingForskyvningUtilsTest {
                 ),
             )
 
+        // Act
         val forskjøvetTidslinje =
             under18VilkårResultat.tilForskjøvetTidslinjeForOppfyltVilkår(vilkår = Vilkår.UNDER_18_ÅR, barn.fødselsdato)
 
+        // Assert
         val forskjøvedePerioder = forskjøvetTidslinje.tilPerioder()
 
         assertEquals(1, forskjøvedePerioder.size)
@@ -253,27 +268,35 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `Skal gi tom liste og ikke kaste feil dersom vi ikke sender med noen vilkårresultater`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
+        // Act
         val forskjøvedeOppfylteVilkårTomListe =
             emptyList<VilkårResultat>()
                 .tilForskjøvetTidslinjeForOppfyltVilkår(
                     vilkår = Vilkår.UNDER_18_ÅR,
                     fødselsdato = barn.fødselsdato,
                 ).tilPerioder()
+
+        // Assert
         assertEquals(forskjøvedeOppfylteVilkårTomListe.size, 0)
 
+        // Act
         val forskjøvedeVilkårTomListe =
             emptyList<VilkårResultat>()
                 .tilForskjøvetTidslinje(
                     vilkår = Vilkår.UNDER_18_ÅR,
                     fødselsdato = barn.fødselsdato,
                 ).tilPerioder()
+
+        // Assert
         assertEquals(forskjøvedeVilkårTomListe.size, 0)
     }
 
     @Test
     fun `skal forskyve eksplisitt avslag når avslaget starter og opphører innenfor samme måned`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val vilkårResultat =
@@ -287,6 +310,7 @@ class VilkårsvurderingForskyvningUtilsTest {
                 ),
             )
 
+        // Act
         val forskjøvedeVilkår =
             vilkårResultat
                 .tilForskjøvetTidslinje(
@@ -294,6 +318,7 @@ class VilkårsvurderingForskyvningUtilsTest {
                     fødselsdato = barn.fødselsdato,
                 ).tilPerioderIkkeNull()
 
+        // Assert
         assertEquals(1, forskjøvedeVilkår.size)
 
         val periode = forskjøvedeVilkår.single()
@@ -303,6 +328,7 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `skal ikke forskyve eksplisitt avslag når avslaget blir etterfulgt av en innvilget periode`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val vilkårResultat =
@@ -322,6 +348,7 @@ class VilkårsvurderingForskyvningUtilsTest {
                 ),
             )
 
+        // Act
         val forskjøvedeVilkår =
             vilkårResultat
                 .tilForskjøvetTidslinje(
@@ -329,6 +356,7 @@ class VilkårsvurderingForskyvningUtilsTest {
                     fødselsdato = barn.fødselsdato,
                 ).tilPerioderIkkeNull()
 
+        // Assert
         assertEquals(2, forskjøvedeVilkår.size)
 
         val periode = forskjøvedeVilkår.single { it.verdi.erEksplisittAvslagPåSøknad == true }
@@ -338,6 +366,7 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `skal ikke forskyve eksplisitt avslag når avslaget ikke opphører innenfor samme måned`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val vilkårResultat =
@@ -351,6 +380,7 @@ class VilkårsvurderingForskyvningUtilsTest {
                 ),
             )
 
+        // Act
         val forskjøvedeVilkår =
             vilkårResultat
                 .tilForskjøvetTidslinje(
@@ -358,6 +388,7 @@ class VilkårsvurderingForskyvningUtilsTest {
                     fødselsdato = barn.fødselsdato,
                 ).tilPerioderIkkeNull()
 
+        // Assert
         assertEquals(1, forskjøvedeVilkår.size)
         val periode = forskjøvedeVilkår.single()
         assertEquals(1.feb(2023), periode.fom)
@@ -366,6 +397,7 @@ class VilkårsvurderingForskyvningUtilsTest {
 
     @Test
     fun `skal ikke forskyve opphørsperioder som starter og slutter innenfor samme måned`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val vilkårResultat =
@@ -378,6 +410,7 @@ class VilkårsvurderingForskyvningUtilsTest {
                 ),
             )
 
+        // Act
         val forskjøvedeVilkår =
             vilkårResultat
                 .tilForskjøvetTidslinje(
@@ -385,11 +418,13 @@ class VilkårsvurderingForskyvningUtilsTest {
                     fødselsdato = barn.fødselsdato,
                 ).tilPerioderIkkeNull()
 
+        // Assert
         assertEquals(0, forskjøvedeVilkår.size)
     }
 
     @Test
     fun `Skal kutte UNDER_18 tidslinjen måneden før 18-årsdag`() {
+        // Arrange
         val barn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2022, Month.DECEMBER, 1).minusYears(18))
 
         val under18VilkårResultat =
@@ -407,8 +442,10 @@ class VilkårsvurderingForskyvningUtilsTest {
                 tom = under18VilkårResultat.periodeTom?.sisteDagIMåned(),
             ).tilTidslinje()
 
+        // Act
         val under18PerioderFørBeskjæring = under18årVilkårTidslinje.tilPerioder()
 
+        // Assert
         assertEquals(1, under18PerioderFørBeskjæring.size)
         assertEquals(
             barn.fødselsdato.førsteDagINesteMåned(),
@@ -419,8 +456,10 @@ class VilkårsvurderingForskyvningUtilsTest {
             under18PerioderFørBeskjæring.first().tom,
         )
 
+        // Act
         val tidslinjeBeskåret = under18årVilkårTidslinje.beskjærPå18År(barn.fødselsdato)
 
+        // Assert
         val under18PerioderEtterBeskjæring = tidslinjeBeskåret.tilPerioder()
 
         assertEquals(1, under18PerioderEtterBeskjæring.size)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -23,6 +23,7 @@ internal class VilkårsvurderingServiceTest {
 
     @Test
     fun `oppdaterVilkårVedDødsfall skal sette tom dato til dødsfallsdato dersom dødsfallsdato er tidligere enn nåværende tom`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.DØDSFALL_BRUKER)
         val aktør = randomAktør()
         val vilkårFomDato = LocalDate.of(2000, 1, 1)
@@ -40,8 +41,10 @@ internal class VilkårsvurderingServiceTest {
 
         every { vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId = behandling.id) } returns vilkårsvurdering
 
+        // Act
         vilkårsvurderingService.oppdaterVilkårVedDødsfall(behandlingId = BehandlingId(behandling.id), dødsfallsDato, aktør)
 
+        // Assert
         val vilkårResultater = vilkårsvurdering.personResultater.single().vilkårResultater
 
         assertThat(vilkårResultater.all { it.periodeTom == dødsfallsDato }, Is(true))
@@ -49,6 +52,7 @@ internal class VilkårsvurderingServiceTest {
 
     @Test
     fun `oppdaterVilkårVedDødsfall skal ikke sette tom dato til dødsfallsdato dersom dødsfallsdato er senere enn nåværende tom`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.DØDSFALL_BRUKER)
         val aktør = randomAktør()
         val vilkårFomDato = LocalDate.of(2000, 1, 1)
@@ -66,8 +70,10 @@ internal class VilkårsvurderingServiceTest {
 
         every { vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId = behandling.id) } returns vilkårsvurdering
 
+        // Act
         vilkårsvurderingService.oppdaterVilkårVedDødsfall(behandlingId = BehandlingId(behandling.id), dødsfallsDato, aktør)
 
+        // Assert
         val vilkårResultater = vilkårsvurdering.personResultater.single().vilkårResultater
 
         assertThat(vilkårResultater.all { it.periodeTom == vilkårTomDato }, Is(true))
@@ -75,6 +81,7 @@ internal class VilkårsvurderingServiceTest {
 
     @Test
     fun `oppdaterVilkårVedDødsfall skal ikke sette tom dato til dødsfallsdato dersom tom dato ikke allerede er satt`() {
+        // Arrange
         val behandling = lagBehandling(årsak = BehandlingÅrsak.DØDSFALL_BRUKER)
         val aktør = randomAktør()
         val vilkårFomDato = LocalDate.of(2000, 1, 1)
@@ -91,8 +98,10 @@ internal class VilkårsvurderingServiceTest {
 
         every { vilkårsvurderingRepository.findByBehandlingAndAktiv(behandlingId = behandling.id) } returns vilkårsvurdering
 
+        // Act
         vilkårsvurderingService.oppdaterVilkårVedDødsfall(behandlingId = BehandlingId(behandling.id), dødsfallsDato, aktør)
 
+        // Assert
         val vilkårResultater = vilkårsvurdering.personResultater.single().vilkårResultater
 
         assertThat(vilkårResultater.all { it.periodeTom == null }, Is(true))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingStegUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingStegUtilsTest.kt
@@ -108,6 +108,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `periode erstattes dersom en periode med overlappende tidsintervall legges til`() {
+        // Arrange
         val vilkårResultatDto =
             VilkårResultatDto(
                 2,
@@ -120,11 +121,14 @@ class VilkårsvurderingStegUtilsTest {
                 LocalDateTime.now(),
                 behandling.id,
             )
+
+        // Act
         VilkårsvurderingUtils.muterPersonVilkårResultaterPut(
             personResultat,
             vilkårResultatDto,
         )
 
+        // Assert
         assertEquals(2, personResultat.vilkårResultater.size)
         assertPeriode(
             Periode(
@@ -145,6 +149,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `periode splittes dersom en periode med inneklemt tidsintervall legges til`() {
+        // Arrange
         val vilkårResultatDto =
             VilkårResultatDto(
                 2,
@@ -158,11 +163,13 @@ class VilkårsvurderingStegUtilsTest {
                 behandling.id,
             )
 
+        // Act
         VilkårsvurderingUtils.muterPersonVilkårResultaterPut(
             personResultat,
             vilkårResultatDto,
         )
 
+        // Assert
         assertEquals(4, personResultat.vilkårResultater.size)
         assertPeriode(
             Periode(
@@ -196,6 +203,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `fom-dato flyttes korrekt`() {
+        // Arrange
         val vilkårResultatDto =
             VilkårResultatDto(
                 2,
@@ -209,11 +217,13 @@ class VilkårsvurderingStegUtilsTest {
                 behandling.id,
             )
 
+        // Act
         VilkårsvurderingUtils.muterPersonVilkårResultaterPut(
             personResultat,
             vilkårResultatDto,
         )
 
+        // Assert
         assertEquals(3, personResultat.vilkårResultater.size)
         assertPeriode(
             Periode(
@@ -240,6 +250,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `tom-dato flyttes korrekt`() {
+        // Arrange
         val vilkårResultatDto =
             VilkårResultatDto(
                 2,
@@ -253,11 +264,13 @@ class VilkårsvurderingStegUtilsTest {
                 behandling.id,
             )
 
+        // Act
         VilkårsvurderingUtils.muterPersonVilkårResultaterPut(
             personResultat,
             vilkårResultatDto,
         )
 
+        // Assert
         assertEquals(3, personResultat.vilkårResultater.size)
         assertPeriode(
             Periode(
@@ -284,6 +297,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `skal sette erAutomatiskVurdert til false og begrunnelseForManuellKontroll til null`() {
+        // Arrange
         val vilkårResultatDto =
             VilkårResultatDto(
                 id = 1,
@@ -302,16 +316,19 @@ class VilkårsvurderingStegUtilsTest {
             it.begrunnelseForManuellKontroll = INFORMASJON_FRA_SØKNAD
         }
 
+        // Act
         VilkårsvurderingUtils.muterPersonVilkårResultaterPut(
             personResultat,
             vilkårResultatDto,
         )
 
+        // Assert
         with(personResultat.vilkårResultater.first { it.id == 1L }) {
             assertThat(erAutomatiskVurdert).isFalse()
             assertThat(begrunnelseForManuellKontroll).isNull()
         }
 
+        // Assert
         assertThat(personResultat.vilkårResultater.filter { it.id != 1L }).allSatisfy {
             assertThat(it.erAutomatiskVurdert).isTrue()
             assertThat(it.begrunnelseForManuellKontroll).isEqualTo(INFORMASJON_FRA_SØKNAD)
@@ -320,8 +337,10 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `Skal fjerne og ikke fylle inn tom periode i midten`() {
+        // Act
         VilkårsvurderingUtils.muterPersonResultatDelete(personResultat, 2)
 
+        // Assert
         assertEquals(2, personResultat.vilkårResultater.size)
         assertPeriode(
             Periode(
@@ -341,11 +360,13 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `Skal fjerne første periode`() {
+        // Act
         VilkårsvurderingUtils.muterPersonResultatDelete(
             personResultat,
             1,
         )
 
+        // Assert
         assertEquals(2, personResultat.vilkårResultater.size)
         assertPeriode(
             Periode(
@@ -365,11 +386,13 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `Skal fjerne siste periode`() {
+        // Act
         VilkårsvurderingUtils.muterPersonResultatDelete(
             personResultat,
             3,
         )
 
+        // Assert
         assertEquals(2, personResultat.vilkårResultater.size)
         assertPeriode(
             Periode(
@@ -389,6 +412,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `Skal nullstille periode hvis det kun finnes en periode`() {
+        // Arrange
         val mockPersonResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -409,25 +433,35 @@ class VilkårsvurderingStegUtilsTest {
             )
         mockPersonResultat.setSortedVilkårResultater(setOf(mockVilkårResultat))
 
+        // Act
         VilkårsvurderingUtils.muterPersonResultatDelete(
             mockPersonResultat,
             1,
         )
 
+        // Assert
         assertEquals(1, mockPersonResultat.vilkårResultater.size)
         assertEquals(Resultat.IKKE_VURDERT, mockPersonResultat.getSortedVilkårResultat(0)!!.resultat)
     }
 
     @Test
     fun `Skal legge til periode`() {
+        // Assert
         assertEquals(3, personResultat.vilkårResultater.size)
+
+        // Act
         VilkårsvurderingUtils.muterPersonResultatPost(personResultat, Vilkår.BOR_MED_SØKER)
+
+        // Assert
         assertEquals(4, personResultat.vilkårResultater.size)
     }
 
     @Test
     fun `Skal kaste feil når det legges til periode i en vilkårtype der det allerede finnes en uvurdert periode`() {
+        // Arrange
         VilkårsvurderingUtils.muterPersonResultatPost(personResultat, Vilkår.BOR_MED_SØKER)
+
+        // Act & Assert
         assertThrows(FunksjonellFeil::class.java) {
             VilkårsvurderingUtils.muterPersonResultatPost(personResultat, Vilkår.BOR_MED_SØKER)
         }
@@ -435,6 +469,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `Skal tilpasse vilkår for endret vilkår når begge mangler tom-dato`() {
+        // Arrange
         val vilkårResultat =
             VilkårResultat(
                 personResultat = personResultat,
@@ -457,14 +492,17 @@ class VilkårsvurderingStegUtilsTest {
                 behandlingId = behandling.id,
             )
 
+        // Act
         VilkårsvurderingUtils.tilpassVilkårForEndretVilkår(personResultat, vilkårResultat, vilkårResultatDto)
 
+        // Assert
         assertEquals(LocalDate.of(2020, 1, 1), vilkårResultat.periodeFom)
         assertEquals(LocalDate.of(2020, 5, 31), vilkårResultat.periodeTom)
     }
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke bort ikke oppfylte perioder når det gjelder samme behandling`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
@@ -477,6 +515,7 @@ class VilkårsvurderingStegUtilsTest {
                 listOf(Resultat.IKKE_OPPFYLT, Resultat.OPPFYLT),
             )
 
+        // Act
         val (initiell, _) =
             VilkårsvurderingUtils.flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initiellVilkårvurdering,
@@ -486,6 +525,7 @@ class VilkårsvurderingStegUtilsTest {
         val opprettetBosattIRiket =
             initiell.personResultater.flatMap { it.vilkårResultater }.filter { it.vilkårType == BOSATT_I_RIKET }
 
+        // Assert
         assertEquals(2, opprettetBosattIRiket.size)
         assertEquals(
             listOf(Resultat.IKKE_OPPFYLT, Resultat.OPPFYLT).sorted(),
@@ -495,6 +535,7 @@ class VilkårsvurderingStegUtilsTest {
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke oppfylt om oppfylt finnes ved kopiering fra forrige behandling`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
         val behandling2 = lagBehandling()
@@ -508,6 +549,7 @@ class VilkårsvurderingStegUtilsTest {
                 listOf(Resultat.IKKE_OPPFYLT, Resultat.OPPFYLT),
             )
 
+        // Act
         val (initiell, _) =
             VilkårsvurderingUtils.flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initiellVilkårvurdering,
@@ -517,12 +559,14 @@ class VilkårsvurderingStegUtilsTest {
         val opprettetBosattIRiket =
             initiell.personResultater.flatMap { it.vilkårResultater }.filter { it.vilkårType == BOSATT_I_RIKET }
 
+        // Assert
         assertEquals(1, opprettetBosattIRiket.size)
         assertEquals(Resultat.OPPFYLT, opprettetBosattIRiket.first().resultat)
     }
 
     @Test
     fun `flyttResultaterTilInitielt filtrer ikke ikke oppfylt om oppfylt ikke finnes`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val behandling = lagBehandling()
 
@@ -535,6 +579,7 @@ class VilkårsvurderingStegUtilsTest {
                 listOf(Resultat.IKKE_OPPFYLT, Resultat.IKKE_OPPFYLT),
             )
 
+        // Act
         val (initiell, _) =
             VilkårsvurderingUtils.flyttResultaterTilInitielt(
                 initiellVilkårsvurdering = initiellVilkårsvurdering,
@@ -544,6 +589,7 @@ class VilkårsvurderingStegUtilsTest {
         val opprettetBosattIRiket =
             initiell.personResultater.flatMap { it.vilkårResultater }.filter { it.vilkårType == BOSATT_I_RIKET }
 
+        // Assert
         assertEquals(2, opprettetBosattIRiket.size)
         assertTrue(opprettetBosattIRiket.none { it.resultat == Resultat.OPPFYLT })
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -29,6 +29,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `feil kastes når det finnes løpende oppfylt ved forsøk på å legge til avslag uten periode`() {
+        // Arrange
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = uvesentligVilkårsvurdering,
@@ -60,6 +61,7 @@ class VilkårsvurderingUtilsTest {
                 erEksplisittAvslagPåSøknad = true,
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             VilkårsvurderingUtils.validerAvslagUtenPeriodeMedLøpende(
                 personSomEndres = personResultat,
@@ -70,6 +72,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `feil kastes når det finnes avslag uten periode ved forsøk på å legge til løpende oppfylt`() {
+        // Arrange
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = uvesentligVilkårsvurdering,
@@ -101,6 +104,7 @@ class VilkårsvurderingUtilsTest {
                 behandlingId = 0,
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             VilkårsvurderingUtils.validerAvslagUtenPeriodeMedLøpende(
                 personSomEndres = personResultat,
@@ -111,6 +115,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `skal ikke kaste feil hvis vilkåret er bor med søker`() {
+        // Arrange
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = uvesentligVilkårsvurdering,
@@ -142,6 +147,7 @@ class VilkårsvurderingUtilsTest {
                 erEksplisittAvslagPåSøknad = true,
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             VilkårsvurderingUtils.validerAvslagUtenPeriodeMedLøpende(
                 personSomEndres = personResultat,
@@ -152,6 +158,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `feil kastes ikke når når ingen periode er løpende`() {
+        // Arrange
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = uvesentligVilkårsvurdering,
@@ -183,6 +190,7 @@ class VilkårsvurderingUtilsTest {
                 behandlingId = 0,
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             VilkårsvurderingUtils.validerAvslagUtenPeriodeMedLøpende(
                 personSomEndres = personResultat,
@@ -193,6 +201,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `skal liste opp begrunnelser uten vilkår`() {
+        // Arrange
         val sanityBegrunnelser =
             mapOf(
                 Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
@@ -204,14 +213,17 @@ class VilkårsvurderingUtilsTest {
             )
         val vedtakBegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET
 
+        // Act
         val vedtakBegrunnelserTilknyttetVilkårDto =
             vedtakBegrunnelseTilVedtakBegrunnelseTilknyttetVilkårDto(sanityBegrunnelser, vedtakBegrunnelse)
 
+        // Assert
         Assertions.assertEquals(1, vedtakBegrunnelserTilknyttetVilkårDto.size)
     }
 
     @Test
     fun `skal liste opp begrunnelsene en gang per vilkår`() {
+        // Arrange
         val sanityBegrunnelser =
             mapOf(
                 Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET to
@@ -223,25 +235,30 @@ class VilkårsvurderingUtilsTest {
             )
         val vedtakBegrunnelse = Standardbegrunnelse.INNVILGET_BOSATT_I_RIKTET
 
+        // Act
         val vedtakBegrunnelserTilknyttetVilkårDto =
             vedtakBegrunnelseTilVedtakBegrunnelseTilknyttetVilkårDto(sanityBegrunnelser, vedtakBegrunnelse)
 
+        // Assert
         Assertions.assertEquals(2, vedtakBegrunnelserTilknyttetVilkårDto.size)
     }
 
     @Test
     fun `genererPersonResultatForPerson skal sette til-og-med dato på alle vilkår til dødsfallsdato og begrunnelse til dødsfall hvis barn er død`() {
+        // Arrange
         val nyBehandling = lagBehandling()
 
         val vilkårsvurdering = Vilkårsvurdering(behandling = nyBehandling)
         val dødtBarn = lagPerson(type = PersonType.BARN).apply { dødsfall = lagDødsfallFraPdl(this, "2012-12-12", null) }
 
+        // Act
         val personResultatForDødtBarn =
             genererPersonResultatForPerson(
                 vilkårsvurdering = vilkårsvurdering,
                 person = dødtBarn,
             )
 
+        // Assert
         Assertions.assertTrue(personResultatForDødtBarn.vilkårResultater.all { it.begrunnelse == "Dødsfall" })
         Assertions.assertTrue(
             personResultatForDødtBarn.vilkårResultater.all {
@@ -252,17 +269,20 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `genererPersonResultatForPerson skal sette til-og-med dato på under-18-årsvilkår til 18 års datoen hvis barn ikke er død`() {
+        // Arrange
         val nyBehandling = lagBehandling()
 
         val vilkårsvurdering = Vilkårsvurdering(behandling = nyBehandling)
         val levendeBarn = lagPerson(type = PersonType.BARN, fødselsdato = LocalDate.of(2020, 10, 10))
 
+        // Act
         val personResultatForLevendeBarn =
             genererPersonResultatForPerson(
                 vilkårsvurdering = vilkårsvurdering,
                 person = levendeBarn,
             )
 
+        // Assert
         val under18ÅrVilkår =
             personResultatForLevendeBarn.vilkårResultater.find { it.vilkårType == Vilkår.UNDER_18_ÅR }!!
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLoggTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/domene/EndringIPreutfyltVilkårLoggTest.kt
@@ -11,6 +11,7 @@ import java.time.LocalDateTime
 class EndringIPreutfyltVilkårLoggTest {
     @Test
     fun `oppdaterEndringIPreutfyltVilkårLogg beholder forrige-verdier og oppdaterer ny-verdier`() {
+        // Arrange
         val behandling = lagBehandling(id = 1234)
         val forrigeVilkår =
             VilkårResultat(
@@ -76,8 +77,10 @@ class EndringIPreutfyltVilkårLoggTest {
                 nyttVilkår = førsteEditDto,
             )
 
+        // Act
         val oppdatertLogg = opprinneligLogg.oppdaterEndringIPreutfyltVilkårLogg(andreEditDto)
 
+        // Assert
         // forrige*-felt er uendret (original preutfylt-tilstand)
         assertThat(oppdatertLogg.forrigeResultat).isEqualTo(Resultat.IKKE_OPPFYLT)
         assertThat(oppdatertLogg.forrigeFom).isEqualTo(LocalDate.of(2020, 1, 1))
@@ -97,6 +100,7 @@ class EndringIPreutfyltVilkårLoggTest {
 
     @Test
     fun `opprettLoggForEndringIPreutfyltVilkår mapper forrige og nye verdier`() {
+        // Arrange
         val behandling = lagBehandling(id = 1234)
         val forrigeVilkår =
             VilkårResultat(
@@ -134,6 +138,7 @@ class EndringIPreutfyltVilkårLoggTest {
                 begrunnelseForManuellKontroll = null,
             )
 
+        // Act
         val logg =
             EndringIPreutfyltVilkårLogg.opprettLoggForEndringIPreutfyltVilkår(
                 behandling = behandling,
@@ -141,6 +146,7 @@ class EndringIPreutfyltVilkårLoggTest {
                 nyttVilkår = nyttVilkår,
             )
 
+        // Assert
         assertThat(logg.behandling).isEqualTo(behandling)
         assertThat(logg.vilkårResultatId).isEqualTo(forrigeVilkår.id)
         assertThat(logg.vilkårType).isEqualTo(Vilkår.BOSATT_I_RIKET)
@@ -161,6 +167,7 @@ class EndringIPreutfyltVilkårLoggTest {
 
     @Test
     fun `opprettLoggForEndringIPreutfyltVilkår håndterer nullfelt`() {
+        // Arrange
         val behandling = lagBehandling(id = 5678)
         val forrigeVilkår =
             VilkårResultat(
@@ -198,6 +205,7 @@ class EndringIPreutfyltVilkårLoggTest {
                 begrunnelseForManuellKontroll = null,
             )
 
+        // Act
         val logg =
             EndringIPreutfyltVilkårLogg.opprettLoggForEndringIPreutfyltVilkår(
                 behandling = behandling,
@@ -205,6 +213,7 @@ class EndringIPreutfyltVilkårLoggTest {
                 nyttVilkår = nyttVilkår,
             )
 
+        // Assert
         assertThat(logg.forrigeFom).isNull()
         assertThat(logg.nyFom).isNull()
         assertThat(logg.forrigeTom).isNull()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/AuditLoggerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/AuditLoggerTest.kt
@@ -47,13 +47,17 @@ internal class AuditLoggerTest {
 
     @Test
     internal fun `logger melding uten custom strings`() {
+        // Act
         auditLogger.log(Sporingsdata(AuditLoggerEvent.ACCESS, "12345678901"))
+
+        // Assert
         assertThat(listAppender.list).hasSize(1)
         assertThat(getMessage()).isEqualTo(expectedBaseLog)
     }
 
     @Test
     internal fun `logger melding med custom strings`() {
+        // Act
         auditLogger.log(
             Sporingsdata(
                 event = AuditLoggerEvent.ACCESS,
@@ -63,6 +67,8 @@ internal class AuditLoggerTest {
                 custom3 = CustomKeyValue("k3", "v3"),
             ),
         )
+
+        // Assert
         assertThat(listAppender.list).hasSize(1)
         assertThat(getMessage())
             .isEqualTo("${expectedBaseLog}cs3Label=k cs3=v cs5Label=k2 cs5=v2 cs6Label=k3 cs6=v3")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SikkerhetContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/sikkerhet/SikkerhetContextTest.kt
@@ -49,7 +49,10 @@ class SikkerhetContextTest {
     inner class ErSystemKontekstTest {
         @Test
         fun `returnerer false når NAVident er en saksbehandler-ident`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")))
+
+            // Act & Assert
             assertThat(erSystemKontekst()).isFalse()
         }
 
@@ -63,6 +66,7 @@ class SikkerhetContextTest {
     inner class ErMaskinTilMaskinTokenTest {
         @Test
         fun `returnerer true når oid er lik sub og roles inneholder access_as_application`() {
+            // Arrange
             val appId = "appId"
             settSikkerhetscontext(
                 lagJwt(
@@ -73,11 +77,14 @@ class SikkerhetContextTest {
                     ),
                 ),
             )
+
+            // Act & Assert
             assertThat(erMaskinTilMaskinToken()).isTrue()
         }
 
         @Test
         fun `returnerer false når oid er ulik sub`() {
+            // Arrange
             settSikkerhetscontext(
                 lagJwt(
                     mapOf(
@@ -87,11 +94,14 @@ class SikkerhetContextTest {
                     ),
                 ),
             )
+
+            // Act & Assert
             assertThat(erMaskinTilMaskinToken()).isFalse()
         }
 
         @Test
         fun `returnerer false når oid er lik sub men rollen mangler`() {
+            // Arrange
             val appId = "appId"
             settSikkerhetscontext(
                 lagJwt(
@@ -102,6 +112,8 @@ class SikkerhetContextTest {
                     ),
                 ),
             )
+
+            // Act & Assert
             assertThat(erMaskinTilMaskinToken()).isFalse()
         }
 
@@ -115,13 +127,19 @@ class SikkerhetContextTest {
     inner class HentSaksbehandlerTest {
         @Test
         fun `returnerer NAVident-claim fra token`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")))
+
+            // Act & Assert
             assertThat(hentSaksbehandler()).isEqualTo("Z999999")
         }
 
         @Test
         fun `returnerer systemforkortelse når NAVident-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentSaksbehandler()).isEqualTo(SikkerhetContext.SYSTEM_FORKORTELSE)
         }
     }
@@ -130,13 +148,19 @@ class SikkerhetContextTest {
     inner class HentSaksbehandlerEpostTest {
         @Test
         fun `returnerer preferred_username-claim fra token`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("preferred_username" to "fornavn.etternavn@nav.no")))
+
+            // Act & Assert
             assertThat(hentSaksbehandlerEpost()).isEqualTo("fornavn.etternavn@nav.no")
         }
 
         @Test
         fun `returnerer systemforkortelse når preferred_username-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentSaksbehandlerEpost()).isEqualTo(SikkerhetContext.SYSTEM_FORKORTELSE)
         }
     }
@@ -145,13 +169,19 @@ class SikkerhetContextTest {
     inner class HentSaksbehandlerNavnTest {
         @Test
         fun `returnerer name-claim fra token`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("name" to "Etternavn, Fornavn")))
+
+            // Act & Assert
             assertThat(hentSaksbehandlerNavn()).isEqualTo("Etternavn, Fornavn")
         }
 
         @Test
         fun `returnerer systemnavn når name-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentSaksbehandlerNavn()).isEqualTo(SikkerhetContext.SYSTEM_NAVN)
         }
     }
@@ -160,14 +190,20 @@ class SikkerhetContextTest {
     inner class HentGrupperTest {
         @Test
         fun `returnerer groups-claim som liste`() {
+            // Arrange
             val grupper = listOf("gruppe-a", "gruppe-b")
             settSikkerhetscontext(lagJwt(mapOf("groups" to grupper)))
+
+            // Act & Assert
             assertThat(hentGrupper()).containsExactlyElementsOf(grupper)
         }
 
         @Test
         fun `returnerer tom liste når groups-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentGrupper()).isEmpty()
         }
     }
@@ -176,13 +212,19 @@ class SikkerhetContextTest {
     inner class HarRolleTest {
         @Test
         fun `returnerer true når bruker har den angitte rollen`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(), roller = listOf(Rolle.SAKSBEHANDLER))
+
+            // Act & Assert
             assertThat(harRolle(Rolle.SAKSBEHANDLER)).isTrue()
         }
 
         @Test
         fun `returnerer false når bruker mangler den angitte rollen`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(), roller = listOf(Rolle.VEILEDER))
+
+            // Act & Assert
             assertThat(harRolle(Rolle.SAKSBEHANDLER)).isFalse()
         }
     }
@@ -198,31 +240,46 @@ class SikkerhetContextTest {
 
             @Test
             fun `returnerer BESLUTTER ved kun BESLUTTER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.BESLUTTER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.BESLUTTER)
             }
 
             @Test
             fun `returnerer SAKSBEHANDLER ved kun SAKSBEHANDLER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.SAKSBEHANDLER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.SAKSBEHANDLER)
             }
 
             @Test
             fun `returnerer FORVALTER ved kun FORVALTER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.FORVALTER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.FORVALTER)
             }
 
             @Test
             fun `returnerer VEILEDER ved kun VEILEDER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.VEILEDER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.VEILEDER)
             }
 
             @Test
             fun `returnerer UKJENT uten noen roller`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), emptyList())
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.UKJENT)
             }
         }
@@ -231,25 +288,34 @@ class SikkerhetContextTest {
         inner class Rekkefølgetester {
             @Test
             fun `BESLUTTER returneres før alle lavere roller når bruker har alle roller`() {
+                // Arrange
                 settSikkerhetscontext(
                     lagJwt(mapOf("NAVident" to "Z999999")),
                     listOf(Rolle.BESLUTTER, Rolle.SAKSBEHANDLER, Rolle.FORVALTER, Rolle.VEILEDER),
                 )
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.BESLUTTER)
             }
 
             @Test
             fun `SAKSBEHANDLER returneres før FORVALTER og VEILEDER`() {
+                // Arrange
                 settSikkerhetscontext(
                     lagJwt(mapOf("NAVident" to "Z999999")),
                     listOf(Rolle.SAKSBEHANDLER, Rolle.FORVALTER, Rolle.VEILEDER),
                 )
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.SAKSBEHANDLER)
             }
 
             @Test
             fun `FORVALTER returneres før VEILEDER`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.FORVALTER, Rolle.VEILEDER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.FORVALTER)
             }
         }
@@ -264,19 +330,28 @@ class SikkerhetContextTest {
 
         @Test
         fun `returnerer UKJENT når lavesteSikkerhetsnivå er null og bruker ikke er system`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.SAKSBEHANDLER))
+
+            // Act & Assert
             assertThat(hentRolletilgangFraSikkerhetscontext(null)).isEqualTo(BehandlerRolle.UKJENT)
         }
 
         @Test
         fun `returnerer lavesteSikkerhetsnivå når bruker har tilstrekkelig nivå`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.BESLUTTER))
+
+            // Act & Assert
             assertThat(hentRolletilgangFraSikkerhetscontext(BehandlerRolle.SAKSBEHANDLER)).isEqualTo(BehandlerRolle.SAKSBEHANDLER)
         }
 
         @Test
         fun `returnerer UKJENT når bruker ikke har tilstrekkelig nivå`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.VEILEDER))
+
+            // Act & Assert
             assertThat(hentRolletilgangFraSikkerhetscontext(BehandlerRolle.SAKSBEHANDLER)).isEqualTo(BehandlerRolle.UKJENT)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/FinnSakerMedFlereMigreringsbehandlingerTaskTest.kt
@@ -16,6 +16,7 @@ class FinnSakerMedFlereMigreringsbehandlingerTaskTest {
 
     @Test
     fun `Skal kaste feil hvis man finner åpne saker med flere migreringsbehandlinger fra sist måned`() {
+        // Arrange
         val fagsakMedMigrering1 = mockk<FagsakMedFlereMigreringer>()
         val fagsakMedMigrering2 = mockk<FagsakMedFlereMigreringer>()
         every { fagsakMedMigrering1.fagsakId } returns 1
@@ -25,11 +26,13 @@ class FinnSakerMedFlereMigreringsbehandlingerTaskTest {
         every { fagsakRepository.finnFagsakerMedFlereMigreringsbehandlinger(any()) } returns
             listOf(fagsakMedMigrering1, fagsakMedMigrering2)
 
+        // Act & Assert
         val exception =
             assertThrows<Feil> {
                 task.doTask(Task(type = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE, payload = "2023-10"))
             }
 
+        // Assert
         assertThat(exception.message).isEqualTo(
             """
             Det er nye fagsaker som har har flere enn 1 migrering fra Infotrygd. Send liste til fag og avvikshåndter tasken. fraOgMedÅrMåned=2023-10 
@@ -41,8 +44,10 @@ class FinnSakerMedFlereMigreringsbehandlingerTaskTest {
 
     @Test
     fun `Skal ikke kaste feil hvis man ikke finner nye åpne saker som har flere enn 1 migrering`() {
+        // Arrange
         every { fagsakRepository.finnFagsakerMedFlereMigreringsbehandlinger(any()) } returns emptyList()
 
+        // Act
         task.doTask(Task(type = FinnSakerMedFlereMigreringsbehandlingerTask.TASK_STEP_TYPE, payload = "2023-10"))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/GrensesnittavstemMotOppdragTest.kt
@@ -41,9 +41,11 @@ class GrensesnittavstemMotOppdragTest {
         triggerDato: LocalDate,
         nesteTriggerDato: LocalDate,
     ) {
+        // Arrange
         val slot = slot<Task>()
         every { taskRepositoryMock.save(capture(slot)) } answers { slot.captured }
 
+        // Act
         grensesnittavstemMotOppdrag.onCompletion(
             Task(
                 payload =
@@ -59,6 +61,7 @@ class GrensesnittavstemMotOppdragTest {
             ).medTriggerTid(triggerDato.atTime(8, 0, 0)),
         )
 
+        // Assert
         val lagretTask = slot.captured
         val testDto = jsonMapper.readValue(lagretTask.payload, GrensesnittavstemmingTaskDTO::class.java)
 
@@ -69,46 +72,59 @@ class GrensesnittavstemMotOppdragTest {
 
     @Test
     fun skalBeregneNesteAvstemmingForSammenhengendeHelligdag() {
+        // Arrange
         val juledagen = LocalDate.of(2019, 12, 24)
 
+        // Act
         val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(juledagen)
 
+        // Assert
         assertEquals(LocalDate.of(2019, 12, 27).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2019, 12, 24).atStartOfDay(), testDto.fomDato)
     }
 
     @Test
     fun skalBeregneNesteAvstemmingForEnkeltHelligdag() {
+        // Arrange
         val nyttårsdag = LocalDate.of(2019, 12, 31)
 
+        // Act
         val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(nyttårsdag)
 
+        // Assert
         assertEquals(LocalDate.of(2020, 1, 2).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2019, 12, 31).atStartOfDay(), testDto.fomDato)
     }
 
     @Test
     fun skalBeregneNesteAvstemmingForLanghelg() {
+        // Arrange
         val valborg = LocalDate.of(2020, 4, 30)
 
+        // Act
         val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(valborg)
 
+        // Assert
         assertEquals(LocalDate.of(2020, 5, 4).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2020, 4, 30).atStartOfDay(), testDto.fomDato)
     }
 
     @Test
     fun skalBeregneNesteAvstemmingForUkedag() {
+        // Arrange
         val enTirsdag = LocalDate.of(2020, 1, 14)
 
+        // Act
         val testDto = GrensesnittavstemMotOppdrag.nesteAvstemmingDTO(enTirsdag)
 
+        // Assert
         assertEquals(LocalDate.of(2020, 1, 15).atStartOfDay(), testDto.tomDato)
         assertEquals(LocalDate.of(2020, 1, 14).atStartOfDay(), testDto.fomDato)
     }
 
     @Test
     fun skalLageNyAvstemmingstaskEtterJobb() {
+        // Arrange
         val iDag = LocalDate.of(2020, 1, 15).atStartOfDay()
         val testTask =
             Task(
@@ -127,8 +143,10 @@ class GrensesnittavstemMotOppdragTest {
         val slot = slot<Task>()
         every { taskRepositoryMock.save(any()) } returns testTask
 
+        // Act
         grensesnittavstemMotOppdrag.onCompletion(testTask)
 
+        // Assert
         verify(exactly = 1) { taskRepositoryMock.save(capture(slot)) }
         assertEquals(GrensesnittavstemMotOppdrag.TASK_STEP_TYPE, slot.captured.type)
         assertEquals(iDag.plusDays(1).toLocalDate().atTime(8, 0), slot.captured.triggerTid)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/KonsistensavstemMotOppdragStartTaskTest.kt
@@ -18,6 +18,7 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
 
     @Test
     fun `Ved kjøring av task første gang, så skal den sende start til økonomi, opprette finn perioder til avstemming task og og sende avslutt til økonomi`() {
+        // Arrange
         val (transaksjonsId, task) = opprettStartTask()
 
         every { avstemmingService.harBatchStatusFerdig(123L) } returns false
@@ -41,8 +42,10 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
         }
         justRun { avstemmingService.opprettKonsistensavstemmingAvsluttTask(any()) }
 
+        // Act
         startTask.doTask(task)
 
+        // Assert
         verify(exactly = 1) { avstemmingService.sendKonsistensavstemmingStart(any(), transaksjonsId) }
         verify(exactly = 3) {
             avstemmingService.opprettKonsistensavstemmingFinnPerioderForRelevanteBehandlingerTask(
@@ -55,12 +58,15 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
 
     @Test
     fun `Ved rekjøring av task som er alt kjørt, så skal den avslutte uten å sende meldinger eller generere perioder`() {
+        // Arrange
         val (transaksjonsId, task) = opprettStartTask()
 
         every { avstemmingService.harBatchStatusFerdig(123L) } returns true
 
+        // Act
         startTask.doTask(task)
 
+        // Assert
         verify(exactly = 0) { avstemmingService.sendKonsistensavstemmingStart(any(), transaksjonsId) }
         verify(exactly = 0) {
             avstemmingService.opprettKonsistensavstemmingFinnPerioderForRelevanteBehandlingerTask(
@@ -73,6 +79,7 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
 
     @Test
     fun `Ved rekjøring av task som er delvis kjørt, så skal den ikke sende start melding, men opprette finn perioder til avstemminger som det ikke er sendt og sende avslutt melding til økonomi`() {
+        // Arrange
         val (transaksjonsId, task) = opprettStartTask()
 
         every { avstemmingService.harBatchStatusFerdig(123L) } returns false
@@ -97,8 +104,10 @@ internal class KonsistensavstemMotOppdragStartTaskTest {
         }
         justRun { avstemmingService.opprettKonsistensavstemmingAvsluttTask(any()) }
 
+        // Act
         startTask.doTask(task)
 
+        // Assert
         verify(exactly = 0) { avstemmingService.sendKonsistensavstemmingStart(any(), transaksjonsId) }
         verify(exactly = 1) {
             avstemmingService.opprettKonsistensavstemmingFinnPerioderForRelevanteBehandlingerTask(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/MånedligValutajusteringTaskTest.kt
@@ -15,6 +15,7 @@ class MånedligValutajusteringTaskTest {
 
     @Test
     fun `doTask utfører valutajustering når nåværende måned samsvarer med måned i paýload`() {
+        // Arrange
         val currentMonth = YearMonth.now()
         val taskDto =
             MånedligValutajusteringTask.MånedligValutajusteringTaskDto(
@@ -24,10 +25,12 @@ class MånedligValutajusteringTaskTest {
         val taskPayload = jsonMapper.writeValueAsString(taskDto)
         val taskInstance = Task(type = MånedligValutajusteringTask.TASK_STEP_TYPE, payload = taskPayload)
 
+        // Act
         assertDoesNotThrow {
             task.doTask(taskInstance)
         }
 
+        // Assert
         verify {
             autovedtakMånedligValutajusteringService.utførMånedligValutajustering(
                 fagsakId = 123L,
@@ -38,6 +41,7 @@ class MånedligValutajusteringTaskTest {
 
     @Test
     fun `doTask logger info og utfører ikke valutajustering når nåværende måned ikke samsvarer med måned i paýload`() {
+        // Arrange
         val taskDto =
             MånedligValutajusteringTask.MånedligValutajusteringTaskDto(
                 fagsakId = 123L,
@@ -46,10 +50,12 @@ class MånedligValutajusteringTaskTest {
         val taskPayload = jsonMapper.writeValueAsString(taskDto)
         val taskInstance = Task(type = MånedligValutajusteringTask.TASK_STEP_TYPE, payload = taskPayload)
 
+        // Act
         assertDoesNotThrow {
             task.doTask(taskInstance)
         }
 
+        // Assert
         verify(exactly = 0) {
             autovedtakMånedligValutajusteringService.utførMånedligValutajustering(any(), any())
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/OpprettOppgaveTaskTest.kt
@@ -23,7 +23,7 @@ class OpprettOppgaveTaskTest {
 
     @Test
     fun `oppretter oppgave når behandling har annen status enn iverksatt eller avsluttet`() {
-        // Given
+        // Arrange
         val behandling =
             mockk<Behandling> {
                 every { status } returns BehandlingStatus.UTREDES
@@ -43,10 +43,10 @@ class OpprettOppgaveTaskTest {
         every { behandlingHentOgPersisterService.hent(1L) } returns behandling
         every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any()) } returns "12345"
 
-        // When
+        // Act
         opprettOppgaveTask.doTask(task)
 
-        // Then
+        // Assert
         verify(exactly = 1) {
             oppgaveService.opprettOppgave(
                 behandlingId = 1L,
@@ -62,7 +62,7 @@ class OpprettOppgaveTaskTest {
 
     @Test
     fun `oppretter ikke oppgave når behandling er iverksatt og oppgavetype er GodkjenneVedtak`() {
-        // Given
+        // Arrange
         val behandling =
             mockk<Behandling> {
                 every { status } returns BehandlingStatus.IVERKSETTER_VEDTAK
@@ -81,16 +81,16 @@ class OpprettOppgaveTaskTest {
 
         every { behandlingHentOgPersisterService.hent(2L) } returns behandling
 
-        // When
+        // Act
         opprettOppgaveTask.doTask(task)
 
-        // Then
+        // Assert
         verify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `oppretter ikke oppgave når behandling er avsluttet og oppgavetype er BehandleUnderkjentVedtak`() {
-        // Given
+        // Arrange
         val behandling =
             mockk<Behandling> {
                 every { status } returns BehandlingStatus.AVSLUTTET
@@ -109,16 +109,16 @@ class OpprettOppgaveTaskTest {
 
         every { behandlingHentOgPersisterService.hent(3L) } returns behandling
 
-        // When
+        // Act
         opprettOppgaveTask.doTask(task)
 
-        // Then
+        // Assert
         verify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `oppretter oppgave når behandling er iverksatt men oppgavetype er verken GodkjenneVedtak eller BehandleUnderkjentVedtak`() {
-        // Given
+        // Arrange
         val behandling =
             mockk<Behandling> {
                 every { status } returns BehandlingStatus.IVERKSETTER_VEDTAK
@@ -138,16 +138,16 @@ class OpprettOppgaveTaskTest {
         every { behandlingHentOgPersisterService.hent(4L) } returns behandling
         every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any()) } returns "67890"
 
-        // When
+        // Act
         opprettOppgaveTask.doTask(task)
 
-        // Then
+        // Assert
         verify(exactly = 1) { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `oppretter oppgave med alle parametere fylt ut`() {
-        // Given
+        // Arrange
         val behandling =
             mockk<Behandling> {
                 every { status } returns BehandlingStatus.UTREDES
@@ -167,10 +167,10 @@ class OpprettOppgaveTaskTest {
         every { behandlingHentOgPersisterService.hent(5L) } returns behandling
         every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any(), any()) } returns "11111"
 
-        // When
+        // Act
         opprettOppgaveTask.doTask(task)
 
-        // Then
+        // Assert
         verify(exactly = 1) {
             oppgaveService.opprettOppgave(
                 behandlingId = 5L,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/PatchMergetIdentTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/PatchMergetIdentTaskTest.kt
@@ -61,6 +61,7 @@ class PatchMergetIdentTaskTest {
 
     @Test
     fun `Skal kunne patche barnets ident for en fagsak hvor gammel ident er en historisk ident av ny ident`() {
+        // Arrange
         val dto =
             PatchMergetIdentDto(
                 fagsakId = fagsak.id,
@@ -82,8 +83,10 @@ class PatchMergetIdentTaskTest {
         val aktørMergeLoggSlot = slot<AktørMergeLogg>()
         every { aktørMergeLoggRepository.save(capture(aktørMergeLoggSlot)) } answers { aktørMergeLoggSlot.captured }
 
+        // Act
         task.doTask(Task(payload = jsonMapper.writeValueAsString(dto), type = PatchMergetIdentTask.TASK_STEP_TYPE))
 
+        // Assert
         val aktørMergeLogg = aktørMergeLoggSlot.captured
         assertThat(aktørMergeLogg.nyAktørId).isEqualTo(nyAktør.aktørId)
         assertThat(aktørMergeLogg.fagsakId).isEqualTo(dto.fagsakId)
@@ -96,6 +99,7 @@ class PatchMergetIdentTaskTest {
 
     @Test
     fun `Skal kaste feil ved patching av ident hvis ident på barnet ikke finnes på fagsaken`() {
+        // Arrange
         val dto =
             PatchMergetIdentDto(
                 fagsakId = fagsak.id,
@@ -105,6 +109,7 @@ class PatchMergetIdentTaskTest {
 
         every { persongrunnlagService.hentSøkerOgBarnPåFagsak(dto.fagsakId) } returns emptySet()
 
+        // Act & Assert
         assertThrows<Feil> { task.doTask(Task(payload = jsonMapper.writeValueAsString(dto), type = PatchMergetIdentTask.TASK_STEP_TYPE)) }.also {
             assertThat(it.message).isEqualTo("Fant ikke ident som skal patches på fagsak=${fagsak.id} aktører=[]")
         }
@@ -112,6 +117,7 @@ class PatchMergetIdentTaskTest {
 
     @Test
     fun `Skal kaste feil ved patching av ident hvis gammel ident ikke er historisk av ny ident`() {
+        // Arrange
         val dto =
             PatchMergetIdentDto(
                 fagsakId = fagsak.id,
@@ -122,6 +128,7 @@ class PatchMergetIdentTaskTest {
         every { persongrunnlagService.hentSøkerOgBarnPåFagsak(dto.fagsakId) } returns personopplysningGrunnlag.tilPersonEnkelSøkerOgBarn().toSet()
         every { pdlIdentRestKlient.hentIdenter(nyAktør.aktivFødselsnummer(), true) } returns emptyList()
 
+        // Act & Assert
         assertThrows<Feil> { task.doTask(Task(payload = jsonMapper.writeValueAsString(dto), type = PatchMergetIdentTask.TASK_STEP_TYPE)) }.also {
             assertThat(it.message).isEqualTo("Ident som skal patches finnes ikke som historisk ident av ny ident")
         }
@@ -129,6 +136,7 @@ class PatchMergetIdentTaskTest {
 
     @Test
     fun `Skal kaste feil ved patching av ident hvis ny personident allerede eksisterer i personident`() {
+        // Arrange
         val dto =
             PatchMergetIdentDto(
                 fagsakId = fagsak.id,
@@ -146,6 +154,7 @@ class PatchMergetIdentTaskTest {
 
         every { personidentRepository.findByFødselsnummerOrNull(dto.nyIdent.ident) } returns Personident(nyAktør.aktivFødselsnummer(), nyAktør)
 
+        // Act & Assert
         assertThrows<Feil> { task.doTask(Task(payload = jsonMapper.writeValueAsString(dto), type = PatchMergetIdentTask.TASK_STEP_TYPE)) }.also {
             assertThat(it.message).isEqualTo("Fant allerede en personident for nytt fødselsnummer")
         }
@@ -153,6 +162,7 @@ class PatchMergetIdentTaskTest {
 
     @Test
     fun `Skal kunne patche barnets ident for en fagsak hvor gammel ident ikke er en historisk ident av ny ident, men man har valgt å overstyre`() {
+        // Arrange
         val dto =
             PatchMergetIdentDto(
                 fagsakId = fagsak.id,
@@ -173,8 +183,10 @@ class PatchMergetIdentTaskTest {
         val aktørMergeLoggSlot = slot<AktørMergeLogg>()
         every { aktørMergeLoggRepository.save(capture(aktørMergeLoggSlot)) } answers { aktørMergeLoggSlot.captured }
 
+        // Act
         task.doTask(Task(payload = jsonMapper.writeValueAsString(dto), type = PatchMergetIdentTask.TASK_STEP_TYPE))
 
+        // Assert
         val aktørMergeLogg = aktørMergeLoggSlot.captured
         assertThat(aktørMergeLogg.nyAktørId).isEqualTo(nyAktør.aktørId)
         assertThat(aktørMergeLogg.fagsakId).isEqualTo(dto.fagsakId)
@@ -187,6 +199,7 @@ class PatchMergetIdentTaskTest {
 
     @Test
     fun `Skal kunne patche søkers ident for en fagsak hvor gammel ident er en historisk ident av ny ident`() {
+        // Arrange
         val dto =
             PatchMergetIdentDto(
                 fagsakId = fagsak.id,
@@ -208,8 +221,10 @@ class PatchMergetIdentTaskTest {
         val aktørMergeLoggSlot = slot<AktørMergeLogg>()
         every { aktørMergeLoggRepository.save(capture(aktørMergeLoggSlot)) } answers { aktørMergeLoggSlot.captured }
 
+        // Act
         task.doTask(Task(payload = jsonMapper.writeValueAsString(dto), type = PatchMergetIdentTask.TASK_STEP_TYPE))
 
+        // Assert
         val aktørMergeLogg = aktørMergeLoggSlot.captured
         assertThat(aktørMergeLogg.nyAktørId).isEqualTo(nyAktør.aktørId)
         assertThat(aktørMergeLogg.fagsakId).isEqualTo(dto.fagsakId)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/PubliserVedtakV2TaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/PubliserVedtakV2TaskTest.kt
@@ -34,8 +34,10 @@ class PubliserVedtakV2TaskTest {
 
     @Test
     fun skalOppretteTask() {
+        // Act
         val task = PubliserVedtakV2Task.opprettTask("ident", 42)
 
+        // Assert
         Assertions.assertThat(task.payload).isEqualTo("42")
         Assertions.assertThat(task.metadata["personIdent"]).isEqualTo("ident")
         Assertions.assertThat(task.type).isEqualTo("publiserVedtakV2Task")
@@ -43,13 +45,17 @@ class PubliserVedtakV2TaskTest {
 
     @Test
     fun `skal kjøre task`() {
+        // Arrange
         every { kafkaProducerMock.sendMessageForTopicVedtakV2(ofType(VedtakDVHV2::class)) }.returns(100)
         every { taskRepositoryMock.save(any()) } returns Task(type = "test", payload = "")
 
         val task = PubliserVedtakV2Task.opprettTask("ident", 42)
+
+        // Act
         publiserVedtakV2Task.doTask(task)
         taskRepositoryMock.save(task)
 
+        // Assert
         val slot = slot<Task>()
         verify(exactly = 1) { taskRepositoryMock.save(capture(slot)) }
         Assertions.assertThat(slot.captured.metadata["offset"]).isEqualTo("100")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendAutobrevPgaAlderTaskTest.kt
@@ -18,14 +18,17 @@ class SendAutobrevPgaAlderTaskTest {
 
     @Test
     fun `ignorere gammel task når nåværende måned ikke samsvarer med måned i payload`() {
+        // Arrange
         val autobrevDTO = AutobrevPgaAlderDTO(fagsakId = 1, alder = 18, årMåned = YearMonth.now().minusMonths(1))
         val taskPayload = jsonMapper.writeValueAsString(autobrevDTO)
         val taskInstance = Task(type = SendAutobrevPgaAlderTask.TASK_STEP_TYPE, payload = taskPayload)
 
+        // Act
         assertDoesNotThrow {
             sendAutobrevPgaAlderTask.doTask(taskInstance)
         }
 
+        // Assert
         verify(exactly = 0) {
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(any(), any())
         }
@@ -34,6 +37,7 @@ class SendAutobrevPgaAlderTaskTest {
 
     @Test
     fun `Kall opprettOmregningsoppgaveForBarnIBrytingsalder hvis dato i tasken er nåværendeMåned måned`() {
+        // Arrange
         val nåværendeMåned = YearMonth.now()
         val autobrevDTO = AutobrevPgaAlderDTO(fagsakId = 1, alder = 18, årMåned = nåværendeMåned)
         val taskPayload = jsonMapper.writeValueAsString(autobrevDTO)
@@ -43,10 +47,12 @@ class SendAutobrevPgaAlderTaskTest {
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(any(), any())
         } returns AutobrevOmregningSvar.OK
 
+        // Act
         assertDoesNotThrow {
             sendAutobrevPgaAlderTask.doTask(taskInstance)
         }
 
+        // Assert
         verify {
             autobrevOmregningPgaAlderService.opprettOmregningsoppgaveForBarnIBrytingsalder(any(), any())
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendVedtakTilInfotrygdTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/task/SendVedtakTilInfotrygdTaskTest.kt
@@ -28,14 +28,17 @@ internal class SendVedtakTilInfotrygdTaskTest {
 
     @Test
     fun `skal sende vedtak til infotrygd ved første gang behandling`() {
+        // Arrange
         val behandling = lagBehandling(status = BehandlingStatus.AVSLUTTET)
         val fom = YearMonth.now().minusMonths(2)
         every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id) } returns lagAndelerMedFom(behandling, fom)
         val slot = slot<InfotrygdVedtakFeedDto>()
         every { infotrygdFeedKlient.sendVedtakFeedTilInfotrygd(capture(slot)) } returns Unit
 
+        // Act
         sendVedtakTilInfotrygdTask.doTask(SendVedtakTilInfotrygdTask.opprettTask(behandling.fagsak.aktør.aktivFødselsnummer(), behandling.id))
 
+        // Assert
         assertThat(slot.captured.fnrStoenadsmottaker).isEqualTo(behandling.fagsak.aktør.aktivFødselsnummer())
         assertThat(slot.captured.datoStartNyBa).isEqualTo(fom.atDay(1))
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/common/EksternTjenesteKallerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/common/EksternTjenesteKallerTest.kt
@@ -52,6 +52,7 @@ class EksternTjenesteKallerTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `Tjeneste svarer med 200 OK og feilet ressurs`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/oppgave/opprett").willReturn(
                 aResponse()
@@ -61,12 +62,14 @@ class EksternTjenesteKallerTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act & Assert
         assertThrows<IntegrasjonException> { integrasjonKlient.opprettOppgave(lagTestOppgave()) }
     }
 
     @Test
     @Tag("integration")
     fun `Tjeneste svarer med 500 og skal feile`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/oppgave/opprett").willReturn(
                 aResponse()
@@ -75,12 +78,14 @@ class EksternTjenesteKallerTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act & Assert
         assertThrows<IntegrasjonException> { integrasjonKlient.opprettOppgave(lagTestOppgave()) }
     }
 
     @Test
     @Tag("integration")
     fun `Tjeneste svarer med forbidden og skal kaste feil videre`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/oppgave/opprett").willReturn(
                 aResponse()
@@ -90,6 +95,7 @@ class EksternTjenesteKallerTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act & Assert
         val feil =
             assertThrows<HttpClientErrorException.Forbidden> { integrasjonKlient.opprettOppgave(lagTestOppgave()) }
         assertTrue(feil.statusCode == HttpStatus.FORBIDDEN)
@@ -99,6 +105,7 @@ class EksternTjenesteKallerTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `Tjeneste svarer med 404 og not found skal ligge på integrasjon exception`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/oppgave/opprett").willReturn(
                 aResponse()
@@ -106,6 +113,7 @@ class EksternTjenesteKallerTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act & Assert
         assertThrows<HttpClientErrorException.NotFound> { integrasjonKlient.opprettOppgave(lagTestOppgave()) }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/common/EnvServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/common/EnvServiceTest.kt
@@ -13,8 +13,10 @@ class EnvServiceTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `erDev skal returnere true dersom appen er startet med dev-profil`() {
+        // Arrange
         val envService = EnvService(environment)
 
+        // Act & Assert
         assertTrue(envService.erDev())
         assertFalse(envService.erProd())
         assertFalse(envService.erPreprod())

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/SecurityConfigurationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/SecurityConfigurationTest.kt
@@ -28,6 +28,7 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
     inner class PermitAll {
         @Test
         fun `internal endepunkt er tilgjengelig uten token`() {
+            // Act
             val response =
                 restClient
                     .get()
@@ -35,6 +36,7 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
                     .retrieve()
                     .toEntity(String::class.java)
 
+            // Assert
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         }
     }
@@ -43,6 +45,7 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
     inner class UtenToken {
         @Test
         fun `api-kall uten token returnerer 401`() {
+            // Act & Assert
             val feil =
                 assertThrows<HttpStatusCodeException> {
                     restClient
@@ -66,8 +69,10 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
         fun `saksbehandlere har tilgang til interne endepunkter`(
             rolle: Rolle,
         ) {
+            // Arrange
             val headers = hentHeaders(groups = listOf(rolle.name))
 
+            // Act & Assert
             try {
                 restClient
                     .get()
@@ -82,12 +87,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
 
         @Test
         fun `m2m-token fra teamfamilie-app har tilgang til interne endepunkter`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(token(mapOf("azp_name" to "dev-gcp:teamfamilie:tilfeldig-applikasjon")))
                 }
 
+            // Act & Assert
             try {
                 restClient
                     .get()
@@ -102,12 +109,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
 
         @Test
         fun `m2m-token uten teamfamilie-namespace har ikke tilgang til interne endepunkter`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(token(mapOf("azp_name" to "dev-gcp:ukjent-namespace:ukjent-applikasjon")))
                 }
 
+            // Act & Assert
             val feil =
                 assertThrows<HttpStatusCodeException> {
                     restClient
@@ -128,12 +137,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
 
         @Test
         fun `token fra annen applikasjon enn klage har ikke tilgang til klage-endepunkt`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(token(mapOf("azp_name" to "dev-gcp:teamfamilie:ikke-klage")))
                 }
 
+            // Act & Assert
             val feil =
                 assertThrows<HttpStatusCodeException> {
                     restClient
@@ -149,12 +160,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
 
         @Test
         fun `klage-token har tilgang til klage-endepunkt`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(klageToken())
                 }
 
+            // Act & Assert
             try {
                 restClient
                     .get()
@@ -174,12 +187,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
 
         @Test
         fun `pensjon-token har ikke tilgang til generelt api-endepunkt`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(pensjonToken("omsorgsopptjening-start-innlesning"))
                 }
 
+            // Act & Assert
             val feil =
                 assertThrows<HttpStatusCodeException> {
                     restClient
@@ -198,12 +213,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
         fun `pensjon-token har tilgang til pensjon-endepunkt`(
             applikasjonNavn: String,
         ) {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(pensjonToken(applikasjonNavn))
                 }
 
+            // Act & Assert
             try {
                 restClient
                     .get()
@@ -223,12 +240,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
 
         @Test
         fun `bisys-token har ikke tilgang til generelt api-endepunkt`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(bisysToken("bidrag-grunnlag"))
                 }
 
+            // Act & Assert
             val feil =
                 assertThrows<HttpStatusCodeException> {
                     restClient
@@ -247,12 +266,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
         fun `bisys-token har tilgang til bisys-endepunkt`(
             applikasjonNavn: String,
         ) {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(bisysToken(applikasjonNavn))
                 }
 
+            // Act & Assert
             try {
                 restClient
                     .post()
@@ -270,12 +291,14 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
     inner class TokenXIsolasjon {
         @Test
         fun `tokenx-token blir avvist på azuread-endepunkt`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(hentTokenForTokenX("12345678910"))
                 }
 
+            // Act & Assert
             val feil =
                 assertThrows<HttpStatusCodeException> {
                     restClient
@@ -291,8 +314,10 @@ class SecurityConfigurationTest : WebSpringAuthTestRunner() {
 
         @Test
         fun `azure-token blir avvist på tokenx-endepunkt`() {
+            // Arrange
             val headers = hentHeaders()
 
+            // Act & Assert
             val feil =
                 assertThrows<HttpStatusCodeException> {
                     restClient

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/featureToggle/miljø/EnvironmentConfigTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/config/featureToggle/miljø/EnvironmentConfigTest.kt
@@ -9,13 +9,19 @@ import org.springframework.core.env.Environment
 class EnvironmentConfigTest {
     @Test
     fun `aktiv profil skal være aktiv`() {
+        // Arrange
         val env = mockk<Environment>().also { every { it.activeProfiles } returns arrayOf("dev") }
+
+        // Act & Assert
         assertThat(env.erAktiv(Profil.Dev)).isTrue
     }
 
     @Test
     fun `profil som ikke er lista som aktiv skal ikke være aktiv`() {
+        // Arrange
         val env = mockk<Environment>().also { every { it.activeProfiles } returns arrayOf("prod") }
+
+        // Act & Assert
         assertThat(env.erAktiv(Profil.Dev)).isFalse
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysControllerIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/bisys/BisysControllerIntegrasjonsTest.kt
@@ -59,6 +59,7 @@ class BisysControllerIntegrasjonsTest : WebSpringAuthTestRunner() {
 
     @Test
     fun `Skal kaste gode feilmeldinger ved feil mot infotrygd-barnetrygd`() {
+        // Arrange
         val fnr = randomFnr()
 
         stubFor(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/FinnIdenterMedLøpendeBarnetrygdForGittÅrTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/FinnIdenterMedLøpendeBarnetrygdForGittÅrTest.kt
@@ -46,6 +46,7 @@ class FinnIdenterMedLøpendeBarnetrygdForGittÅrTest : AbstractSpringIntegration
 
     @Test
     fun `Skal plukke riktig identer som har hatt barnetryd i løpet av gitt år`() {
+        // Arrange
         val søker = tilfeldigPerson()
         val barn1 = tilfeldigPerson()
         personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
@@ -71,13 +72,18 @@ class FinnIdenterMedLøpendeBarnetrygdForGittÅrTest : AbstractSpringIntegration
             }
             avsluttOgLagreBehandling(behandling)
         }
+
+        // Act
         val identer = andelTilkjentYtelseRepository.finnIdenterMedLøpendeBarnetrygdForGittÅr(2023)
+
+        // Assert
         Assertions.assertTrue(identer.isNotEmpty())
         Assertions.assertTrue(identer.contains(søker.aktør.aktivFødselsnummer()))
     }
 
     @Test
     fun `Verifiser at ingen har barnetrygd for angitt år `() {
+        // Arrange
         val søker = tilfeldigPerson()
         val barn1 = tilfeldigPerson()
         personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
@@ -104,7 +110,10 @@ class FinnIdenterMedLøpendeBarnetrygdForGittÅrTest : AbstractSpringIntegration
             avsluttOgLagreBehandling(behandling)
         }
 
+        // Act
         val identer = andelTilkjentYtelseRepository.finnIdenterMedLøpendeBarnetrygdForGittÅr(2018)
+
+        // Assert
         Assertions.assertFalse(identer.contains(søker.aktør.aktivFødselsnummer()))
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonControllerTest.kt
@@ -26,12 +26,15 @@ import java.util.UUID
 class PensjonControllerTest : WebSpringAuthTestRunner() {
     @Test
     fun `Verifiser at pensjon-endepunkt - bestillPersonerMedBarnetrygdForGittÅrPåKafka - for henting av identer med barnetrygd - returnerer en gyldig UUID som string`() {
+        // Arrange
         val headers = HttpHeaders()
         headers.accept = Arrays.asList(MediaType.TEXT_PLAIN)
         headers.setBearerAuth(
             hentTokenForPsys(),
         )
         val entity: HttpEntity<String> = HttpEntity<String>(headers)
+
+        // Act
         val responseEntity: ResponseEntity<String> =
             restClient
                 .get()
@@ -39,17 +42,21 @@ class PensjonControllerTest : WebSpringAuthTestRunner() {
                 .headers { h -> h.addAll(entity.headers) }
                 .retrieve()
                 .toEntity(String::class.java)
+
+        // Assert
         assertEquals(UUID.fromString(responseEntity.body.toString()).toString(), responseEntity.body.toString())
     }
 
     @Test
     fun `Skal kaste feil tilgang når psys kaller tjenste som ikke er psys-relatert`() {
+        // Arrange
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON
         headers.setBearerAuth(
             hentTokenForPsys(),
         )
 
+        // Act & Assert
         val error =
             assertThrows<HttpStatusCodeException> {
                 restClient

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/ekstern/pensjon/PensjonServiceIntegrationTest.kt
@@ -47,6 +47,7 @@ class PensjonServiceIntegrationTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `skal finne en relaterte fagsaker per barn`() {
+        // Arrange
         val søker = tilfeldigPerson()
         val barn1 = tilfeldigPerson()
         val søkerAktør = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
@@ -58,12 +59,16 @@ class PensjonServiceIntegrationTest(
         val fagsak2 = fagsakService.hentEllerOpprettFagsakForPersonIdent(barn1.aktør.aktivFødselsnummer())
         leggTilAvsluttetBehandling(fagsak2, barn1, barnAktør)
 
+        // Act
         val barnetrygdTilPensjon = pensjonService.hentBarnetrygd(søkerAktør.aktivFødselsnummer(), LocalDate.of(2023, 1, 1))
+
+        // Assert
         assertThat(barnetrygdTilPensjon).hasSize(2)
     }
 
     @Test
     fun `skal inkludere periode fra Infotrygd sammen med perioden fra BA-sak på den samme identen`() {
+        // Arrange
         val søker = tilfeldigPerson()
         val barn1 = tilfeldigPerson()
         val søkerAktør = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
@@ -77,7 +82,10 @@ class PensjonServiceIntegrationTest(
 
         mockInfotrygdBarnetrygdResponse(søkerAktør)
 
+        // Act
         val barnetrygdTilPensjon = pensjonService.hentBarnetrygd(søkerAktør.aktivFødselsnummer(), LocalDate.of(2023, 1, 1))
+
+        // Assert
         assertThat(barnetrygdTilPensjon).hasSize(2)
         assertThat(barnetrygdTilPensjon.filter { it.barnetrygdPerioder.any { it.kildesystem == "Infotrygd" } }).hasSize(1)
         assertThat(barnetrygdTilPensjon.filter { it.barnetrygdPerioder.all { it.kildesystem == "Infotrygd" } }).hasSize(0)
@@ -85,6 +93,7 @@ class PensjonServiceIntegrationTest(
 
     @Test
     fun `skal fjerne overlapp ved å kutte perioden fra Infotrygd til før perioden for den samme personen starter i BA-sak`() {
+        // Arrange
         val søker = tilfeldigPerson()
         val barn1 = tilfeldigPerson()
         val søkerAktør = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
@@ -108,6 +117,7 @@ class PensjonServiceIntegrationTest(
             stønadTom = infotrygdStønadTom,
         )
 
+        // Act
         val (basakPeriode, infotrygdperiode) =
             pensjonService
                 .hentBarnetrygd(søkerAktør.aktivFødselsnummer(), LocalDate.of(2023, 1, 1))
@@ -116,30 +126,39 @@ class PensjonServiceIntegrationTest(
                 .partition { it.kildesystem == "BA" }
                 .run { first.single() to second.single() }
 
+        // Assert
         assertThat(infotrygdperiode.stønadFom).isEqualTo(infotrygdStønadFom)
         assertThat(infotrygdperiode.stønadTom).isEqualTo(basakPeriode.stønadFom.minusMonths(1))
     }
 
     @Test
     fun `skal finne og returnere perioder fra Infotrygd som har infotrygd sin definisjon på uendelighet`() {
+        // Arrange
         val søker = tilfeldigPerson()
         val søkerAktør = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
 
         mockInfotrygdBarnetrygdResponse(søker = søkerAktør, stønadFom = YearMonth.now(), stønadTom = YearMonth.of(999999999, 12))
 
+        // Act
         val barnetrygdTilPensjon = pensjonService.hentBarnetrygd(søkerAktør.aktivFødselsnummer(), LocalDate.of(2023, 1, 1))
+
+        // Assert
         assertThat(barnetrygdTilPensjon).hasSize(1)
         assertThat(barnetrygdTilPensjon.filter { it.barnetrygdPerioder.all { it.kildesystem == "Infotrygd" } }).hasSize(1)
     }
 
     @Test
     fun `skal finne og returnere perioder fra Infotrygd`() {
+        // Arrange
         val søker = tilfeldigPerson()
         val søkerAktør = personidentService.hentOgLagreAktør(søker.aktør.aktivFødselsnummer(), true)
 
         mockInfotrygdBarnetrygdResponse(søkerAktør)
 
+        // Act
         val barnetrygdTilPensjon = pensjonService.hentBarnetrygd(søkerAktør.aktivFødselsnummer(), LocalDate.of(2023, 1, 1))
+
+        // Assert
         assertThat(barnetrygdTilPensjon).hasSize(1)
         assertThat(barnetrygdTilPensjon.filter { it.barnetrygdPerioder.all { it.kildesystem == "Infotrygd" } }).hasSize(1)
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonKlientTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/IntegrasjonKlientTest.kt
@@ -119,6 +119,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `Opprett oppgave skal returnere oppgave id`() {
+        // Arrange
         MDC.put("callId", "opprettOppgave")
         wireMockServer.stubFor(
             post("/api/oppgave/opprett").willReturn(
@@ -128,8 +129,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
 
         val request = lagTestOppgave()
 
+        // Act
         val opprettOppgaveResponse = integrasjonKlient.opprettOppgave(request).oppgaveId.toString()
 
+        // Assert
         assertThat(opprettOppgaveResponse).isEqualTo("1234")
         wireMockServer.verify(
             anyRequestedFor(anyUrl())
@@ -142,6 +145,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `Opprett oppgave skal kaste feil hvis response er ugyldig`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/oppgave/opprett").willReturn(
                 aResponse()
@@ -150,6 +154,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act & Assert
         val feil = assertThrows<IntegrasjonException> { integrasjonKlient.opprettOppgave(lagTestOppgave()) }
         assertTrue(feil.message?.contains("test") == true)
     }
@@ -157,6 +162,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `hentOppgaver skal returnere en liste av oppgaver og antallet oppgaver`() {
+        // Arrange
         val oppgave = Oppgave()
         wireMockServer.stubFor(
             post("/api/oppgave/v4").willReturn(
@@ -168,13 +174,17 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act
         val oppgaverOgAntall = integrasjonKlient.hentOppgaver(FinnOppgaveRequest(tema = Tema.BAR))
+
+        // Assert
         assertThat(oppgaverOgAntall.oppgaver).hasSize(1)
     }
 
     @Test
     @Tag("integration")
     fun `Journalfør vedtaksbrev skal journalføre dokument, returnere 201 og journalpostId`() {
+        // Arrange
         MDC.put("callId", "journalfør")
         wireMockServer.stubFor(
             post("/api/arkiv/v4")
@@ -191,6 +201,8 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
         vedtak.stønadBrevPdF = mockPdf
 
         val fagsak = vedtak.behandling.fagsak
+
+        // Act
         val journalPostId =
             utgåendeJournalføringService.journalførDokument(
                 fagsak = fagsak,
@@ -215,6 +227,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 eksternReferanseId = "0_${vedtak.behandling.id}_journalfør",
             )
 
+        // Assert
         assertThat(journalPostId).isEqualTo(MOCK_JOURNALPOST_FOR_VEDTAK_ID)
         wireMockServer.verify(
             anyRequestedFor(anyUrl())
@@ -238,6 +251,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `distribuerVedtaksbrev returnerer normalt ved vellykket integrasjonskall`() {
+        // Arrange
         MDC.put("callId", "distribuerVedtaksbrev")
         wireMockServer.stubFor(
             post("/api/dist/v1")
@@ -245,7 +259,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 .willReturn(okJson(jsonMapper.writeValueAsString(success("1234567")))),
         )
 
+        // Act & Assert
         assertDoesNotThrow { integrasjonKlient.distribuerBrev(lagDistribuerDokumentDTO()) }
+
+        // Assert
         wireMockServer.verify(
             postRequestedFor(anyUrl())
                 .withHeader(NavHttpHeaders.NAV_CALL_ID.asString(), equalTo("distribuerVedtaksbrev"))
@@ -267,24 +284,28 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `distribuerVedtaksbrev kaster exception hvis integrasjoner gir blank response`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/dist/v1")
                 .withHeader("Accept", containing("json"))
                 .willReturn(okJson(jsonMapper.writeValueAsString(success("")))),
         )
 
+        // Act & Assert
         assertThrows<Feil> { integrasjonKlient.distribuerBrev(lagDistribuerDokumentDTO()) }
     }
 
     @Test
     @Tag("integration")
     fun `distribuerVedtaksbrev kaster exception hvis integrasjoner gir failure response`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/dist/v1")
                 .withHeader("Accept", containing("json"))
                 .willReturn(okJson(jsonMapper.writeValueAsString(failure<Any>("")))),
         )
 
+        // Act & Assert
         val feil = assertThrows<IntegrasjonException> { integrasjonKlient.distribuerBrev(lagDistribuerDokumentDTO()) }
         assertTrue(feil.message?.contains("dokdist") == true)
     }
@@ -292,6 +313,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `distribuerVedtaksbrev kaster exception hvis responsekoden ikke er 2xx`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/dist/v1")
                 .withHeader("Accept", containing("json"))
@@ -302,12 +324,14 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 ),
         )
 
+        // Act & Assert
         assertThrows<HttpClientErrorException.BadRequest> { integrasjonKlient.distribuerBrev(lagDistribuerDokumentDTO()) }
     }
 
     @Test
     @Tag("integration")
     fun `Ferdigstill oppgave returnerer OK`() {
+        // Arrange
         MDC.put("callId", "ferdigstillOppgave")
         wireMockServer.stubFor(
             patch(urlEqualTo("/api/oppgave/123/ferdigstill"))
@@ -315,8 +339,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 .willReturn(okJson(jsonMapper.writeValueAsString(success(OppgaveResponse(1))))),
         )
 
+        // Act
         integrasjonKlient.ferdigstillOppgave(123)
 
+        // Assert
         wireMockServer.verify(
             patchRequestedFor(urlEqualTo("/api/oppgave/123/ferdigstill"))
                 .withHeader(NavHttpHeaders.NAV_CALL_ID.asString(), equalTo("ferdigstillOppgave"))
@@ -327,6 +353,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `Ferdigstill oppgave returnerer feil `() {
+        // Arrange
         MDC.put("callId", "ferdigstillOppgave")
         wireMockServer.stubFor(
             patch(urlEqualTo("/api/oppgave/123/ferdigstill"))
@@ -339,6 +366,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 ),
         )
 
+        // Act & Assert
         val feil =
             assertThrows<HttpClientErrorException> { integrasjonKlient.ferdigstillOppgave(123) }
         assertTrue(feil.responseBodyAsString.contains("test"))
@@ -347,6 +375,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `hentBehandlendeEnhet returnerer OK uten behandlingstype`() {
+        // Arrange
         every { featureToggleService.isEnabled(HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE) } returns false
         wireMockServer.stubFor(
             post("/api/arbeidsfordeling/enhet/BAR")
@@ -364,7 +393,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 ),
         )
 
+        // Act
         val enhet = integrasjonKlient.hentBehandlendeEnhet("1")
+
+        // Assert
         assertThat(enhet).isNotEmpty
         assertThat(enhet.first().enhetId).isEqualTo("2")
     }
@@ -372,6 +404,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `hentBehandlendeEnhet returnerer OK med behandlingstype`() {
+        // Arrange
         every { featureToggleService.isEnabled(HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE) } returns true
         wireMockServer.stubFor(
             post("/api/arbeidsfordeling/enhet/BAR?behandlingstype=E%C3%98S")
@@ -389,7 +422,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 ),
         )
 
+        // Act
         val enhet = integrasjonKlient.hentBehandlendeEnhet("1", Behandlingstype.EØS)
+
+        // Assert
         assertThat(enhet).isNotEmpty
         assertThat(enhet.first().enhetId).isEqualTo("2")
     }
@@ -397,6 +433,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `finnOppgaveMedId returnerer OK`() {
+        // Arrange
         val oppgaveId = 1234L
         wireMockServer.stubFor(
             get("/api/oppgave/$oppgaveId").willReturn(
@@ -412,15 +449,18 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act
         val oppgave = integrasjonKlient.finnOppgaveMedId(oppgaveId)
-        assertThat(oppgave.id).isEqualTo(oppgaveId)
 
+        // Assert
+        assertThat(oppgave.id).isEqualTo(oppgaveId)
         wireMockServer.verify(getRequestedFor(urlEqualTo("/api/oppgave/$oppgaveId")))
     }
 
     @Test
     @Tag("integration")
     fun `hentJournalpost returnerer OK`() {
+        // Arrange
         val journalpostId = "1234"
         val fnr = randomFnr()
         wireMockServer.stubFor(
@@ -435,16 +475,19 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act
         val journalpost = integrasjonKlient.hentJournalpost(journalpostId)
+
+        // Assert
         assertThat(journalpost).isNotNull
         assertThat(journalpost.journalpostId).isEqualTo(journalpostId)
         assertThat(journalpost.bruker?.id).isEqualTo(fnr)
-
         wireMockServer.verify(getRequestedFor(urlEqualTo("/api/journalpost/tilgangsstyrt/baks?journalpostId=$journalpostId")))
     }
 
     @Test
     fun `hentDokument returnerer OK`() {
+        // Arrange
         val journalpostId = "1234"
         val dokumentId = "5678"
         val fnr = randomFnr()
@@ -460,16 +503,19 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act
         val dokument = integrasjonKlient.hentDokument(journalpostId = journalpostId, dokumentInfoId = dokumentId)
+
+        // Assert
         assertThat(dokument).isNotNull
         assertThat(dokument.decodeToString()).isEqualTo("Test")
-
         wireMockServer.verify(getRequestedFor(urlEqualTo("/api/journalpost/hentdokument/tilgangsstyrt/baks/$journalpostId/$dokumentId")))
     }
 
     @Test
     @Tag("integration")
     fun `skal hente arbeidsforhold for person`() {
+        // Arrange
         val fnr = randomFnr()
 
         val arbeidsforhold =
@@ -492,8 +538,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
             ),
         )
 
+        // Act
         val response = integrasjonKlient.hentArbeidsforhold(fnr, LocalDate.now())
 
+        // Assert
         assertThat(response).hasSize(1)
         assertThat(response.first().arbeidsgiver?.organisasjonsnummer).isEqualTo("998877665")
         assertThat(
@@ -508,10 +556,12 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal kaste integrasjonsfeil mot arbeidsforhold`() {
+        // Arrange
         val fnr = randomFnr()
 
         wireMockServer.stubFor(post("/api/aareg/arbeidsforhold").willReturn(status(500)))
 
+        // Act & Assert
         val feil = assertThrows<IntegrasjonException> { integrasjonKlient.hentArbeidsforhold(fnr, LocalDate.now()) }
         assertTrue(feil.message?.contains("aareg") == true)
     }
@@ -519,12 +569,15 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal opprette skyggesak for Sak`() {
+        // Arrange
         val aktørId = randomAktør()
 
         wireMockServer.stubFor(post("/api/skyggesak/v1").willReturn(okJson(jsonMapper.writeValueAsString(success(null)))))
 
+        // Act
         integrasjonKlient.opprettSkyggesak(aktørId, MOCK_FAGSAK_ID.toLong())
 
+        // Assert
         wireMockServer.verify(
             postRequestedFor(urlEqualTo("/api/skyggesak/v1"))
                 .withRequestBody(
@@ -545,10 +598,12 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal kaste integrasjonsfeil ved oppretting av skyggesak`() {
+        // Arrange
         val aktørId = randomAktør()
 
         wireMockServer.stubFor(post("/api/skyggesak/v1").willReturn(status(500)))
 
+        // Act & Assert
         val feil =
             assertThrows<IntegrasjonException> { integrasjonKlient.opprettSkyggesak(aktørId, MOCK_FAGSAK_ID.toLong()) }
         assertTrue(feil.message?.contains("skyggesak") == true)
@@ -557,20 +612,24 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal hente ModiaContext`() {
+        // Arrange
         wireMockServer
             .stubFor(
                 get("/api/modia-context-holder")
                     .willReturn(okJson(modiaContextResponse { success(it) })),
             )
 
+        // Act
         val modiaContext = integrasjonKlient.hentModiaContext()
 
+        // Assert
         assertThat(modiaContext.aktivBruker).isEqualTo("13025514402")
     }
 
     @Test
     @Tag("integration")
     fun `skal oppdatere ModiaContext`() {
+        // Arrange
         wireMockServer
             .stubFor(
                 post("/api/modia-context-holder/sett-aktiv-bruker")
@@ -578,14 +637,17 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                     .willReturn(okJson(modiaContextResponse { success(it) })),
             )
 
+        // Act
         val modiaContext = integrasjonKlient.settNyAktivBrukerIModiaContext(NyAktivBrukerIModiaContextDto(personIdent = "13025514402"))
 
+        // Assert
         assertThat(modiaContext.aktivBruker).isEqualTo("13025514402")
     }
 
     @Test
     @Tag("integration")
     fun `skal kaste IntegrasjonException ved henting av ModiaContext`() {
+        // Arrange
         wireMockServer
             .stubFor(
                 get("/api/modia-context-holder")
@@ -596,8 +658,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                     ),
             )
 
+        // Act & Assert
         val exception = assertThrows<IntegrasjonException> { integrasjonKlient.hentModiaContext() }
 
+        // Assert
         assertThat(exception.message).contains("modia-context-holder")
         assertThat(exception.message).contains("Noe gikk galt")
     }
@@ -605,6 +669,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal kaste IntegrasjonException ved oppdatering av ModiaContext`() {
+        // Arrange
         wireMockServer
             .stubFor(
                 post("/api/modia-context-holder/sett-aktiv-bruker")
@@ -616,11 +681,13 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                     ),
             )
 
+        // Act & Assert
         val exception =
             assertThrows<IntegrasjonException> {
                 integrasjonKlient.settNyAktivBrukerIModiaContext(NyAktivBrukerIModiaContextDto(personIdent = "13025514402"))
             }
 
+        // Assert
         assertThat(exception.message).contains("modia-context-holder")
         assertThat(exception.message).contains("Noe gikk galt")
     }
@@ -628,6 +695,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal hente VersjonertBarnetrygdSøknad`() {
+        // Arrange
         val journalpostId = "1234"
         val versjonertBarnetrygdSøknadV9 =
             VersjonertBarnetrygdSøknadV9(
@@ -646,8 +714,10 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 ),
         )
 
+        // Act
         val versjonertSøknad = integrasjonKlient.hentVersjonertBarnetrygdSøknad(journalpostId)
 
+        // Assert
         assertThat(versjonertSøknad).isNotNull
         assertThat(versjonertSøknad).isEqualTo(versjonertBarnetrygdSøknadV9)
     }
@@ -655,6 +725,7 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal hente URL mot A-Inntekt`() {
+        // Arrange
         val url = "/test/1234"
         wireMockServer.stubFor(
             post("/api/arbeid-og-inntekt/hent-url")
@@ -663,16 +734,20 @@ class IntegrasjonKlientTest : AbstractSpringIntegrationTest() {
                 ),
         )
 
+        // Act
         val aInntektUrl = integrasjonKlient.hentAInntektUrl(PersonIdent(randomFnr()))
 
+        // Assert
         assertThat(aInntektUrl).isEqualTo(url)
     }
 
     @Test
     @Tag("integration")
     fun `skal kaste feil når henting av URL mot A-Inntekt feiler`() {
+        // Arrange
         wireMockServer.stubFor(post("/api/arbeid-og-inntekt/hent-url").willReturn(status(500)))
 
+        // Act & Assert
         val feil = assertThrows<IntegrasjonException> { integrasjonKlient.hentAInntektUrl(PersonIdent(randomFnr())) }
         assertTrue(feil.message?.contains("a-inntekt-url") == true)
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ainntekt/AInntektControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/ainntekt/AInntektControllerTest.kt
@@ -29,12 +29,16 @@ class AInntektControllerTest(
 
     @Test
     fun `kan hente ut A-Inntekt url`() {
+        // Act
         val responseRessurs = ainntektController.hentAInntektUrl(PersonIdent(ident = randomFnr()))
+
+        // Assert
         assertThat(responseRessurs.data).isEqualTo(ainntektUrl)
     }
 
     @Test
     fun `prøver å hente ut A-Inntekt url på et ugyldig fnr`() {
+        // Act & Assert
         val feil =
             assertThrows<IllegalStateException> {
                 ainntektController.hentAInntektUrl(PersonIdent(ident = "10000111111"))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdBarnetrygdKlientTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdBarnetrygdKlientTest.kt
@@ -61,6 +61,7 @@ class InfotrygdBarnetrygdKlientTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `Skal lage InfotrygdBarnetrygdRequest basert på lister med fnr og barns fødselsnummer`() {
+        // Arrange
         wireMockServer.stubFor(
             post(løpendeBarnetrygdURL).willReturn(
                 okJson(
@@ -91,10 +92,12 @@ class InfotrygdBarnetrygdKlientTest : AbstractSpringIntegrationTest() {
 
         val infotrygdSøkRequest = InfotrygdSøkRequest(søkersIdenter, barnasIdenter)
 
+        // Act
         val finnesIkkeHosInfotrygd = klient.harLøpendeSakIInfotrygd(søkersIdenter, barnasIdenter)
         val hentsakerResponse = klient.hentSaker(søkersIdenter, barnasIdenter)
         val hentstønaderResponse = klient.hentStønader(søkersIdenter, barnasIdenter)
 
+        // Assert
         wireMockServer.verify(
             anyRequestedFor(urlEqualTo(løpendeBarnetrygdURL)).withRequestBody(
                 equalToJson(
@@ -129,6 +132,7 @@ class InfotrygdBarnetrygdKlientTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `Skal lage InfotrygdBarnetrygdRequest basert på lister med fnr`() {
+        // Arrange
         wireMockServer.stubFor(
             post(løpendeBarnetrygdURL).willReturn(
                 okJson(
@@ -141,8 +145,10 @@ class InfotrygdBarnetrygdKlientTest : AbstractSpringIntegrationTest() {
 
         val infotrygdSøkRequest = InfotrygdSøkRequest(søkersIdenter, emptyList())
 
+        // Act
         val finnesIkkeHosInfotrygd = klient.harLøpendeSakIInfotrygd(søkersIdenter, emptyList())
 
+        // Assert
         wireMockServer.verify(
             anyRequestedFor(urlEqualTo(løpendeBarnetrygdURL)).withRequestBody(
                 equalToJson(
@@ -157,8 +163,10 @@ class InfotrygdBarnetrygdKlientTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `Invokering av Infotrygd-Barnetrygd genererer http feil`() {
+        // Arrange
         wireMockServer.stubFor(post(løpendeBarnetrygdURL).willReturn(aResponse().withStatus(401)))
 
+        // Act & Assert
         assertThrows<HttpClientErrorException> {
             klient.harLøpendeSakIInfotrygd(søkersIdenter, barnasIdenter)
         }
@@ -166,18 +174,21 @@ class InfotrygdBarnetrygdKlientTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `harNyligSendtBrevFor skal returnerer true for personIdent`() {
+        // Arrange
         wireMockServer.stubFor(
             post(brevURL).willReturn(
                 okJson(jsonMapper.writeValueAsString(InfotrygdBarnetrygdKlient.SendtBrevResponse(true, emptyList()))),
             ),
         )
 
+        // Act
         val harNyligSendtBrev =
             klient.harNyligSendtBrevFor(
                 søkersIdenter,
                 listOf(InfotrygdBrevkode.BREV_BATCH_INNVILGET_SMÅBARNSTILLEGG),
             )
 
+        // Assert
         Assertions.assertEquals(true, harNyligSendtBrev.harSendtBrev)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdFeedKlientTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/InfotrygdFeedKlientTest.kt
@@ -49,6 +49,7 @@ class InfotrygdFeedKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `skal legge til fødselsnummer i infotrygd feed`() {
+        // Arrange
         wireMockServer.stubFor(
             post("/api/barnetrygd/v1/feed/foedselsmelding").willReturn(
                 okJson(jsonMapper.writeValueAsString(success("Create"))),
@@ -56,10 +57,12 @@ class InfotrygdFeedKlientTest : AbstractSpringIntegrationTest() {
         )
         val request = InfotrygdFødselhendelsesFeedTaskDto(listOf("fnr"))
 
+        // Act
         request.fnrBarn.forEach {
             klient.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto(fnrBarn = it))
         }
 
+        // Assert
         wireMockServer.verify(
             anyRequestedFor(anyUrl())
                 .withHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString(), equalTo("srvfamilie-ba-sak"))
@@ -74,8 +77,10 @@ class InfotrygdFeedKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `Invokering av Infotrygd feed genererer http feil`() {
+        // Arrange
         wireMockServer.stubFor(post("/api/barnetrygd/v1/feed/foedselsmelding").willReturn(aResponse().withStatus(401)))
 
+        // Act & Assert
         assertThrows<HttpClientErrorException> {
             klient.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto("fnr"))
         }
@@ -84,8 +89,10 @@ class InfotrygdFeedKlientTest : AbstractSpringIntegrationTest() {
     @Test
     @Tag("integration")
     fun `Invokering av Infotrygd returnerer ulovlig response format`() {
+        // Arrange
         wireMockServer.stubFor(post("/api/barnetrygd/v1/feed/foedselsmelding").willReturn(aResponse().withBody("Create")))
 
+        // Act & Assert
         assertThrows<RuntimeException> {
             klient.sendFødselhendelsesFeedTilInfotrygd(InfotrygdFødselhendelsesFeedDto("fnr"))
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/SendFødselsmeldingTilInfotrygdTaskTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/infotrygd/SendFødselsmeldingTilInfotrygdTaskTest.kt
@@ -10,11 +10,14 @@ import org.junit.jupiter.api.Test
 class SendFødselsmeldingTilInfotrygdTaskTest : AbstractSpringIntegrationTest() {
     @Test
     fun `Legg til fødselsmelding til task`() {
+        // Arrange
         val fnrBarn = "12345678910"
         val testTask = SendFødselsmeldingTilInfotrygdTask.opprettTask(listOf(fnrBarn))
 
+        // Act
         val infotrygdFeedDto = jsonMapper.readValue(testTask.payload, InfotrygdFødselhendelsesFeedTaskDto::class.java)
 
+        // Assert
         Assertions.assertEquals(listOf(fnrBarn), infotrygdFeedDto.fnrBarn)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/InnkommendeJournalføringServiceIntegrationTest.kt
@@ -34,10 +34,14 @@ class InnkommendeJournalføringServiceIntegrationTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `journalfør skal opprette en førstegangsbehandling fra journalføring og lagre ned søknadsinfo`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val request = lagMockJournalføringDto(bruker = NavnOgIdent("Mock", søkerFnr))
+
+        // Act
         val fagsakId = innkommendeJournalføringService.journalfør(request, "123", "mockEnhet", "1")
 
+        // Assert
         val behandling = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId.toLong())
         assertNotNull(behandling)
         assertEquals(request.nyBehandlingstype.tilBehandingType(), behandling!!.type)
@@ -53,6 +57,7 @@ class InnkommendeJournalføringServiceIntegrationTest(
 
     @Test
     fun `journalfør skal lagre ned søknadsinfo tilknyttet en tidligere behandling`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val førsteSøknad = lagMockJournalføringDto(bruker = NavnOgIdent("Mock", søkerFnr))
         val fagsakId = innkommendeJournalføringService.journalfør(førsteSøknad, "123", "mockEnhet", "1")
@@ -72,8 +77,10 @@ class InnkommendeJournalføringServiceIntegrationTest(
                     ),
             )
 
+        // Act
         innkommendeJournalføringService.journalfør(nySøknad2DagerSenere, "124", "mockEnhet", "2")
 
+        // Assert
         val søknadsinfo = behandlingSøknadsinfoRepository.findByBehandlingId(behandling.id)
         assertEquals(2, søknadsinfo.size)
 
@@ -83,6 +90,7 @@ class InnkommendeJournalføringServiceIntegrationTest(
 
     @Test
     fun `journalfør skal opprette behandling på fagsak som har BARN som eier hvis enslig mindreårig eller institusjon`() {
+        // Arrange
         val request =
             lagMockJournalføringDto(bruker = NavnOgIdent("Mock", randomFnr()))
                 .copy(fagsakType = FagsakType.BARN_ENSLIG_MINDREÅRIG)
@@ -98,16 +106,24 @@ class InnkommendeJournalføringServiceIntegrationTest(
             ),
         )
 
+        // Act
         val fagsakId = innkommendeJournalføringService.journalfør(request, journalpostId, "mockEnhet", "1")
+
+        // Assert
         val behandling = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId.toLong())
 
         assertNotNull(behandling)
         assertEquals(FagsakType.BARN_ENSLIG_MINDREÅRIG, behandling!!.fagsak.type)
 
+        // Arrange
         val request2 =
             lagMockJournalføringDto(bruker = NavnOgIdent("Mock", randomFnr()))
                 .copy(fagsakType = FagsakType.INSTITUSJON, institusjon = InstitusjonDto("orgnr", tssEksternId = "tss"))
+
+        // Act
         val fagsakId2 = innkommendeJournalføringService.journalfør(request2, "1234", "mockEnhet", "2")
+
+        // Assert
         val behandling2 = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId2.toLong())
 
         assertNotNull(behandling2)
@@ -116,9 +132,11 @@ class InnkommendeJournalføringServiceIntegrationTest(
 
     @Test
     fun `journalfør skal ikke opprette en førstegangsbehandling fra journalføring med manglende mottatt dato`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val request = lagMockJournalføringDto(bruker = NavnOgIdent("Mock", søkerFnr)).copy(datoMottatt = null)
 
+        // Act & Assert
         val exception =
             assertThrows<RuntimeException> {
                 innkommendeJournalføringService.journalfør(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringUtilsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/journalføring/JournalføringUtilsTest.kt
@@ -13,7 +13,10 @@ class JournalføringUtilsTest {
 
     @Test
     fun `Skal utlede ordinær når søknad om ordinær journalføres`() {
+        // Arrange
         val søkerFnr = randomFnr()
+
+        // Act & Assert
         assertEquals(
             BehandlingUnderkategori.ORDINÆR,
             lagMockJournalføringDto(
@@ -27,7 +30,10 @@ class JournalføringUtilsTest {
 
     @Test
     fun `Skal utlede utvidet når søknad om utvidet journalføres`() {
+        // Arrange
         val søkerFnr = randomFnr()
+
+        // Act & Assert
         assertEquals(
             BehandlingUnderkategori.UTVIDET,
             lagMockJournalføringDto(
@@ -42,7 +48,10 @@ class JournalføringUtilsTest {
 
     @Test
     fun `Skal utlede ordinær når søknad om ordinær journalføres, men underkategori ikke er satt`() {
+        // Arrange
         val søkerFnr = randomFnr()
+
+        // Act
         val underkategori: BehandlingUnderkategori =
             lagMockJournalføringDto(bruker = NavnOgIdent(navn = "Mock", søkerFnr))
                 .copy(
@@ -51,12 +60,17 @@ class JournalføringUtilsTest {
                     underkategori = null,
                     opprettOgKnyttTilNyBehandling = true,
                 ).hentUnderkategori()
+
+        // Assert
         assertEquals(BehandlingUnderkategori.ORDINÆR, underkategori)
     }
 
     @Test
     fun `Skal utlede ordinær når søknad om ordinær journalføres, og underkategori er satt til ordinær`() {
+        // Arrange
         val søkerFnr = randomFnr()
+
+        // Act
         val underkategori: BehandlingUnderkategori =
             lagMockJournalføringDto(bruker = NavnOgIdent(navn = "Mock", søkerFnr))
                 .copy(
@@ -65,12 +79,17 @@ class JournalføringUtilsTest {
                     underkategori = BehandlingUnderkategori.ORDINÆR,
                     opprettOgKnyttTilNyBehandling = true,
                 ).hentUnderkategori()
+
+        // Assert
         assertEquals(BehandlingUnderkategori.ORDINÆR, underkategori)
     }
 
     @Test
     fun `Skal utlede utvidet når søknad om utvidet journalføres, men underkategori ikke er satt`() {
+        // Arrange
         val søkerFnr = randomFnr()
+
+        // Act
         val underkategori: BehandlingUnderkategori =
             lagMockJournalføringDto(bruker = NavnOgIdent(navn = "Mock", søkerFnr))
                 .copy(
@@ -79,12 +98,17 @@ class JournalføringUtilsTest {
                     underkategori = null,
                     opprettOgKnyttTilNyBehandling = true,
                 ).hentUnderkategori()
+
+        // Assert
         assertEquals(BehandlingUnderkategori.UTVIDET, underkategori)
     }
 
     @Test
     fun `Skal utlede utvidet når søknad om utvidet journalføres, og underkategori er satt til utvidet`() {
+        // Arrange
         val søkerFnr = randomFnr()
+
+        // Act
         val underkategori: BehandlingUnderkategori =
             lagMockJournalføringDto(bruker = NavnOgIdent(navn = "Mock", søkerFnr))
                 .copy(
@@ -93,6 +117,8 @@ class JournalføringUtilsTest {
                     underkategori = BehandlingUnderkategori.UTVIDET,
                     opprettOgKnyttTilNyBehandling = true,
                 ).hentUnderkategori()
+
+        // Assert
         assertEquals(BehandlingUnderkategori.UTVIDET, underkategori)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/pdl/PersonopplysningerServiceIntegrationTest.kt
@@ -66,6 +66,7 @@ internal class PersonopplysningerServiceIntegrationTest(
 
     @Test
     fun `hentPersoninfoMedRelasjonerOgRegisterinformasjon() skal return riktig personinfo`() {
+        // Arrange
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
             listOf(
                 Tilgang(ID_BARN_1, true),
@@ -74,8 +75,10 @@ internal class PersonopplysningerServiceIntegrationTest(
         )
         fakeIntegrasjonKlient.leggTilEgenansatt(ID_MOR)
 
+        // Act
         val personInfo = personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(lagAktør(ID_MOR))
 
+        // Assert
         assert(LocalDate.of(1955, 9, 13) == personInfo.fødselsdato)
         assertThat(personInfo.adressebeskyttelseGradering).isEqualTo(ADRESSEBESKYTTELSEGRADERING.UGRADERT)
         assertThat(personInfo.forelderBarnRelasjon.size).isEqualTo(1)
@@ -88,6 +91,7 @@ internal class PersonopplysningerServiceIntegrationTest(
 
     @Test
     fun `hentPersoninfoMedRelasjonerOgRegisterinformasjon() skal returnere riktig personinfo for død person`() {
+        // Arrange
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
             listOf(
                 Tilgang(ID_BARN_1, true),
@@ -95,6 +99,7 @@ internal class PersonopplysningerServiceIntegrationTest(
             ),
         )
 
+        // Act
         val personInfo =
             personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(
                 lagAktør(
@@ -102,6 +107,7 @@ internal class PersonopplysningerServiceIntegrationTest(
                 ),
             )
 
+        // Assert
         assertThat(personInfo.dødsfall?.erDød).isTrue
         assertThat(personInfo.dødsfall?.dødsdato).isEqualTo("2020-04-04")
         assertThat(personInfo.kontaktinformasjonForDoedsbo?.adresse?.postnummer).isEqualTo("1234")
@@ -109,11 +115,13 @@ internal class PersonopplysningerServiceIntegrationTest(
 
     @Test
     fun `hentPersoninfoMedRelasjonerOgRegisterinformasjon() skal filtrere bort relasjoner med opphørte folkreregisteridenter eller uten fødselsdato`() {
+        // Arrange
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(
             emptyList(),
             godkjennDefault = true,
         )
 
+        // Act
         val personInfo =
             personopplysningerService.hentPersoninfoMedRelasjonerOgRegisterinformasjon(
                 lagAktør(
@@ -121,6 +129,7 @@ internal class PersonopplysningerServiceIntegrationTest(
                 ),
             )
 
+        // Assert
         assertEquals(1, personInfo.forelderBarnRelasjon.size)
         assertEquals(
             ID_BARN_1,
@@ -133,44 +142,65 @@ internal class PersonopplysningerServiceIntegrationTest(
 
     @Test
     fun `hentStatsborgerskap() skal return riktig statsborgerskap`() {
+        // Act
         val statsborgerskap = personopplysningerService.hentGjeldendeStatsborgerskap(lagAktør(ID_MOR))
+
+        // Assert
         assert(statsborgerskap.land == "XXX")
     }
 
     @Test
     fun `hentOpphold() skal returnere riktig opphold`() {
+        // Act
         val opphold = personopplysningerService.hentGjeldendeOpphold(lagAktør(ID_MOR))
+
+        // Assert
         assert(opphold.type == OPPHOLDSTILLATELSE.MIDLERTIDIG)
     }
 
     @Test
     fun `hentLandkodeUtenlandskAdresse() skal returnere landkode `() {
+        // Act
         val landkode = personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(lagAktør(ID_MOR))
+
+        // Assert
         assertThat(landkode).isEqualTo("GB")
     }
 
     @Test
     fun `hentLandkodeUtenlandskAdresse() skal returnere ZZ hvis ingen landkode `() {
+        // Act
         val landkode = personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(lagAktør(ID_BARN_1))
+
+        // Assert
         assertThat(landkode).isEqualTo("ZZ")
     }
 
     @Test
     fun `hentLandkodeUtenlandskAdresse() skal returnere ZZ hvis ingen bostedsadresse `() {
+        // Act
         val landkode =
             personopplysningerService.hentLandkodeAlpha2UtenlandskBostedsadresse(lagAktør(ID_MOR_MED_TOM_BOSTEDSADRESSE))
+
+        // Assert
         assertThat(landkode).isEqualTo("ZZ")
     }
 
     @Test
     fun `hentadressebeskyttelse skal returnere gradering`() {
+        // Act
         val gradering = personopplysningerService.hentAdressebeskyttelseSomSystembruker(lagAktør(ID_BARN_1))
+
+        // Assert
         assertThat(gradering).isEqualTo(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)
     }
 
     @Test
     fun `hentadressebeskyttelse skal returnere ugradert ved tom liste fra pdl`() {
+        // Act
         val gradering = personopplysningerService.hentAdressebeskyttelseSomSystembruker(lagAktør(ID_UGRADERT_PERSON))
+
+        // Assert
         assertThat(gradering).isEqualTo(ADRESSEBESKYTTELSEGRADERING.UGRADERT)
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/skyggesak/SkyggesakServiceTest.kt
@@ -41,6 +41,7 @@ class SkyggesakServiceTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `Skal sende skyggesak for fagsak med sendtTidspunkt null`() {
+        // Arrange
         val sendtTidspunkt = listOf(null, LocalDateTime.now())
         skyggesakRepository.saveAll(
             sendtTidspunkt.mapIndexed { i, tid -> Skyggesak(fagsakId = i.toLong(), sendtTidspunkt = tid) },
@@ -48,8 +49,10 @@ class SkyggesakServiceTest : AbstractSpringIntegrationTest() {
 
         every { skyggesakService.fagsakRepository.finnFagsak(any()) } returns Fagsak(aktør = Aktør("1234567890123"))
 
+        // Act
         skyggesakService.sendSkyggesaker()
 
+        // Assert
         verify(exactly = 1) {
             skyggesakService.integrasjonKlient.opprettSkyggesak(Aktør("1234567890123"), 0)
         }
@@ -58,6 +61,7 @@ class SkyggesakServiceTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `Skal slette skyggesaker eldre enn 14 dager`() {
+        // Arrange
         val now = LocalDateTime.now()
         val sendtTidspunkt = listOf(now.minusDays(13), now.minusDays(14), null)
 
@@ -66,8 +70,11 @@ class SkyggesakServiceTest : AbstractSpringIntegrationTest() {
         )
 
         Assertions.assertEquals(2, skyggesakRepository.finnSkyggesakerSomErSendt().size)
+
+        // Act
         skyggesakService.fjernGamleSkyggesakInnslag()
 
+        // Assert
         // Sjekker at usendt skyggesak ikke er slettet, samt skyggesak sendt for mindre enn 14 dager siden
         Assertions.assertEquals(
             null,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/FagsakStatusOppdatererIntegrasjonTest.kt
@@ -42,6 +42,7 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `ikke oppdater status på fagsaker som er løpende og har løpende utbetalinger`() {
+        // Arrange
         val forelderIdent = randomFnr()
 
         val fagsakOriginal =
@@ -56,18 +57,23 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
             andelKalkulertUtbetalingsbeløp = 1054,
         )
 
+        // Act
         val fagsak = fagsakService.hentLøpendeFagsaker()
 
+        // Assert
         Assertions.assertTrue(fagsak.any { it.id == fagsakOriginal.id })
 
+        // Act
         fagsakService.oppdaterLøpendeStatusPåFagsaker()
         val fagsak2 = fagsakService.hentLøpendeFagsaker()
 
+        // Assert
         Assertions.assertTrue(fagsak2.any { it.id == fagsakOriginal.id })
     }
 
     @Test
     fun `skal sette status til avsluttet hvis ingen løpende utbetalinger`() {
+        // Arrange
         val forelderIdent = randomFnr()
 
         val fagsakOriginal =
@@ -89,14 +95,17 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
         tilkjentYtelse.stønadTom = LocalDate.now().minusMonths(1).toYearMonth()
         tilkjentYtelseRepository.save(tilkjentYtelse)
 
+        // Act
         fagsakService.oppdaterLøpendeStatusPåFagsaker()
         val fagsak = fagsakService.hentLøpendeFagsaker()
 
+        // Assert
         Assertions.assertFalse(fagsak.any { it.id == fagsakOriginal.id })
     }
 
     @Test
     fun `skal sette status til avsluttet hvis alle løpende andeler er satt til 0 grunnet endret utbetalingsandeler`() {
+        // Arrange
         val forelderIdent = randomFnr()
 
         val fagsakOriginal =
@@ -112,14 +121,17 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
             andelKalkulertUtbetalingsbeløp = 0,
         )
 
+        // Act
         fagsakService.oppdaterLøpendeStatusPåFagsaker()
         val fagsak = fagsakService.hentLøpendeFagsaker()
 
+        // Assert
         Assertions.assertFalse(fagsak.any { it.id == fagsakOriginal.id })
     }
 
     @Test
     fun `skal ikke sette status til avsluttet hvis alle løpende andeler er satt til 0 grunnet nullutbetaling`() {
+        // Arrange
         val forelderIdent = randomFnr()
 
         val fagsakOriginal =
@@ -135,9 +147,11 @@ class FagsakStatusOppdatererIntegrasjonTest : AbstractSpringIntegrationTest() {
             andelKalkulertUtbetalingsbeløp = 0,
         )
 
+        // Act
         fagsakService.oppdaterLøpendeStatusPåFagsaker()
         val fagsak = fagsakService.hentLøpendeFagsaker()
 
+        // Assert
         Assertions.assertTrue(fagsak.any { it.id == fagsakOriginal.id })
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/PeriodeOffsetIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/PeriodeOffsetIntegrasjonTest.kt
@@ -52,6 +52,7 @@ class PeriodeOffsetIntegrasjonTest(
     @Test
     @Tag("integration")
     fun `Sjekk at offset settes på andel tilkjent ytelse når behandlingen iverksettes`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val stønadFom = LocalDate.now()
@@ -95,6 +96,7 @@ class PeriodeOffsetIntegrasjonTest(
                 Assertions.assertNull(it.kildeBehandlingId)
             }
 
+        // Act & Assert
         assertDoesNotThrow {
             iverksettMotOppdrag.utførStegOgAngiNeste(
                 behandling,
@@ -107,6 +109,7 @@ class PeriodeOffsetIntegrasjonTest(
             )
         }
 
+        // Assert
         beregningService
             .hentAndelerTilkjentYtelseForBehandling(behandling.id)
             .forEach {
@@ -118,6 +121,7 @@ class PeriodeOffsetIntegrasjonTest(
     @Test
     @Tag("integration")
     fun `Sjekk at offset IKKE settes på andel tilkjent ytelse når behandlingen simuleres`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val stønadFom = LocalDate.now()
@@ -161,10 +165,12 @@ class PeriodeOffsetIntegrasjonTest(
                 Assertions.assertNull(it.kildeBehandlingId)
             }
 
+        // Act & Assert
         assertDoesNotThrow {
             simuleringService.oppdaterSimuleringPåBehandling(behandling)
         }
 
+        // Assert
         beregningService
             .hentAndelerTilkjentYtelseForBehandling(behandling.id)
             .forEach {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/integrasjoner/økonomi/ØkonomiIntegrasjonTest.kt
@@ -53,6 +53,7 @@ class ØkonomiIntegrasjonTest(
     @Test
     @Tag("integration")
     fun `Iverksett vedtak på aktiv behandling`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val stønadFom = LocalDate.now()
@@ -88,6 +89,7 @@ class ØkonomiIntegrasjonTest(
 
         beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
 
+        // Act & Assert
         assertDoesNotThrow {
             økonomiService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
                 vedtak,
@@ -99,6 +101,7 @@ class ØkonomiIntegrasjonTest(
     @Test
     @Tag("integration")
     fun `Hent behandlinger for løpende fagsaker til konsistensavstemming mot økonomi`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val stønadFom = LocalDate.now()
@@ -142,9 +145,11 @@ class ØkonomiIntegrasjonTest(
         fagsak.status = FagsakStatus.LØPENDE
         fagsakService.lagre(fagsak)
 
+        // Act
         val behandlingerMedAndelerTilAvstemming =
             behandlingHentOgPersisterService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker()
 
+        // Assert
         Assertions.assertTrue(behandlingerMedAndelerTilAvstemming.contains(behandling.id))
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerIntegrasjonstest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerIntegrasjonstest.kt
@@ -19,12 +19,16 @@ class PreprodControllerIntegrasjonstest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `tømPersonopplysningerCache tømmer cache`() {
+        // Arrange
         val cache = cacheManager.getCacheOrThrow("personopplysninger")
 
         cache.put("personopplysninger", "verdi")
         assertThat(cache.get("personopplysninger")?.get()).isEqualTo("verdi")
 
+        // Act
         val response = preprodController.tømPersonopplysningerCache()
+
+        // Assert
         assertThat(response.body).isEqualTo("Personopplysninger-cache er tømt")
         assertThat(cache.get("personopplysninger")).isNull()
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/SnikeIKøenIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/SnikeIKøenIntegrationTest.kt
@@ -75,10 +75,12 @@ class SnikeIKøenIntegrationTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `automatisk behandling sniker foran åpen behandling før besluttersteget og setter den tilbake til vilkårsvurderingssteget`() {
+        // Arrange
         val åpenBehandling = fullførFørstegangsbehandlingOgKjørRevurderingTilSteg(StegType.BEHANDLINGSRESULTAT)
 
         SnikeIKøenServiceTestConfig.endringstidspunktMock = LocalDateTime.now().minusHours(4)
 
+        // Act & Assert
         assertEquals(
             BEHANDLING_FERDIG,
             autovedtakStegService.kjørBehandlingOmregning(
@@ -114,10 +116,12 @@ class SnikeIKøenIntegrationTest(
 
     @Test
     fun `automatisk behandling forsøker å rekjøre og avbrytes med manuell oppgave etter 7 dager med åpen behandling på besluttersteget`() {
+        // Arrange
         val åpenBehandling = fullførFørstegangsbehandlingOgKjørRevurderingTilSteg(StegType.SEND_TIL_BESLUTTER)
 
         val tid6DagerSiden = LocalDateTime.now().minusDays(6)
 
+        // Act & Assert
         assertThrows<RekjørSenereException> {
             autovedtakStegService.kjørBehandlingOmregning(
                 åpenBehandling.fagsak.aktør,
@@ -131,6 +135,7 @@ class SnikeIKøenIntegrationTest(
             )
         }
 
+        // Act
         autovedtakStegService.kjørBehandlingOmregning(
             åpenBehandling.fagsak.aktør,
             OmregningBrevData(
@@ -142,6 +147,7 @@ class SnikeIKøenIntegrationTest(
             førstegangKjørt = tid6DagerSiden.minusDays(1),
         )
 
+        // Assert
         val lagredeTaskerAvType =
             fakeTaskRepositoryWrapper
                 .hentLagredeTaskerAvType(OpprettOppgaveTask.TASK_STEP_TYPE)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutomatiskVilkårsvurderingIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/AutomatiskVilkårsvurderingIntegrasjonTest.kt
@@ -30,6 +30,7 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Ikke bosatt i riket, skal ikke passere vilkår`() {
+        // Arrange
         val mockSøkerUtenHjem = genererAutomatiskTestperson(bostedsadresser = emptyList())
 
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato(), mockSøkerUtenHjem)
@@ -38,13 +39,18 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =
             stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+
+        // Act
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
+
+        // Assert
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)
     }
 
     @Test
     fun `Barnet er gift, skal ikke passere vilkår`() {
+        // Arrange
         val mockBarnGift = genererAutomatiskTestperson(sivilstander = listOf(Sivilstand(SIVILSTANDTYPE.GIFT)))
 
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato(), mockSøkerAutomatiskBehandling)
@@ -53,13 +59,18 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =
             stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+
+        // Act
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
+
+        // Assert
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)
     }
 
     @Test
     fun `Skal ikke passere vilkårsvurdering dersom barn er over 18`() {
+        // Arrange
         val barnFødselsdato = LocalDate.parse("1999-10-10")
         val barn = genererAutomatiskTestperson(barnFødselsdato, emptySet(), emptyList())
 
@@ -82,13 +93,18 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =
             stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+
+        // Act
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
+
+        // Assert
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)
     }
 
     @Test
     fun `Skal ikke passere vilkårsvurdering dersom barn ikke bor med mor`() {
+        // Arrange
         val barnFødselsdato = LocalDate.now()
         val barn = genererAutomatiskTestperson(barnFødselsdato, emptySet(), emptyList())
         val barnFnr = leggTilPersonInfo(barnFødselsdato, barn)
@@ -131,8 +147,12 @@ class AutomatiskVilkårsvurderingIntegrasjonTest(
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
         val behandlingFørVilkår =
             stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(nyBehandling)
+
+        // Act
         val behandlingEtterVilkår =
             stegService.håndterVilkårsvurdering(behandlingFørVilkår.leggTilBehandlingStegTilstand(StegType.VILKÅRSVURDERING))
+
+        // Assert
         Assertions.assertEquals(Behandlingsresultat.AVSLÅTT, behandlingEtterVilkår.resultat)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VelgFagsystemIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VelgFagsystemIntegrasjonTest.kt
@@ -29,13 +29,17 @@ class VelgFagsystemIntegrasjonTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `sjekk om mor har løpende utbetalinger i infotrygd`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         fakeInfotrygdBarnetrygdKlient.leggTilLøpendeSakIInfotrygd(søkerFnr, emptyList(), true)
+
+        // Act & Assert
         assertEquals(true, velgFagSystemService.morEllerBarnHarLøpendeSakIInfotrygd(søkerFnr, emptyList()))
     }
 
     @Test
     fun `skal IKKE velge ba-sak når mor har stønadhistorikk i Infotrygd`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(søkerFnr))
         val fagsystemUtfall = FagsystemUtfall.SAKER_I_INFOTRYGD_MEN_IKKE_LØPENDE_UTBETALINGER
@@ -49,13 +53,17 @@ class VelgFagsystemIntegrasjonTest(
             ),
         )
 
+        // Act
         val (fagsystemRegelVurdering, faktiskFagsystemUtfall) = velgFagSystemService.velgFagsystem(nyBehandling)
+
+        // Assert
         assertEquals(FagsystemRegelVurdering.SEND_TIL_INFOTRYGD, fagsystemRegelVurdering)
         assertEquals(fagsystemUtfall, faktiskFagsystemUtfall)
     }
 
     @Test
     fun `skal IKKE velge ba-sak når mor er EØS borger`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(søkerFnr))
 
@@ -68,13 +76,18 @@ class VelgFagsystemIntegrasjonTest(
                 bekreftelsesdato = null,
             ),
         )
+
+        // Act
         val (fagsystemRegelVurdering, faktiskFagsystemUtfall) = velgFagSystemService.velgFagsystem(nyBehandling)
+
+        // Assert
         assertEquals(FagsystemRegelVurdering.SEND_TIL_BA, fagsystemRegelVurdering)
         assertEquals(FagsystemUtfall.STØTTET_I_BA_SAK, faktiskFagsystemUtfall)
     }
 
     @Test
     fun `skal velge ba-sak når mor er tredjelandsborger`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
         val nyBehandling = NyBehandlingHendelse(søkerFnr, listOf(barnFnr))
@@ -90,7 +103,10 @@ class VelgFagsystemIntegrasjonTest(
             ),
         )
 
+        // Act
         val (fagsystemRegelVurdering, faktiskFagsystemUtfall) = velgFagSystemService.velgFagsystem(nyBehandling)
+
+        // Assert
         assertEquals(FagsystemRegelVurdering.SEND_TIL_BA, fagsystemRegelVurdering)
         assertEquals(fagsystemUtfall, faktiskFagsystemUtfall)
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/fødselshendelse/VilkårVurderingTest.kt
@@ -55,6 +55,7 @@ class VilkårVurderingTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Henting og evaluering av oppfylte vilkår gir rett antall samlede resultater`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
 
@@ -74,9 +75,11 @@ class VilkårVurderingTest(
             )
         personopplysningGrunnlagRepository.save(personopplysningGrunnlag)
 
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.initierVilkårsvurderingForBehandling(behandling, false, null)
 
+        // Assert
         val forventetAntallVurderteVilkår =
             Vilkår.hentVilkårFor(personType = PersonType.BARN, fagsakType = FagsakType.NORMAL, behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR).size +
                 Vilkår.hentVilkårFor(personType = PersonType.SØKER, fagsakType = FagsakType.NORMAL, behandlingUnderkategori = BehandlingUnderkategori.ORDINÆR).size
@@ -88,14 +91,20 @@ class VilkårVurderingTest(
 
     @Test
     fun `Sjekk gyldig vilkårsperiode`() {
+        // Act
         val ubegrensetGyldigVilkårsperiode = GyldigVilkårsperiode()
+
+        // Assert
         assertTrue(ubegrensetGyldigVilkårsperiode.gyldigFor(LocalDate.now()))
 
+        // Arrange
         val begrensetGyldigVilkårsperiode =
             GyldigVilkårsperiode(
                 gyldigFom = LocalDate.now().minusDays(5),
                 gyldigTom = LocalDate.now().plusDays(5),
             )
+
+        // Assert
         assertTrue(begrensetGyldigVilkårsperiode.gyldigFor(LocalDate.now()))
         assertTrue(begrensetGyldigVilkårsperiode.gyldigFor(LocalDate.now().minusDays(5)))
         assertFalse(begrensetGyldigVilkårsperiode.gyldigFor(LocalDate.now().minusDays(6)))
@@ -127,6 +136,7 @@ class VilkårVurderingTest(
 
     @Test
     fun `Sjekk barn bor med søker`() {
+        // Arrange
         val søkerAddress =
             GrVegadresseBostedsadresse(
                 1234,
@@ -165,6 +175,7 @@ class VilkårVurderingTest(
         val barn3 = genererPerson(PersonType.BARN, personopplysningGrunnlag, null, Kjønn.MANN)
         personopplysningGrunnlag.personer.add(barn3)
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.BOR_MED_SØKER.vurderVilkår(barn1, LocalDate.now()).resultat)
         assertEquals(Resultat.IKKE_OPPFYLT, Vilkår.BOR_MED_SØKER.vurderVilkår(barn2, LocalDate.now()).resultat)
         assertEquals(Resultat.IKKE_OPPFYLT, Vilkår.BOR_MED_SØKER.vurderVilkår(barn3, LocalDate.now()).resultat)
@@ -172,6 +183,7 @@ class VilkårVurderingTest(
 
     @Test
     fun `Sjekk barn bor med mor når mor har bodd på adressen lengre enn barn`() {
+        // Arrange
         val søkerAddress =
             GrVegadresseBostedsadresse(
                 1234,
@@ -210,11 +222,13 @@ class VilkårVurderingTest(
         val barn1 = genererPerson(PersonType.BARN, personopplysningGrunnlag, barnAddress, Kjønn.MANN)
         personopplysningGrunnlag.personer.add(barn1)
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.BOR_MED_SØKER.vurderVilkår(barn1, LocalDate.now()).resultat)
     }
 
     @Test
     fun `Negativ vurdering - Barn og søker har ikke adresse angitt`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 2)
         val søker = genererPerson(PersonType.SØKER, personopplysningGrunnlag, null)
         personopplysningGrunnlag.personer.add(søker)
@@ -222,11 +236,13 @@ class VilkårVurderingTest(
         val barn = genererPerson(PersonType.BARN, personopplysningGrunnlag, null)
         personopplysningGrunnlag.personer.add(barn)
 
+        // Act & Assert
         assertEquals(Resultat.IKKE_OPPFYLT, Vilkår.BOR_MED_SØKER.vurderVilkår(barn, barn.fødselsdato).resultat)
     }
 
     @Test
     fun `Skal kaste exception - ingen søker`() {
+        // Arrange
         val søkerAddress =
             GrVegadresseBostedsadresse(
                 1234,
@@ -246,6 +262,7 @@ class VilkårVurderingTest(
         personopplysningGrunnlag.personer.add(barn)
         personopplysningGrunnlag.personer.add(feilregistrertSøker)
 
+        // Act & Assert
         assertThrows(Feil::class.java) {
             Vilkår.BOR_MED_SØKER.vurderVilkår(barn, LocalDate.now()).resultat
         }
@@ -253,6 +270,7 @@ class VilkårVurderingTest(
 
     @Test
     fun `Negativ vurdering - søker har ukjentadresse`() {
+        // Arrange
         val ukjentbosted = GrUkjentBostedBostedsadresse("Oslo")
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val søker = genererPerson(PersonType.SØKER, personopplysningGrunnlag, ukjentbosted)
@@ -260,24 +278,29 @@ class VilkårVurderingTest(
         val barn = genererPerson(PersonType.BARN, personopplysningGrunnlag, ukjentbosted)
         personopplysningGrunnlag.personer.add(barn)
 
+        // Act & Assert
         assertEquals(Resultat.IKKE_OPPFYLT, Vilkår.BOR_MED_SØKER.vurderVilkår(barn, LocalDate.now()).resultat)
     }
 
     @Test
     fun `Sjekk at barn er ugift`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val barn = genererPerson(PersonType.BARN, personopplysningGrunnlag)
         personopplysningGrunnlag.personer.add(barn)
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.GIFT_PARTNERSKAP.vurderVilkår(barn, LocalDate.now()).resultat)
     }
 
     @Test
     fun `Negativ vurdering - barn er gift`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val barn = genererPerson(PersonType.BARN, personopplysningGrunnlag, sivilstand = SIVILSTANDTYPE.GIFT)
         personopplysningGrunnlag.personer.add(barn)
 
+        // Act & Assert
         assertEquals(
             Resultat.IKKE_OPPFYLT,
             Vilkår.GIFT_PARTNERSKAP.vurderVilkår(barn, LocalDate.now()).resultat,
@@ -286,6 +309,7 @@ class VilkårVurderingTest(
 
     @Test
     fun `Negativ vurdering - barn har vært gift`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val barn =
             genererPerson(PersonType.BARN, personopplysningGrunnlag, sivilstand = SIVILSTANDTYPE.GIFT).apply {
@@ -297,6 +321,7 @@ class VilkårVurderingTest(
             }
         personopplysningGrunnlag.personer.add(barn)
 
+        // Act & Assert
         assertEquals(
             Resultat.IKKE_OPPFYLT,
             Vilkår.GIFT_PARTNERSKAP.vurderVilkår(barn).resultat,
@@ -305,15 +330,18 @@ class VilkårVurderingTest(
 
     @Test
     fun `Negativ vurdering - søker er ikke bosatt i norge`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val søker = genererPerson(PersonType.SØKER, personopplysningGrunnlag, sivilstand = SIVILSTANDTYPE.GIFT)
         personopplysningGrunnlag.personer.add(søker)
 
+        // Act & Assert
         assertEquals(Resultat.IKKE_OPPFYLT, Vilkår.BOSATT_I_RIKET.vurderVilkår(søker, LocalDate.now()).resultat)
     }
 
     @Test
     fun `Negativ vurdering - søker har ikke vært bosatt i norge siden barnets fødselsdato`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val søker =
             genererPerson(PersonType.SØKER, personopplysningGrunnlag, sivilstand = SIVILSTANDTYPE.GIFT).apply {
@@ -336,6 +364,7 @@ class VilkårVurderingTest(
             }
         personopplysningGrunnlag.personer.add(søker)
 
+        // Act & Assert
         assertEquals(
             Resultat.IKKE_OPPFYLT,
             Vilkår.BOSATT_I_RIKET.vurderVilkår(søker, LocalDate.now().minusMonths(1)).resultat,
@@ -344,6 +373,7 @@ class VilkårVurderingTest(
 
     @Test
     fun `Sjekk at mor er bosatt i norge`() {
+        // Arrange
         val vegadresse =
             GrVegadresseBostedsadresse(
                 1234,
@@ -362,11 +392,13 @@ class VilkårVurderingTest(
         val mor = genererPerson(PersonType.SØKER, personopplysningGrunnlag, vegadresse)
         personopplysningGrunnlag.personer.add(mor)
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.BOSATT_I_RIKET.vurderVilkår(mor, LocalDate.now()).resultat)
     }
 
     @Test
     fun `Sjekk at mor har vært bosatt i norge siden barnet ble født`() {
+        // Arrange
         val vegadresse =
             GrVegadresseBostedsadresse(
                 matrikkelId = 1234,
@@ -386,6 +418,7 @@ class VilkårVurderingTest(
         val mor = genererPerson(PersonType.SØKER, personopplysningGrunnlag, vegadresse)
         personopplysningGrunnlag.personer.add(mor)
 
+        // Act & Assert
         assertEquals(
             Resultat.OPPFYLT,
             Vilkår.BOSATT_I_RIKET.vurderVilkår(mor, LocalDate.now().minusMonths(3)).resultat,
@@ -394,6 +427,7 @@ class VilkårVurderingTest(
 
     @Test
     fun `Negativ vurdering - mor har bare adresse deler av perioden siden barnet ble født`() {
+        // Arrange
         val vegadresser =
             listOf(
                 DatoIntervallEntitet(LocalDate.now().minusMonths(7), LocalDate.now().minusMonths(4)),
@@ -421,6 +455,7 @@ class VilkårVurderingTest(
             }
         personopplysningGrunnlag.personer.add(mor)
 
+        // Act & Assert
         assertEquals(
             Resultat.IKKE_OPPFYLT,
             Vilkår.BOSATT_I_RIKET.vurderVilkår(mor, LocalDate.now().minusMonths(6)).resultat,
@@ -429,15 +464,18 @@ class VilkårVurderingTest(
 
     @Test
     fun `Negativ vurdering - mor er ikke bosatt i norge`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val mor = genererPerson(PersonType.SØKER, personopplysningGrunnlag, sivilstand = SIVILSTANDTYPE.GIFT)
         personopplysningGrunnlag.personer.add(mor)
 
+        // Act & Assert
         assertEquals(Resultat.IKKE_OPPFYLT, Vilkår.BOSATT_I_RIKET.vurderVilkår(mor, LocalDate.now()).resultat)
     }
 
     @Test
     fun `Lovlig opphold - nordisk statsborger`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val person =
             genererPerson(PersonType.BARN, personopplysningGrunnlag, sivilstand = SIVILSTANDTYPE.GIFT)
@@ -457,12 +495,14 @@ class VilkårVurderingTest(
                         )
                 }
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.LOVLIG_OPPHOLD.vurderVilkår(person, LocalDate.now()).resultat)
     }
 
     @Test
     @Disabled
     fun `Mor er fra EØS og har et løpende arbeidsforhold - lovlig opphold, skal evalueres til Ja`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val person =
             genererPerson(PersonType.SØKER, personopplysningGrunnlag, sivilstand = SIVILSTANDTYPE.GIFT)
@@ -479,6 +519,7 @@ class VilkårVurderingTest(
                     it.arbeidsforhold = løpendeArbeidsforhold(it)
                 }
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.LOVLIG_OPPHOLD.vurderVilkår(person, LocalDate.now()).resultat)
         assertEquals(
             "Mor er EØS-borger, men har et løpende arbeidsforhold i Norge.",
@@ -491,6 +532,7 @@ class VilkårVurderingTest(
     @Test
     @Disabled
     fun `Mor er fra EØS og har ikke et løpende arbeidsforhold, bor sammen med annen forelder som er fra norden - lovlig opphold, skal evalueres til Ja`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val bostedsadresse = Bostedsadresse(vegadresse = Vegadresse(0, null, null, "32E", null, null, null, null))
         val person =
@@ -514,6 +556,7 @@ class VilkårVurderingTest(
         val annenForelder = opprettAnnenForelder(personopplysningGrunnlag, bostedsadresse, Medlemskap.NORDEN)
         person.personopplysningGrunnlag.personer.add(annenForelder)
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.LOVLIG_OPPHOLD.vurderVilkår(person, LocalDate.now()).resultat)
         assertEquals(
             "Annen forelder er norsk eller nordisk statsborger.",
@@ -526,6 +569,7 @@ class VilkårVurderingTest(
     @Test
     @Disabled
     fun `Mor er fra EØS og har ikke et løpende arbeidsforhold, bor sammen med annen forelder som er tredjelandsborger - lovlig opphold, skal evalueres til Nei`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val bostedsadresse = Bostedsadresse(vegadresse = Vegadresse(0, null, null, "32E", null, null, null, null))
         val person =
@@ -550,6 +594,7 @@ class VilkårVurderingTest(
 
         person.personopplysningGrunnlag.personer.add(annenForelder)
 
+        // Act & Assert
         assertEquals(
             Resultat.IKKE_OPPFYLT,
             Vilkår.LOVLIG_OPPHOLD.vurderVilkår(person, LocalDate.now()).resultat,
@@ -565,6 +610,7 @@ class VilkårVurderingTest(
     @Test
     @Disabled
     fun `Mor er fra EØS og har ikke et løpende arbeidsforhold, bor sammen med annen forelder som er statsløs - lovlig opphold, skal evalueres til Nei`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val bostedsadresse = Bostedsadresse(vegadresse = Vegadresse(0, null, null, "32E", null, null, null, null))
         val person =
@@ -588,6 +634,7 @@ class VilkårVurderingTest(
         val annenForelder = opprettAnnenForelder(personopplysningGrunnlag, bostedsadresse, Medlemskap.UKJENT)
         person.personopplysningGrunnlag.personer.add(annenForelder)
 
+        // Act & Assert
         assertEquals(
             Resultat.IKKE_OPPFYLT,
             Vilkår.LOVLIG_OPPHOLD.vurderVilkår(person, LocalDate.now()).resultat,
@@ -603,6 +650,7 @@ class VilkårVurderingTest(
     @Test
     @Disabled
     fun `Mor er fra EØS og har ikke et løpende arbeidsforhold, bor sammen med annen forelder fra EØS som har løpende arbeidsforhold - lovlig opphold, skal evalueres til Ja`() {
+        // Arrange
         val personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 6)
         val bostedsadresse = Bostedsadresse(vegadresse = Vegadresse(0, null, null, "32E", null, null, null, null))
         val person =
@@ -628,6 +676,7 @@ class VilkårVurderingTest(
                 .also { it.arbeidsforhold = løpendeArbeidsforhold(it) }
         person.personopplysningGrunnlag.personer.add(annenForelder)
 
+        // Act & Assert
         assertEquals(Resultat.OPPFYLT, Vilkår.LOVLIG_OPPHOLD.vurderVilkår(person, LocalDate.now()).resultat)
         assertEquals(
             "Annen forelder er fra EØS, men har et løpende arbeidsforhold i Norge.",

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsKjøringRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/autovedtak/satsendringeøs/SatsendringEøsKjøringRepositoryTest.kt
@@ -26,6 +26,7 @@ class SatsendringEøsKjøringRepositoryTest(
 
     @Test
     fun `findByBehandlingId returnerer kjøring når behandlingId matcher`() {
+        // Arrange
         val fagsak = opprettFagsak()
         val behandling = behandlingRepository.saveAndFlush(lagBehandlingUtenId(fagsak = fagsak))
 
@@ -39,20 +40,25 @@ class SatsendringEøsKjøringRepositoryTest(
                 ),
             )
 
+        // Act
         val funnet = satsendringEøsKjøringRepository.findByBehandlingId(behandling.id)
 
+        // Assert
         assertThat(funnet).isEqualTo(lagretKjøring)
     }
 
     @Test
     fun `findByBehandlingId returnerer null når behandlingId ikke finnes`() {
+        // Act
         val funnet = satsendringEøsKjøringRepository.findByBehandlingId(999L)
 
+        // Assert
         assertThat(funnet).isNull()
     }
 
     @Test
     fun `findByFagsakIdAndUtbetalingslandAndSatsTidspunkt returnerer kjøring når alle felter matcher`() {
+        // Arrange
         val fagsak = opprettFagsak()
         val lagretKjøring =
             satsendringEøsKjøringRepository.saveAndFlush(
@@ -63,6 +69,7 @@ class SatsendringEøsKjøringRepositoryTest(
                 ),
             )
 
+        // Act
         val funnet =
             satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(
                 fagsakId = fagsak.id,
@@ -70,11 +77,13 @@ class SatsendringEøsKjøringRepositoryTest(
                 satsTidspunkt = satsTidspunkt,
             )
 
+        // Assert
         assertThat(funnet).isEqualTo(lagretKjøring)
     }
 
     @Test
     fun `findByFagsakIdAndUtbetalingslandAndSatsTidspunkt returnerer null når utbetalingsland ikke matcher`() {
+        // Arrange
         val fagsak = opprettFagsak()
         satsendringEøsKjøringRepository.saveAndFlush(
             SatsendringEøsKjøring(
@@ -84,6 +93,7 @@ class SatsendringEøsKjøringRepositoryTest(
             ),
         )
 
+        // Act
         val funnet =
             satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(
                 fagsakId = fagsak.id,
@@ -91,11 +101,13 @@ class SatsendringEøsKjøringRepositoryTest(
                 satsTidspunkt = satsTidspunkt,
             )
 
+        // Assert
         assertThat(funnet).isNull()
     }
 
     @Test
     fun `findByFagsakIdAndUtbetalingslandAndSatsTidspunkt returnerer null når satsTidspunkt ikke matcher`() {
+        // Arrange
         val fagsak = opprettFagsak()
         satsendringEøsKjøringRepository.saveAndFlush(
             SatsendringEøsKjøring(
@@ -105,6 +117,7 @@ class SatsendringEøsKjøringRepositoryTest(
             ),
         )
 
+        // Act
         val funnet =
             satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(
                 fagsakId = fagsak.id,
@@ -112,11 +125,13 @@ class SatsendringEøsKjøringRepositoryTest(
                 satsTidspunkt = satsTidspunkt.plusMonths(1),
             )
 
+        // Assert
         assertThat(funnet).isNull()
     }
 
     @Test
     fun `findByFagsakIdAndUtbetalingslandAndSatsTidspunkt returnerer null når fagsakId ikke matcher`() {
+        // Arrange
         val fagsak = opprettFagsak()
         satsendringEøsKjøringRepository.saveAndFlush(
             SatsendringEøsKjøring(
@@ -127,6 +142,8 @@ class SatsendringEøsKjøringRepositoryTest(
         )
 
         val annenFagsak = opprettFagsak()
+
+        // Act
         val funnet =
             satsendringEøsKjøringRepository.findByFagsakIdAndUtbetalingslandAndSatsTidspunkt(
                 fagsakId = annenFagsak.id,
@@ -134,6 +151,7 @@ class SatsendringEøsKjøringRepositoryTest(
                 satsTidspunkt = satsTidspunkt,
             )
 
+        // Assert
         assertThat(funnet).isNull()
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingHentOgPersisterServiceIntegrationTest.kt
@@ -16,6 +16,7 @@ class BehandlingHentOgPersisterServiceIntegrationTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `skal hente aktiv fødselsnummere`() {
+        // Arrange
         val fødselsnummere = listOf(randomFnr(), randomFnr())
         val fagsak1 = fagsakService.hentEllerOpprettFagsakForPersonIdent(fødselsnummere[0])
         fagsakService.oppdaterStatus(fagsak1, FagsakStatus.LØPENDE)
@@ -25,6 +26,7 @@ class BehandlingHentOgPersisterServiceIntegrationTest(
         fagsakService.oppdaterStatus(fagsak2, FagsakStatus.LØPENDE)
         val behandling2 = behandlingHentOgPersisterService.lagreEllerOppdater(lagBehandlingUtenId(fagsak2), false)
 
+        // Act
         val aktivFødselsnummere =
             behandlingHentOgPersisterService.hentAktivtFødselsnummerForBehandlinger(
                 listOf(
@@ -32,15 +34,20 @@ class BehandlingHentOgPersisterServiceIntegrationTest(
                     behandling2.id,
                 ),
             )
+
+        // Assert
         assertEquals(fødselsnummere[0], aktivFødselsnummere[behandling1.id])
         assertEquals(fødselsnummere[1], aktivFødselsnummere[behandling2.id])
     }
 
     @Test
     fun `skal hente status på behandling`() {
+        // Arrange
         val fnr = randomFnr()
         val fagsak1 = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
         val behandling1 = behandlingHentOgPersisterService.lagreEllerOppdater(lagBehandlingUtenId(fagsak1), false)
+
+        // Act & Assert
         assertThat(behandlingHentOgPersisterService.hentStatus(behandling1.id)).isEqualTo(behandling1.status)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/BehandlingIntegrationTest.kt
@@ -120,27 +120,37 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Kjør flyway migreringer og sjekk at behandlingslagerservice klarer å lese å skrive til postgresql`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
+
+        // Act
         behandlingService.opprettBehandling(
             nyOrdinærBehandling(
                 fagsakId = fagsak.id,
             ),
         )
+
+        // Assert
         assertEquals(1, behandlingHentOgPersisterService.hentBehandlinger(fagsak.id).size)
     }
 
     @Test
     fun `Test at opprettEllerOppdaterBehandling kjører uten feil`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
+
+        // Act
         behandlingService.opprettBehandling(
             nyOrdinærBehandling(
                 fagsakId = fagsak.id,
             ),
         )
+
+        // Assert
         assertEquals(
             1,
             behandlingHentOgPersisterService.hentBehandlinger(fagsak.id).size,
@@ -149,31 +159,40 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Opprett behandling`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
+
+        // Act
         val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))
+
+        // Assert
         assertEquals(fagsak.id, behandling.fagsak.id)
     }
 
     @Test
     fun `Kast feil ved opprettelse av behandling for ny person med åpen sak i Infotrygd`() {
+        // Arrange
         val fnr = randomFnr()
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
 
         fakeInfotrygdBarnetrygdKlient.leggTilÅpenSakIInfotrygd(fnr, emptyList(), true)
 
+        // Act & Assert
         assertThatThrownBy { behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak)) }
             .hasMessageContaining("sak i Infotrygd")
     }
 
     @Test
     fun `Kast feil ved opprettelse av behandling for ny person med løpende sak i Infotrygd, utenom migrering`() {
+        // Arrange
         val fnr = randomFnr()
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
 
         fakeInfotrygdBarnetrygdKlient.leggTilLøpendeSakIInfotrygd(fnr, emptyList(), true)
 
+        // Act & Assert
         assertThatThrownBy { behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak)) }
             .hasMessageContaining("sak i Infotrygd")
 
@@ -201,11 +220,15 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Opprett behandle sak oppgave ved opprettelse av førstegangsbehandling`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
+
+        // Act
         val behandling = behandlingService.opprettBehandling(nyOrdinærBehandling(fagsakId = fagsak.id))
 
+        // Assert
         val lagredeTaskerAvType =
             fakeTaskRepositoryWrapper
                 .hentLagredeTaskerAvType(OpprettOppgaveTask.TASK_STEP_TYPE)
@@ -218,20 +241,27 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Opprett aktivt vedtak ved opprettelse av behandling`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
+
+        // Act
         val behandling =
             behandlingService.opprettBehandling(nyOrdinærBehandling(fagsakId = fagsak.id))
 
+        // Assert
         assertNotNull(vedtakService.hentAktivForBehandling(behandlingId = behandling.id))
     }
 
     @Test
     fun `Ikke opprett behandle sak oppgave ved opprettelse av fødselshendelsebehandling`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
+
+        // Act
         val behandling =
             behandlingService.opprettBehandling(
                 NyBehandling(
@@ -244,6 +274,7 @@ class BehandlingIntegrationTest(
                 ),
             )
 
+        // Assert
         val lagredeTaskerAvType =
             fakeTaskRepositoryWrapper
                 .hentLagredeTaskerAvType(OpprettOppgaveTask.TASK_STEP_TYPE)
@@ -256,6 +287,7 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Kast feil om man lager ny behandling på fagsak som har behandling som skal godkjennes`() {
+        // Arrange
         val morId = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = morId))
@@ -270,6 +302,7 @@ class BehandlingIntegrationTest(
         )
         behandlingRepository.saveAndFlush(behandling)
 
+        // Act & Assert
         assertThrows(Exception::class.java) {
             behandlingService.opprettBehandling(
                 NyBehandling(
@@ -285,6 +318,7 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Opprett barnas beregning på vedtak`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barn1Fnr = randomFnr()
         val barn2Fnr = randomFnr()
@@ -362,6 +396,7 @@ class BehandlingIntegrationTest(
             )
         vilkårsvurderingRepository.save(vilkårsvurdering)
 
+        // Act
         val tilkjentYtelse = beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
         val barnOgYtelsePeriodeDtoMap =
             personopplysningGrunnlag
@@ -371,6 +406,7 @@ class BehandlingIntegrationTest(
                     { personMedAndelerDto -> personMedAndelerDto.ytelsePerioder.sortedBy { it.stønadFom } },
                 )
 
+        // Assert
         val satsEndringDatoSeptember2020 =
             SatsService.hentDatoForSatsendring(SatsType.TILLEGG_ORBA, 1354)!!.toYearMonth()
         val satsEndringDatoSeptember2021 =
@@ -417,6 +453,7 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Endre barnas beregning på vedtak`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barn1Fnr = randomFnr()
         val barn2Fnr = randomFnr()
@@ -482,6 +519,7 @@ class BehandlingIntegrationTest(
             )
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering2)
 
+        // Act
         val satsEndringDatoSeptember2021 =
             SatsService.hentDatoForSatsendring(SatsType.TILLEGG_ORBA, 1654)!!.toYearMonth()
         val satsEndringDatoJanuar2022 = SatsService.hentDatoForSatsendring(SatsType.TILLEGG_ORBA, 1676)!!.toYearMonth()
@@ -495,6 +533,7 @@ class BehandlingIntegrationTest(
                     { personMedAndelerDto -> personMedAndelerDto.ytelsePerioder.sortedBy { it.stønadFom } },
                 )
 
+        // Assert
         assertEquals(2, barnOgYtelsePeriodeDtoMap.size)
 
         // Barn 1
@@ -526,6 +565,7 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Hent en persons bostedsadresse fra PDL og lagre den i database`() {
+        // Arrange
         val matrikkelId = 123456L
         val søkerHusnummer = "12"
         val søkerHusbokstav = "A"
@@ -614,6 +654,7 @@ class BehandlingIntegrationTest(
             Målform.NB,
         )
 
+        // Assert
         val søker = personRepository.findByAktør(søkerAktør).first()
         val vegadresse = søker.bostedsadresser.sisteAdresse() as GrVegadresseBostedsadresse
         assertEquals(søkerAdressnavn, vegadresse.adressenavn)
@@ -651,6 +692,7 @@ class BehandlingIntegrationTest(
 
     @Test
     fun `Skal lagre og sende korrekt sakstatistikk for behandlingsresultat`() {
+        // Arrange
         val fnr = randomFnr()
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr))
         val behandling =
@@ -658,6 +700,7 @@ class BehandlingIntegrationTest(
         behandlingService.opprettOgInitierNyttVedtakForBehandling(behandling = behandling)
         val vedtak = vedtakService.hentAktivForBehandling(behandling.id)
 
+        // Act
         vedtakService.oppdater(vedtak!!)
 
         behandlingHentOgPersisterService.lagreEllerOppdater(
@@ -666,6 +709,7 @@ class BehandlingIntegrationTest(
             },
         )
 
+        // Assert
         val behandlingDvhMeldinger =
             saksstatistikkMellomlagringRepository
                 .finnMeldingerKlarForSending()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
@@ -58,12 +58,16 @@ class SnikeIKøenServiceTest(
     @ParameterizedTest
     @EnumSource(BehandlingStatus::class, names = ["UTREDES", "SATT_PÅ_VENT"], mode = EnumSource.Mode.INCLUDE)
     fun `skal kunne sette en behandling med status UTREDES eller SATT_PÅ_VENT på maskinell vent`(status: BehandlingStatus) {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling = opprettBehandling(status = status, fagsak = fagsak)
 
+        // Act
         settAktivBehandlingTilPåMaskinellVent(behandling)
 
         val oppdatertBehandling = behandlingRepository.finnBehandling(behandling.id)
+
+        // Assert
         assertThat(behandling.status).isEqualTo(status)
         assertThat(behandling.aktiv).isTrue()
         assertThat(oppdatertBehandling.status).isEqualTo(BehandlingStatus.SATT_PÅ_MASKINELL_VENT)
@@ -72,20 +76,25 @@ class SnikeIKøenServiceTest(
 
     @Test
     fun `reaktivering av behandling skal sette status tilbake til UTREDES`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling1 = opprettBehandling(fagsak = fagsak)
         settAktivBehandlingTilPåMaskinellVent(behandling1)
         val behandling2 = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = true, fagsak = fagsak)
 
+        // Act
         snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)
 
         val oppdatertBehandling = behandlingRepository.finnBehandling(behandling1.id)
+
+        // Assert
         assertThat(oppdatertBehandling.status).isEqualTo(BehandlingStatus.UTREDES)
         assertThat(oppdatertBehandling.aktiv).isTrue()
     }
 
     @Test
     fun `reaktivering av behandling som er på vent skal sette status tilbake til SATT_PÅ_VENT`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling1 = opprettBehandling(fagsak = fagsak)
         lagreArbeidsfordeling(behandling1)
@@ -93,53 +102,65 @@ class SnikeIKøenServiceTest(
         settAktivBehandlingTilPåMaskinellVent(behandling1)
         val behandling2 = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = true, fagsak = fagsak)
 
+        // Act
         snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)
 
         val oppdatertBehandling = behandlingRepository.finnBehandling(behandling1.id)
+
+        // Assert
         assertThat(oppdatertBehandling.status).isEqualTo(BehandlingStatus.SATT_PÅ_VENT)
         assertThat(oppdatertBehandling.aktiv).isTrue()
     }
 
     @Test
     fun `siste behandlingen er den som er aktiv til at behandlingen som er satt på vent er aktivert på nytt`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = false, fagsak = fagsak)
         val behandling2 = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = true, fagsak = fagsak)
         lagUtbetalingsoppdragOgAvslutt(behandling2)
 
+        // Assert
         validerSisteBehandling(fagsak = fagsak, behandling = behandling2)
         validerErAktivBehandling(behandling = behandling2)
     }
 
     @Test
     fun `behandling som er satt på vent blir aktivert, men ennå ikke iverksatt, og er då siste aktive behandlingen`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling1 = opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = false, fagsak = fagsak)
         val behandling2 = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = true, fagsak = fagsak)
         lagUtbetalingsoppdragOgAvslutt(behandling2)
 
+        // Act
         snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)
 
+        // Assert
         validerSisteBehandling(fagsak = fagsak, behandling = behandling2)
         validerErAktivBehandling(behandling1)
     }
 
     @Test
     fun `behandling som er satt på vent blir aktivert og iverksatt, og er då siste aktive behandlingen`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling1 = opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = false, fagsak = fagsak)
         val behandling2 = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = true, fagsak = fagsak)
         lagUtbetalingsoppdragOgAvslutt(behandling2)
 
+        // Act
         snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)
         lagUtbetalingsoppdragOgAvslutt(behandling1)
 
+        // Assert
         validerSisteBehandling(behandling = behandling1, fagsak = fagsak)
         validerErAktivBehandling(behandling1)
     }
 
     @Test
     fun `reaktivering skal tilbakestille behandling på vent`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling1 = opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = false, fagsak = fagsak)
 
@@ -156,13 +177,16 @@ class SnikeIKøenServiceTest(
         val behandling2 = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = true, fagsak = fagsak)
         lagUtbetalingsoppdragOgAvslutt(behandling2)
 
+        // Act
         snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)
 
+        // Assert
         assertThat(vedtaksperiodeHentOgPersisterService.finnVedtaksperioderFor(vedtak.id)).isEmpty()
     }
 
     @Test
     fun `reaktivering skal tilbakestille til vilkårsvurdering kun dersom steget er lagt til på behandlingen`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling1 = opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = false, fagsak = fagsak)
         lagreArbeidsfordeling(behandling1)
@@ -173,9 +197,12 @@ class SnikeIKøenServiceTest(
         val behandling2 = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = true, fagsak = fagsak)
         lagUtbetalingsoppdragOgAvslutt(behandling2)
 
+        // Act
         snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)
 
         val oppdatertBehandling = behandlingRepository.finnBehandling(behandling1.id)
+
+        // Assert
         assertThat(oppdatertBehandling.steg).isEqualTo(initielStegTilstand)
 
         behandlingService.leggTilStegPåBehandlingOgSettTidligereStegSomUtført(oppdatertBehandling.id, StegType.VILKÅRSVURDERING)
@@ -201,7 +228,10 @@ class SnikeIKøenServiceTest(
 
     @Test
     fun `skal ikke reaktivere noe hvis det ikke finnes en behandling som er på maskinell vent`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
+
+        // Act
         val behandling2 =
             opprettBehandling(
                 status = BehandlingStatus.AVSLUTTET,
@@ -209,12 +239,14 @@ class SnikeIKøenServiceTest(
                 fagsak = fagsak,
             )
 
+        // Assert
         assertThat(snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)).isFalse()
         assertThat(behandlingRepository.finnBehandling(behandling2.id).aktiv).isTrue()
     }
 
     @Test
     fun `skal kunne reaktivere en behandling selv om det ikke finnes en annen behandling som er aktiv, eks henlagt`() {
+        // Arrange
         val fagsak = opprettLøpendeFagsak()
         val behandling1 = opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = false, fagsak = fagsak)
         val behandling2 =
@@ -225,8 +257,10 @@ class SnikeIKøenServiceTest(
                 fagsak = fagsak,
             )
 
+        // Act
         snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandling2)
 
+        // Assert
         assertThat(behandlingRepository.finnBehandling(behandling1.id).aktiv).isTrue()
         assertThat(behandlingRepository.finnBehandling(behandling2.id).aktiv).isFalse()
     }
@@ -235,9 +269,11 @@ class SnikeIKøenServiceTest(
     inner class ValideringAvSettPåVent {
         @Test
         fun `kan ikke sette en inaktiv behandling på vent`() {
+            // Arrange
             val fagsak = opprettLøpendeFagsak()
             val behandling = opprettBehandling(aktiv = false, fagsak = fagsak)
 
+            // Act & Assert
             assertThatThrownBy {
                 settAktivBehandlingTilPåMaskinellVent(behandling)
             }.hasMessageContaining("er ikke aktiv")
@@ -246,9 +282,11 @@ class SnikeIKøenServiceTest(
         @ParameterizedTest
         @EnumSource(BehandlingStatus::class, names = ["UTREDES", "SATT_PÅ_VENT"], mode = EnumSource.Mode.EXCLUDE)
         fun `kan ikke sette en behandling på vent med annen status enn UTREDES eller SATT_PÅ_VENT`(status: BehandlingStatus) {
+            // Arrange
             val fagsak = opprettLøpendeFagsak()
             val behandling = opprettBehandling(status = status, fagsak = fagsak)
 
+            // Act & Assert
             assertThatThrownBy {
                 settAktivBehandlingTilPåMaskinellVent(behandling)
             }.hasMessageContaining("kan ikke settes på maskinell vent då status")
@@ -260,20 +298,24 @@ class SnikeIKøenServiceTest(
         @Suppress("UNUSED_VARIABLE")
         @Test
         fun `skal feile når åpen behandling er aktiv`() {
+            // Arrange
             val fagsak = opprettLøpendeFagsak()
             val behandlingPåVent = opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = true, fagsak = fagsak)
             val behandlingSomSnekIKøen = opprettBehandling(status = BehandlingStatus.AVSLUTTET, aktiv = false, fagsak = fagsak)
 
+            // Act & Assert
             assertThatThrownBy { snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandlingSomSnekIKøen) }
                 .hasMessageContaining("Åpen behandling har feil tilstand")
         }
 
         @Test
         fun `skal feile når behandling som snek i køen har status satt på vent`() {
+            // Arrange
             val fagsak = opprettLøpendeFagsak()
             opprettBehandling(status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT, aktiv = false, fagsak = fagsak)
             val behandlingSomSnekIKøen = opprettBehandling(status = BehandlingStatus.UTREDES, aktiv = true, fagsak = fagsak)
 
+            // Act & Assert
             assertThatThrownBy { snikeIKøenService.reaktiverBehandlingPåMaskinellVent(behandlingSomSnekIKøen) }
                 .hasMessageContaining("er ikke avsluttet")
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/behandling/settpåvent/SettPåVentServiceTest.kt
@@ -63,8 +63,10 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `Kan sette en behandling på vent hvis statusen er utredes`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val behandling = opprettBehandling()
 
+        // Act
         val settBehandlingPåVent =
             settPåVentService.settBehandlingPåVent(
                 behandling.id,
@@ -72,6 +74,7 @@ class SettPåVentServiceTest(
                 årsak,
             )
 
+        // Assert
         assertThat(settBehandlingPåVent.behandling.id).isEqualTo(behandling.id)
         assertThat(settBehandlingPåVent.frist).isEqualTo(frist)
         assertThat(settBehandlingPåVent.årsak).isEqualTo(årsak)
@@ -83,8 +86,10 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `gjenopprett behandling skal sette status til utredes på nytt`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val behandling = opprettBehandling()
 
+        // Act
         settPåVentService.settBehandlingPåVent(
             behandling.id,
             frist,
@@ -93,6 +98,7 @@ class SettPåVentServiceTest(
         val behandlingEtterSattPåVent = behandlingRepository.finnBehandling(behandling.id).status
         val gjenopptattSettPåVent = settPåVentService.gjenopptaBehandling(behandling.id)
 
+        // Assert
         assertThat(gjenopptattSettPåVent.aktiv).isFalse()
         assertThat(behandling.status).isEqualTo(BehandlingStatus.UTREDES)
         assertThat(behandlingEtterSattPåVent).isEqualTo(BehandlingStatus.SATT_PÅ_VENT)
@@ -118,6 +124,7 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `Kan ikke endre på behandling etter at den er satt på vent`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
 
@@ -142,6 +149,7 @@ class SettPåVentServiceTest(
             årsak = årsak,
         )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             stegService.håndterBehandlingsresultat(behandlingRepository.finnBehandling(behandlingId))
         }
@@ -150,6 +158,7 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `Kan endre på behandling etter venting er deaktivert`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
         val behandlingEtterVilkårsvurderingSteg =
@@ -174,12 +183,14 @@ class SettPåVentServiceTest(
 
         val nå = LocalDate.now()
 
+        // Act
         val settPåVent =
             settPåVentService.gjenopptaBehandling(
                 behandlingId = behandlingEtterVilkårsvurderingSteg.id,
                 nå = nå,
             )
 
+        // Assert
         Assertions.assertEquals(
             nå,
             settPåVentRepository.findByIdOrNull(settPåVent.id)!!.tidTattAvVent,
@@ -193,6 +204,7 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `Kan ikke sette ventefrist til før dagens dato`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
         val behandlingEtterVilkårsvurderingSteg =
@@ -209,6 +221,7 @@ class SettPåVentServiceTest(
                 brevmalService = brevmalService,
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             settPåVentService.settBehandlingPåVent(
                 behandlingId = behandlingEtterVilkårsvurderingSteg.id,
@@ -221,6 +234,7 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `Kan oppdatere sett på vent på behandling`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
 
@@ -253,15 +267,18 @@ class SettPåVentServiceTest(
 
         val nyFrist = LocalDate.now().plusDays(9)
 
+        // Act
         settPåVent.frist = nyFrist
         settPåVentRepository.save(settPåVent)
 
+        // Assert
         Assertions.assertEquals(nyFrist, settPåVentService.finnAktivSettPåVentPåBehandling(behandlingId)!!.frist)
     }
 
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `Skal gjennopta behandlinger etter ventefristen`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
 
@@ -309,6 +326,7 @@ class SettPåVentServiceTest(
             årsak = årsak,
         )
 
+        // Act
         taBehandlingerEtterVentefristAvVentTask.doTask(
             Task(
                 type = TaBehandlingerEtterVentefristAvVentTask.TASK_STEP_TYPE,
@@ -316,6 +334,7 @@ class SettPåVentServiceTest(
             ),
         )
 
+        // Assert
         Assertions.assertNull(settPåVentRepository.findByBehandlingIdAndAktiv(behandling1.id, true))
         Assertions.assertNotNull(settPåVentRepository.findByBehandlingIdAndAktiv(behandling2.id, true))
     }
@@ -323,6 +342,7 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class)
     fun `Skal ikke kunne gjenoppta behandlingen hvis den er satt på maskinell vent`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val behandling = opprettBehandling()
 
         settPåVentService.settBehandlingPåVent(
@@ -332,10 +352,13 @@ class SettPåVentServiceTest(
         )
         snikeIKøenService.settAktivBehandlingPåMaskinellVent(behandling.id, SettPåMaskinellVentÅrsak.SATSENDRING)
 
+        // Act
         val throwable =
             catchThrowable {
                 settPåVentService.gjenopptaBehandling(behandling.id)
             }
+
+        // Assert
         assertThat(throwable).isInstanceOf(FunksjonellFeil::class.java)
         assertThat((throwable as FunksjonellFeil).frontendFeilmelding)
             .isEqualTo("Behandlingen er under maskinell vent, og kan gjenopptas senere.")
@@ -343,8 +366,10 @@ class SettPåVentServiceTest(
 
     @Test
     fun `Skal kaste feil for årsak AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING med annen frist enn 5 dager`() {
+        // Arrange
         val behandling = opprettBehandling()
 
+        // Act & Assert
         val feil =
             assertThrows<Feil> {
                 settPåVentService.settBehandlingPåVent(
@@ -362,8 +387,10 @@ class SettPåVentServiceTest(
 
     @Test
     fun `Skal opprette Tilbakekrevingsvedtak motregning for behandlinger som settes på vent med årsak AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING`() {
+        // Arrange
         val behandling = opprettBehandling()
 
+        // Act
         val settPåVent =
             settPåVentService.settBehandlingPåVent(
                 behandlingId = behandling.id,
@@ -371,6 +398,7 @@ class SettPåVentServiceTest(
                 årsak = SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING,
             )
 
+        // Assert
         assertThat(settPåVent.årsak).isEqualTo(SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING)
         assertThat(settPåVent.frist).isEqualTo(frist)
 
@@ -383,14 +411,17 @@ class SettPåVentServiceTest(
     @ParameterizedTest
     @EnumSource(value = SettPåVentÅrsak::class, mode = EnumSource.Mode.EXCLUDE, names = ["AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING"])
     fun `Skal ikke opprette Tilbakekrevingsvedtak motregning for behandlinger som settes på vent med annen årsak enn AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING`(årsak: SettPåVentÅrsak) {
+        // Arrange
         val behandling = opprettBehandling()
 
+        // Act
         settPåVentService.settBehandlingPåVent(
             behandlingId = behandling.id,
             frist = frist,
             årsak = årsak,
         )
 
+        // Assert
         val tilbakekrevingsvedtakMotregning = tilbakekrevingsvedtakMotregningService.finnTilbakekrevingsvedtakMotregning(behandling.id)
 
         assertThat(tilbakekrevingsvedtakMotregning).isNull()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/beregning/BeregningServiceIntegrationTest.kt
@@ -83,6 +83,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `Skal lagre andelerTilkjentYtelse med kobling til TilkjentYtelse`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barn1Fnr = randomFnr()
         val barn2Fnr = randomFnr()
@@ -128,8 +129,10 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
             )
         vilkårsvurderingService.lagreNyOgDeaktiverGammel(vilkårsvurdering = vilkårsvurdering)
 
+        // Act
         beregningService.oppdaterBehandlingMedBeregning(behandling, personopplysningGrunnlag)
 
+        // Assert
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandling(behandling.id)
         val andelBarn1 = tilkjentYtelse.andelerTilkjentYtelse.filter { it.aktør.aktivFødselsnummer() == barn1Id }
         val andelBarn2 = tilkjentYtelse.andelerTilkjentYtelse.filter { it.aktør.aktivFødselsnummer() == barn2Id }
@@ -152,6 +155,7 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
     @Test
     @Transactional
     fun `genererTilkjentYtelseFraVilkårsvurdering - skal trigge differanseberegning`() {
+        // Arrange
         val søker = personidentService.hentOgLagreAktør(randomFnr(), true)
         val barn = personidentService.hentOgLagreAktør(randomFnr(), true)
 
@@ -236,8 +240,10 @@ class BeregningServiceIntegrationTest : AbstractSpringIntegrationTest() {
         utenlandskPeriodebeløpRepository.save(utenlandskPeriodebeløp)
         valutakursRepository.save(valutakurs)
 
+        // Act
         val tilkjentYtelse = beregningService.genererTilkjentYtelseFraVilkårsvurdering(behandling = behandling, personopplysningGrunnlag = personopplysningGrunnlag)
 
+        // Assert
         assertThat(tilkjentYtelse.andelerTilkjentYtelse.any { it.differanseberegnetPeriodebeløp != null }).isEqualTo(true)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentControllerTest.kt
@@ -41,26 +41,35 @@ class DokumentControllerTest(
     @Test
     @Tag("integration")
     fun `Test generer vedtaksbrev`() {
+        // Arrange
         every { vedtakService.hent(any()) } returns lagVedtak()
         every { mockDokumentGenereringService.genererBrevForVedtak(any()) } returns "pdf".toByteArray()
 
+        // Act
         val response = mockDokumentController.genererVedtaksbrev(1)
+
+        // Assert
         assert(response.status == Ressurs.Status.SUKSESS)
     }
 
     @Test
     @Tag("integration")
     fun `Test hent pdf vedtak`() {
+        // Arrange
         every { vedtakService.hent(any()) } returns lagVedtak(stønadBrevPdF = "pdf".toByteArray())
         every { mockDokumentService.hentBrevForVedtak(any()) } returns Ressurs.success("pdf".toByteArray())
 
+        // Act
         val response = mockDokumentController.hentVedtaksbrev(1)
+
+        // Assert
         assert(response.status == Ressurs.Status.SUKSESS)
     }
 
     @Test
     @Tag("integration")
     fun `Kast feil ved hent av vedtaksbrev når det ikke er generert brev`() {
+        // Act & Assert
         assertThrows<Feil> {
             dokumentService.hentBrevForVedtak(lagVedtak())
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/DokumentServiceIntegrationTest.kt
@@ -102,6 +102,7 @@ class DokumentServiceIntegrationTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Hent vedtaksbrev`() {
+        // Arrange
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
 
         val behandlingEtterVilkårsvurderingSteg =
@@ -133,13 +134,17 @@ class DokumentServiceIntegrationTest(
 
         vedtakService.oppdaterVedtakMedStønadsbrev(vedtak!!)
 
+        // Act
         val pdfvedtaksbrevRess = dokumentService.hentBrevForVedtak(vedtak)
+
+        // Assert
         assertEquals(Ressurs.Status.SUKSESS, pdfvedtaksbrevRess.status)
         assert(pdfvedtaksbrevRess.data!!.contentEquals(TEST_PDF))
     }
 
     @Test
     fun `Skal generere vedtaksbrev`() {
+        // Arrange
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
 
         val behandlingEtterVilkårsvurderingSteg =
@@ -171,12 +176,16 @@ class DokumentServiceIntegrationTest(
         val vedtak = vedtakService.hentAktivForBehandling(behandlingId = behandlingEtterVilkårsvurderingSteg.id)
         vedtakService.oppdaterVedtakMedStønadsbrev(vedtak!!)
 
+        // Act
         val pdfvedtaksbrev = dokumentGenereringService.genererBrevForVedtak(vedtak)
+
+        // Assert
         assert(pdfvedtaksbrev.contentEquals(TEST_PDF))
     }
 
     @Test
     fun `Skal verifisere at brev får riktig signatur ved alle steg i behandling`() {
+        // Arrange
         val mockSaksbehandler = "Mock Saksbehandler"
         val mockSaksbehandlerId = "mock.saksbehandler@nav.no"
         val mockBeslutter = "Mock Beslutter"
@@ -200,8 +209,10 @@ class DokumentServiceIntegrationTest(
             )
         val vedtak = vedtakService.hentAktivForBehandling(behandlingId = behandlingEtterVilkårsvurderingSteg.id)!!
 
+        // Act
         val vedtaksbrevFellesFelter = brevService.lagVedtaksbrevFellesfelter(vedtak)
 
+        // Assert
         assertEquals("Nav familie- og pensjonsytelser Oslo 1", vedtaksbrevFellesFelter.enhet)
         assertEquals("System", vedtaksbrevFellesFelter.saksbehandler)
         assertEquals("Beslutter", vedtaksbrevFellesFelter.beslutter)
@@ -218,9 +229,11 @@ class DokumentServiceIntegrationTest(
         val vedtakEtterSendTilBeslutter =
             vedtakService.hentAktivForBehandling(behandlingId = behandlingEtterSendTilBeslutter.id)!!
 
+        // Act
         val vedtaksbrevFellesFelterEtterSendTilBeslutter =
             brevService.lagVedtaksbrevFellesfelter(vedtakEtterSendTilBeslutter)
 
+        // Assert
         assertEquals(mockSaksbehandler, vedtaksbrevFellesFelterEtterSendTilBeslutter.saksbehandler)
         assertEquals("System", vedtaksbrevFellesFelterEtterSendTilBeslutter.beslutter)
 
@@ -236,15 +249,18 @@ class DokumentServiceIntegrationTest(
         val vedtakEtterVedtakBesluttet =
             vedtakService.hentAktivForBehandling(behandlingId = behandlingEtterVedtakBesluttet.id)!!
 
+        // Act
         val vedtaksbrevFellesFelterEtterVedtakBesluttet =
             brevService.lagVedtaksbrevFellesfelter(vedtakEtterVedtakBesluttet)
 
+        // Assert
         assertEquals(mockSaksbehandler, vedtaksbrevFellesFelterEtterVedtakBesluttet.saksbehandler)
         assertEquals(mockBeslutter, vedtaksbrevFellesFelterEtterVedtakBesluttet.beslutter)
     }
 
     @Test
     fun `Skal ekskludere navn på enhet i signatur i brev for automatisk behandling`() {
+        // Arrange
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
 
@@ -277,8 +293,10 @@ class DokumentServiceIntegrationTest(
             simuleringResultat = DetaljertSimuleringResultat(simuleringMottaker = emptyList()),
         )
 
+        // Act
         autovedtakFinnmarkstilleggService.kjørBehandling(FinnmarkstilleggData(forrigeBehandling.fagsak.id))
 
+        // Assert
         val automatiskBehandlingMedVedtaksbrev = behandlingHentOgPersisterService.hentBehandlinger(forrigeBehandling.fagsak.id).first { it.aktiv }
 
         assertEquals(automatiskBehandlingMedVedtaksbrev.opprettetÅrsak, BehandlingÅrsak.FINNMARKSTILLEGG)
@@ -294,6 +312,7 @@ class DokumentServiceIntegrationTest(
 
     @Test
     fun `Skal verifisere at man ikke får generert brev etter at behandlingen er sendt fra beslutter`() {
+        // Arrange
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
 
         val behandlingEtterVedtakBesluttet =
@@ -311,6 +330,8 @@ class DokumentServiceIntegrationTest(
             )
 
         val vedtak = vedtakService.hentAktivForBehandling(behandlingId = behandlingEtterVedtakBesluttet.id)!!
+
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 dokumentGenereringService.genererBrevForVedtak(vedtak)
@@ -323,6 +344,7 @@ class DokumentServiceIntegrationTest(
 
     @Test
     fun `Test sending varsel om revurdering til institusjon`() {
+        // Arrange
         val fnr = "09121079074"
         val orgNummer = "998765432"
 
@@ -349,6 +371,7 @@ class DokumentServiceIntegrationTest(
             ),
         )
 
+        // Act
         val manueltBrevRequest =
             dokumentService
                 .byggMottakerdataFraBehandling(
@@ -357,6 +380,7 @@ class DokumentServiceIntegrationTest(
                 )
         dokumentService.sendManueltBrev(manueltBrevRequest, behandling, behandling.fagsak.id)
 
+        // Assert
         val lagretJournalførManueltBrevTaskPayloadForBehandling = fakeTaskRepositoryWrapper.hentLagredeTaskerAvType(JournalførManueltBrevTask.TASK_STEP_TYPE).tilPayload<JournalførManueltBrevDTO>().single { it.behandlingId == behandling.id }
 
         assertThat(lagretJournalførManueltBrevTaskPayloadForBehandling).isNotNull
@@ -370,6 +394,7 @@ class DokumentServiceIntegrationTest(
 
     @Test
     fun `Test sending innhent dokumentasjon til institusjon`() {
+        // Arrange
         val fnr = randomFnr()
         val orgNummer = "998765432"
 
@@ -396,6 +421,7 @@ class DokumentServiceIntegrationTest(
             ),
         )
 
+        // Act
         val manueltBrevRequest =
             dokumentService.byggMottakerdataFraBehandling(
                 behandling,
@@ -403,6 +429,7 @@ class DokumentServiceIntegrationTest(
             )
         dokumentService.sendManueltBrev(manueltBrevRequest, behandling, behandling.fagsak.id)
 
+        // Assert
         val lagretJournalførManueltBrevTaskPayloadForBehandling = fakeTaskRepositoryWrapper.hentLagredeTaskerAvType(JournalførManueltBrevTask.TASK_STEP_TYPE).tilPayload<JournalførManueltBrevDTO>().single { it.behandlingId == behandling.id }
         assertThat(lagretJournalførManueltBrevTaskPayloadForBehandling).isNotNull
         val avsenderMottaker = lagretJournalførManueltBrevTaskPayloadForBehandling.mottaker.avsenderMottaker
@@ -415,6 +442,7 @@ class DokumentServiceIntegrationTest(
 
     @Test
     fun `Test sending svartidsbrev til institusjon`() {
+        // Arrange
         val fnr = "10121079074"
         val orgNummer = "998765432"
 
@@ -441,6 +469,7 @@ class DokumentServiceIntegrationTest(
             ),
         )
 
+        // Act
         val manueltBrevRequest =
             dokumentService.byggMottakerdataFraBehandling(
                 behandling,
@@ -448,6 +477,7 @@ class DokumentServiceIntegrationTest(
             )
         dokumentService.sendManueltBrev(manueltBrevRequest, behandling, behandling.fagsak.id)
 
+        // Assert
         val lagretJournalførManueltBrevTaskPayloadForBehandling = fakeTaskRepositoryWrapper.hentLagredeTaskerAvType(JournalførManueltBrevTask.TASK_STEP_TYPE).tilPayload<JournalførManueltBrevDTO>().single { it.behandlingId == behandling.id }
         assertThat(lagretJournalførManueltBrevTaskPayloadForBehandling).isNotNull
         val avsenderMottaker = lagretJournalførManueltBrevTaskPayloadForBehandling.mottaker.avsenderMottaker
@@ -460,6 +490,7 @@ class DokumentServiceIntegrationTest(
 
     @Test
     fun `Test sending forlenget svartidsbrev til institusjon`() {
+        // Arrange
         val fnr = randomFnr()
         val orgNummer = "998765432"
 
@@ -486,6 +517,7 @@ class DokumentServiceIntegrationTest(
             ),
         )
 
+        // Act
         val manueltBrevRequest =
             dokumentService.byggMottakerdataFraBehandling(
                 behandling,
@@ -496,6 +528,7 @@ class DokumentServiceIntegrationTest(
             )
         dokumentService.sendManueltBrev(manueltBrevRequest, behandling, behandling.fagsak.id)
 
+        // Assert
         val lagretJournalførManueltBrevTaskPayloadForBehandling = fakeTaskRepositoryWrapper.hentLagredeTaskerAvType(JournalførManueltBrevTask.TASK_STEP_TYPE).tilPayload<JournalførManueltBrevDTO>().single { it.behandlingId == behandling.id }
         assertThat(lagretJournalførManueltBrevTaskPayloadForBehandling).isNotNull
         val avsenderMottaker = lagretJournalførManueltBrevTaskPayloadForBehandling.mottaker.avsenderMottaker

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/brev/mottaker/BrevmottakerControllerTest.kt
@@ -30,6 +30,7 @@ internal class BrevmottakerControllerTest(
     @Test
     @Tag("integration")
     fun kanLagreOgSlette() {
+        // Arrange
         val fagsak =
             lagFagsakUtenId(aktør = randomAktør().also { aktørIdRepository.save(it) }).let { fagsakRepository.save(it) }
         val behandling = lagBehandlingUtenId(fagsak = fagsak).let { behandlingRepository.save(it) }
@@ -45,9 +46,13 @@ internal class BrevmottakerControllerTest(
                 "poststed",
                 "NO",
             )
+
+        // Act
         brevmottakerController.leggTilBrevmottaker(behandling.id, brevmottaker)
 
         brevmottakerController.leggTilBrevmottaker(behandling.id, brevmottaker.copy(type = MottakerType.VERGE))
+
+        // Assert
         brevmottakerController.hentBrevmottakere(behandling.id).body?.data!!.apply {
             Assertions.assertThat(this).hasSize(2)
             forEach { lagretBrevmottaker ->

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/VilkårsvurderingTilValutakursIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/VilkårsvurderingTilValutakursIntegrasjonTest.kt
@@ -18,6 +18,7 @@ class VilkårsvurderingTilValutakursIntegrasjonTest : AbstractSpringIntegrationT
 
     @Test
     fun `vilkårsvurdering med EØS-perioder + kompetanser med sekundærland fører til skjemaer med valutakurser`() {
+        // Arrange
         val søkerStartdato = 1.jan(2020)
         val barnStartdato = 2.jan(2020)
 
@@ -43,20 +44,24 @@ class VilkårsvurderingTilValutakursIntegrasjonTest : AbstractSpringIntegrationT
                 barnStartdato to "PPPSSSSSSPPSSS--",
             )
 
+        // Act
         val utvidetBehandlingFør =
             vilkårsvurderingTestController
                 .opprettBehandlingMedVilkårsvurdering(vilkårsvurderingRequest)
                 .body
                 ?.data!!
 
+        // Assert
         assertTrue(utvidetBehandlingFør.valutakurser.isEmpty())
 
+        // Act
         val utvidetBehandlingEtter =
             kompetanseTestController
                 .endreKompetanser(utvidetBehandlingFør.behandlingId, kompetanseRequest)
                 .body
                 ?.data!!
 
+        // Assert
         assertTrue(utvidetBehandlingEtter.valutakurser.isNotEmpty())
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/differanseberegning/DifferanseberegningIntegrasjonTest.kt
@@ -35,6 +35,7 @@ class DifferanseberegningIntegrasjonTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `vilkårsvurdering med EØS-perioder + kompetanser med sekundærland fører til skjemaer med valutakurser`() {
+        // Arrange
         val søkerStartdato = 1.jan(2020)
         val barnStartdato = 2.jan(2020)
 
@@ -75,6 +76,7 @@ class DifferanseberegningIntegrasjonTest : AbstractSpringIntegrationTest() {
                 barnStartdato to "5555566644234489",
             )
 
+        // Act
         val utvidetBehandlingFørsteGang =
             vilkårsvurderingTestController
                 .opprettBehandlingMedVilkårsvurdering(vilkårsvurderingRequest)
@@ -107,9 +109,11 @@ class DifferanseberegningIntegrasjonTest : AbstractSpringIntegrationTest() {
         val sumUtbetalingDifferanseberegnet =
             utvidetbehandlingDifferanseberegnet.utbetalingsperioder.sumUtbetaling()
 
+        // Assert
         Assertions.assertEquals(3, utvidetbehandlingDifferanseberegnet.endretUtbetalingAndeler.size)
         Assertions.assertEquals(10, utvidetbehandlingDifferanseberegnet.utbetalingsperioder.size)
 
+        // Arrange
         val vilkårsvurderingRequest2 =
             mapOf(
                 søkerStartdato to
@@ -127,6 +131,7 @@ class DifferanseberegningIntegrasjonTest : AbstractSpringIntegrationTest() {
                     ),
             )
 
+        // Act
         val utvidetBehandlingTilbakestilt =
             vilkårsvurderingTestController
                 .oppdaterVilkårsvurderingIBehandling(
@@ -138,6 +143,7 @@ class DifferanseberegningIntegrasjonTest : AbstractSpringIntegrationTest() {
         val sumUtbetalingTilbakestilt =
             utvidetBehandlingTilbakestilt.utbetalingsperioder.sumUtbetaling()
 
+        // Assert
         Assertions.assertEquals(3, utvidetBehandlingTilbakestilt.endretUtbetalingAndeler.size)
         Assertions.assertEquals(4, utvidetBehandlingTilbakestilt.utbetalingsperioder.size)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseRepositoryTest.kt
@@ -22,6 +22,7 @@ class KompetanseRepositoryTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal lagre flere kompetanser med gjenbruk av flere aktører`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
         val barn2 = aktørIdRepository.save(randomAktør())
@@ -29,6 +30,7 @@ class KompetanseRepositoryTest(
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak))
 
+        // Act
         val kompetanse =
             kompetanseRepository.save(
                 lagKompetanse(
@@ -43,11 +45,13 @@ class KompetanseRepositoryTest(
                 ).also { it.behandlingId = behandling.id },
             )
 
+        // Assert
         assertEquals(kompetanse.barnAktører, kompetanse2.barnAktører)
     }
 
     @Test
     fun `Skal lagre skjema-feltene`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
 
@@ -68,8 +72,10 @@ class KompetanseRepositoryTest(
                 ),
             )
 
+        // Act
         val hentedeKompetanser = kompetanseRepository.finnFraBehandlingId(behandlingId = behandling.id)
 
+        // Assert
         assertEquals(1, hentedeKompetanser.size)
         assertEquals(kompetanse, hentedeKompetanser.first())
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseUtfyltTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/kompetanse/KompetanseUtfyltTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 class KompetanseUtfyltTest {
     @Test
     fun `Skal sette UtfyltStatus til OK når alle felter i skjema er fylt ut`() {
+        // Arrange
         val kompetanse =
             lagKompetanse(
                 annenForeldersAktivitet = KompetanseAktivitet.I_ARBEID,
@@ -22,13 +23,16 @@ class KompetanseUtfyltTest {
                 søkersAktivitetsland = "NO",
             )
 
+        // Act
         val kompetanseDto = kompetanse.tilKompetanseDto()
 
+        // Assert
         assertEquals(UtfyltStatus.OK, kompetanseDto.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til OK dersom alle felter unntatt annenForeldersAktivitetsland er fylt ut og annenForeldersAktivitet er IKKE_AKTUELT eller INAKTIV`() {
+        // Arrange
         var kompetanse =
             lagKompetanse(
                 annenForeldersAktivitet = KompetanseAktivitet.IKKE_AKTUELT,
@@ -38,8 +42,10 @@ class KompetanseUtfyltTest {
                 søkersAktivitetsland = "NO",
             )
 
+        // Act
         var kompetanseDto = kompetanse.tilKompetanseDto()
 
+        // Assert
         assertEquals(UtfyltStatus.OK, kompetanseDto.status)
 
         kompetanse =
@@ -58,6 +64,7 @@ class KompetanseUtfyltTest {
 
     @Test
     fun `Skal sette UtfyltStatus til UFULLSTENDIG dersom alle felter unntatt annenForeldersAktivitetsland er fylt ut og annenForeldersAktivitet ikke er IKKE_AKTUELT eller INAKTIV`() {
+        // Arrange
         var kompetanse =
             lagKompetanse(
                 annenForeldersAktivitet = KompetanseAktivitet.I_ARBEID,
@@ -66,8 +73,10 @@ class KompetanseUtfyltTest {
                 søkersAktivitet = KompetanseAktivitet.ARBEIDER,
             )
 
+        // Act
         var kompetanseDto = kompetanse.tilKompetanseDto()
 
+        // Assert
         assertEquals(UtfyltStatus.UFULLSTENDIG, kompetanseDto.status)
 
         kompetanse =
@@ -109,13 +118,16 @@ class KompetanseUtfyltTest {
 
     @Test
     fun `Skal sette UtfyltStatus til UFULLSTENDIG dersom 1 til 4 felter er satt med unntak av regel om annenForeldersAktivitet`() {
+        // Arrange
         var kompetanse =
             lagKompetanse(
                 annenForeldersAktivitet = KompetanseAktivitet.IKKE_AKTUELT,
             )
 
+        // Act
         var kompetanseDto = kompetanse.tilKompetanseDto()
 
+        // Assert
         assertEquals(UtfyltStatus.UFULLSTENDIG, kompetanseDto.status)
 
         kompetanse =
@@ -154,15 +166,19 @@ class KompetanseUtfyltTest {
 
     @Test
     fun `Skal sette UtfyltStatus til IKKE_UTFYLT dersom ingen av feltene er utfylt`() {
+        // Arrange
         val kompetanse = lagKompetanse()
 
+        // Act
         val kompetanseDto = kompetanse.tilKompetanseDto()
 
+        // Assert
         assertEquals(UtfyltStatus.IKKE_UTFYLT, kompetanseDto.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til UFULLSTENDIG dersom alle felter unntatt søkersAktivitetsland er fylt ut`() {
+        // Arrange
         val kompetanse =
             lagKompetanse(
                 annenForeldersAktivitet = KompetanseAktivitet.I_ARBEID,
@@ -172,8 +188,10 @@ class KompetanseUtfyltTest {
                 søkersAktivitet = KompetanseAktivitet.ARBEIDER,
             )
 
+        // Act
         val kompetanseDto = kompetanse.tilKompetanseDto()
 
+        // Assert
         assertEquals(UtfyltStatus.UFULLSTENDIG, kompetanseDto.status)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
@@ -39,6 +39,7 @@ class UtenlandskPeriodebeløpControllerTest {
 
     @Test
     fun `Skal kaste feil dersom validering av input feiler`() {
+        // Act & Assert
         val exception =
             assertThrows<ConstraintViolationException> {
                 utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(
@@ -47,6 +48,7 @@ class UtenlandskPeriodebeløpControllerTest {
                 )
             }
 
+        // Assert
         val forventedeFelterMedFeil = listOf("beløp")
         val faktiskeFelterMedFeil =
             exception.constraintViolations.map { constraintViolation ->
@@ -63,15 +65,18 @@ class UtenlandskPeriodebeløpControllerTest {
 
     @Test
     fun `Skal ikke kaste feil dersom validering av input går bra`() {
+        // Arrange
         every { utenlandskPeriodebeløpRepository.getReferenceById(any()) } returns UtenlandskPeriodebeløp.NULL
         every { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) } just runs
 
+        // Act
         val response =
             utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(
                 1,
                 UtenlandskPeriodebeløpDto(1, null, null, emptyList(), beløp = 1.0.toBigDecimal(), null, null, null, null),
             )
 
+        // Assert
         assertEquals(HttpStatus.OK, response.statusCode)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
@@ -23,6 +23,7 @@ class UtenlandskPeriodebeløpRepositoryTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal lagre flere utenlandske periodebeløp med gjenbruk av flere aktører`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
         val barn2 = aktørIdRepository.save(randomAktør())
@@ -30,6 +31,7 @@ class UtenlandskPeriodebeløpRepositoryTest(
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak))
 
+        // Act
         val utenlandskPeriodebeløp =
             utenlandskPeriodebeløpRepository.save(
                 lagUtenlandskPeriodebeløp(
@@ -44,11 +46,13 @@ class UtenlandskPeriodebeløpRepositoryTest(
                 ).also { it.behandlingId = behandling.id },
             )
 
+        // Assert
         assertEquals(utenlandskPeriodebeløp.barnAktører, utenlandskPeriodebeløp2.barnAktører)
     }
 
     @Test
     fun `Skal lagre skjema-feltene`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
 
@@ -68,9 +72,11 @@ class UtenlandskPeriodebeløpRepositoryTest(
                 ),
             )
 
+        // Act
         val hentedeUtenlandskePeriodebeløp =
             utenlandskPeriodebeløpRepository.finnFraBehandlingId(behandlingId = behandling.id)
 
+        // Assert
         assertEquals(1, hentedeUtenlandskePeriodebeløp.size)
         assertEquals(utenlandskPeriodebeløp, hentedeUtenlandskePeriodebeløp.first())
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
@@ -11,6 +11,7 @@ import java.math.BigDecimal
 class UtenlandskePeriodebeløpUtfyltTest {
     @Test
     fun `Skal sette UtfyltStatus til OK når alle felter er utfylt`() {
+        // Arrange
         val utenlandskPeriodebeløp =
             lagUtenlandskPeriodebeløp(
                 beløp = BigDecimal.valueOf(500),
@@ -18,39 +19,50 @@ class UtenlandskePeriodebeløpUtfyltTest {
                 intervall = Intervall.MÅNEDLIG,
             )
 
+        // Act
         val utenlandskPeriodebeløpDto = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.OK, utenlandskPeriodebeløpDto.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til UFULLSTENDIG når ett eller to felter er utfylt`() {
+        // Arrange
         var utenlandskPeriodebeløp =
             lagUtenlandskPeriodebeløp(
                 beløp = BigDecimal.valueOf(500),
             )
 
+        // Act
         var utenlandskPeriodebeløpDto = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.UFULLSTENDIG, utenlandskPeriodebeløpDto.status)
 
+        // Arrange
         utenlandskPeriodebeløp =
             lagUtenlandskPeriodebeløp(
                 beløp = BigDecimal.valueOf(500),
                 valutakode = "NOK",
             )
 
+        // Act
         utenlandskPeriodebeløpDto = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.UFULLSTENDIG, utenlandskPeriodebeløpDto.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til IKKE_UTFYLT når ingen felter er utfylt`() {
+        // Arrange
         val utenlandskPeriodebeløp = lagUtenlandskPeriodebeløp()
 
+        // Act
         val utenlandskPeriodebeløpDto = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.IKKE_UTFYLT, utenlandskPeriodebeløpDto.status)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursRepositoryTest.kt
@@ -23,6 +23,7 @@ class ValutakursRepositoryTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal lagre flere valutakurser med gjenbruk av flere aktører`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
         val barn2 = aktørIdRepository.save(randomAktør())
@@ -30,6 +31,7 @@ class ValutakursRepositoryTest(
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak))
 
+        // Act
         val valutakurs =
             valutakursRepository.save(
                 lagValutakurs(
@@ -44,11 +46,13 @@ class ValutakursRepositoryTest(
                 ).also { it.behandlingId = behandling.id },
             )
 
+        // Assert
         assertEquals(valutakurs.barnAktører, valutakurs2.barnAktører)
     }
 
     @Test
     fun `Skal lagre skjema-feltene`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
 
@@ -68,9 +72,11 @@ class ValutakursRepositoryTest(
                 ),
             )
 
+        // Act
         val hentedeValutakurser =
             valutakursRepository.finnFraBehandlingId(behandlingId = behandling.id)
 
+        // Assert
         assertEquals(1, hentedeValutakurser.size)
         assertEquals(valutakurs, hentedeValutakurser.first())
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursUtfyltTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/eøs/valutakurs/ValutakursUtfyltTest.kt
@@ -11,44 +11,56 @@ import java.time.LocalDate
 class ValutakursUtfyltTest {
     @Test
     fun `Skal sette UtfyltStatus til OK når alle felter er utfylt`() {
+        // Arrange
         val valutakurs =
             lagValutakurs(
                 valutakursdato = LocalDate.now(),
                 kurs = BigDecimal.valueOf(10),
             )
 
+        // Act
         val valutakursDto = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.OK, valutakursDto.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til UFULLSTENDIG når ett felt er utfylt`() {
+        // Arrange
         var valutakurs =
             lagValutakurs(
                 valutakursdato = LocalDate.now(),
             )
 
+        // Act
         var valutaKursDto = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.UFULLSTENDIG, valutaKursDto.status)
 
+        // Arrange
         valutakurs =
             lagValutakurs(
                 kurs = BigDecimal.valueOf(10),
             )
 
+        // Act
         valutaKursDto = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.UFULLSTENDIG, valutaKursDto.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til IKKE_UTFYLT når ingen felter er utfylt`() {
+        // Arrange
         val valutakurs = lagValutakurs()
 
+        // Act
         val valutaKursDto = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.IKKE_UTFYLT, valutaKursDto.status)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakControllerTest.kt
@@ -64,9 +64,13 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal opprette fagsak av type NORMAL`() {
+        // Arrange
         val fnr = randomFnr()
 
+        // Act
         fagsakController.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr))
+
+        // Assert
         val fagsak = fagsakService.hentNormalFagsak(lagAktør(fnr))
         assertEquals(fnr, fagsak?.aktør?.aktivFødselsnummer())
         assertEquals(FagsakType.NORMAL, fagsak?.type)
@@ -77,12 +81,15 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal opprette fagsak av type SKJERMET_BARN`() {
+        // Arrange
         val fnr = randomFnr()
         val søkersIdent = randomFnr()
         val skjermetBarnSøker = SkjermetBarnSøkerDto(søkersIdent = søkersIdent)
 
+        // Act
         fagsakController.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr, fagsakType = FagsakType.SKJERMET_BARN, skjermetBarnSøker = skjermetBarnSøker))
 
+        // Assert
         val fagsak = fagsakService.hentFagsakPåPerson(lagAktør(fnr), FagsakType.SKJERMET_BARN)
 
         assertThat(fnr).isEqualTo(fagsak?.aktør?.aktivFødselsnummer())
@@ -94,10 +101,13 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal opprette skyggesak i Sak`() {
+        // Arrange
         val fnr = randomFnr()
 
+        // Act
         val fagsak = fagsakController.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr)).body?.data
 
+        // Assert
         val skyggesak = skyggesakRepository.finnSkyggesakerKlareForSending(Pageable.unpaged())
         assertEquals(1, skyggesak.filter { it.fagsakId == fagsak?.id }.size)
     }
@@ -105,9 +115,13 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal returnere eksisterende fagsak på person som allerede finnes`() {
+        // Arrange
         val fnr = randomFnr()
 
+        // Act
         val nyMinimalFagsakDto = fagsakController.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr))
+
+        // Assert
         assertEquals(Ressurs.Status.SUKSESS, nyMinimalFagsakDto.body?.status)
         assertEquals(fnr, fagsakService.hentNormalFagsak(lagAktør(fnr))?.aktør?.aktivFødselsnummer())
 
@@ -124,6 +138,7 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal returnere eksisterende fagsak på person som allerede finnes med gammel ident`() {
+        // Arrange
         val fnr = randomFnr()
         val nyttFnr = randomFnr()
         val aktørId = randomAktør().aktørId
@@ -132,7 +147,10 @@ class FagsakControllerTest(
         val aktør = aktørIdRepository.save(Aktør(aktørId))
         personidentRepository.save(Personident(fødselsnummer = fnr, aktør = aktør, aktiv = true))
 
+        // Act
         val nyFagsakDto = fagsakController.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr))
+
+        // Assert
         assertEquals(Ressurs.Status.SUKSESS, nyFagsakDto.body?.status)
         assertEquals(fnr, fagsakService.hentNormalFagsak(aktør)?.aktør?.aktivFødselsnummer())
 
@@ -155,12 +173,17 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal returnere eksisterende fagsak på person som allerede finnes basert på aktørid`() {
+        // Arrange
         val aktørId = randomAktør()
         val fagsakRequest = FagsakRequest(personIdent = aktørId.aktivFødselsnummer())
+
+        // Act
         val fagsakDto =
             fagsakController.hentEllerOpprettFagsak(
                 fagsakRequest,
             )
+
+        // Assert
         assertEquals(Ressurs.Status.SUKSESS, fagsakDto.body?.status)
 
         val eksisterendeFagsakDto = fagsakController.hentEllerOpprettFagsak(fagsakRequest)
@@ -171,8 +194,10 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal få valideringsfeil ved oppretting av fagsak av type INSTITUSJON uten FagsakInstitusjon satt`() {
+        // Arrange
         val fnr = randomFnr()
 
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 fagsakController.hentEllerOpprettFagsak(
@@ -190,9 +215,11 @@ class FagsakControllerTest(
     @Test
     @Tag("integration")
     fun `Skal opprette fagsak av type INSTITUSJON hvor FagsakInstitusjon er satt`() {
+        // Arrange
         val fnr = randomFnr()
         val orgNrNav = "889640782"
 
+        // Act
         fagsakController.hentEllerOpprettFagsak(
             FagsakRequest(
                 personIdent = fnr,
@@ -200,6 +227,8 @@ class FagsakControllerTest(
                 institusjon = InstitusjonDto(orgNrNav, "tss-id"),
             ),
         )
+
+        // Assert
         val fagsakerRessurs = fagsakService.hentMinimalFagsakerForPerson(lagAktør(fnr))
         assert(fagsakerRessurs.status == Ressurs.Status.SUKSESS)
         val fagsaker = fagsakerRessurs.data!!

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerControllerTest.kt
@@ -45,12 +45,14 @@ class FagsakDeltagerControllerTest(
 
     @Test
     fun `Skal oppgi person med fagsak som fagsakdeltaker`() {
+        // Arrange
         val personAktør = mockPersonidentService.hentAktør(randomFnr())
 
         fagsakService
             .hentEllerOpprettFagsak(personAktør.aktivFødselsnummer())
             .also { fagsakService.oppdaterStatus(it, FagsakStatus.LØPENDE) }
 
+        // Act & Assert
         fagsakDeltagerController.oppgiFagsakdeltagere(SøkParamDto(personAktør.aktivFødselsnummer(), emptyList())).apply {
             assertEquals(personAktør.aktivFødselsnummer(), body!!.data!!.first().ident)
             assertEquals(FagsakDeltagerRolle.FORELDER, body!!.data!!.first().rolle)
@@ -59,6 +61,7 @@ class FagsakDeltagerControllerTest(
 
     @Test
     fun `Skal oppgi det første barnet i listen som fagsakdeltaker`() {
+        // Arrange
         val personAktør = mockPersonidentService.hentOgLagreAktør(randomFnr(), true)
         val søkerFnr = randomFnr()
         val barnaFnr = listOf(randomBarnFnr())
@@ -83,6 +86,7 @@ class FagsakDeltagerControllerTest(
             Målform.NB,
         )
 
+        // Act & Assert
         fagsakDeltagerController
             .oppgiFagsakdeltagere(
                 SøkParamDto(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerServiceIntegrationTest.kt
@@ -68,6 +68,7 @@ class FagsakDeltagerServiceIntegrationTest(
      */
     @Test
     fun `test å søke fagsak med fnr`() {
+        // Arrange
         val søker1Fødselsdato = LocalDate.of(1990, 2, 19)
         val søker1Fnr =
             leggTilPersonInfo(
@@ -194,6 +195,7 @@ class FagsakDeltagerServiceIntegrationTest(
             RegistrerPersongrunnlagDTO(ident = søker2Fnr, barnasIdenter = listOf(barn1Fnr)),
         )
 
+        // Act & Assert
         val søkeresultat1 = fagsakDeltagerService.hentFagsakDeltagere(søker1Fnr)
         assertEquals(1, søkeresultat1.size)
         assertEquals(Kjønn.KVINNE, søkeresultat1[0].kjønn)
@@ -239,6 +241,7 @@ class FagsakDeltagerServiceIntegrationTest(
 
     @Test
     fun `Skal teste at arkiverte fagsaker med behandling ikke blir funnet ved søk`() {
+        // Arrange
         val søker1Fnr =
             leggTilPersonInfo(
                 randomSøkerFødselsdato(),
@@ -267,14 +270,17 @@ class FagsakDeltagerServiceIntegrationTest(
             fagsakService.hentFagsakPåPerson(søker1Aktør).also { it?.arkivert = true }!!,
         )
 
+        // Act
         val søkeresultat1 = fagsakDeltagerService.hentFagsakDeltagere(søker1Fnr)
 
+        // Assert
         assertEquals(1, søkeresultat1.size)
         assertNull(søkeresultat1.first().fagsakId)
     }
 
     @Test
     fun `Skal teste at arkiverte fagsaker uten behandling ikke blir funnet ved søk`() {
+        // Arrange
         val søker1Fnr =
             leggTilPersonInfo(
                 randomSøkerFødselsdato(),
@@ -292,14 +298,17 @@ class FagsakDeltagerServiceIntegrationTest(
             fagsakService.hentFagsakPåPerson(søker1Aktør).also { it?.arkivert = true }!!,
         )
 
+        // Act
         val søkeresultat1 = fagsakDeltagerService.hentFagsakDeltagere(søker1Fnr)
 
+        // Assert
         assertEquals(1, søkeresultat1.size)
         assertNull(søkeresultat1.first().fagsakId)
     }
 
     @Test
     fun `Skal returnere tom liste ved søk hvis ident ikke har aktiv fødselsnummer`() {
+        // Arrange
         val fnr = randomFnr()
         fakePdlIdentRestKlient.leggTilIdent(
             fnr,
@@ -308,14 +317,19 @@ class FagsakDeltagerServiceIntegrationTest(
                 IdentInformasjon("122334343", gruppe = "AKTOERID", historisk = false),
             ),
         )
+
+        // Act & Assert
         assertThat(fagsakDeltagerService.hentFagsakDeltagere(fnr)).hasSize(0)
     }
 
     @Test
     fun `Søk på fnr som ikke finnes i PDL skal vi tom liste`() {
+        // Arrange
         val aktør = lagAktør()
 
         leggTilPersonIkkeFunnet(aktør.aktivFødselsnummer())
+
+        // Act & Assert
         assertEquals(emptyList<FagsakDeltagerDto>(), fagsakDeltagerService.hentFagsakDeltagere(aktør.aktivFødselsnummer()))
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDtoTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDtoTest.kt
@@ -35,6 +35,7 @@ class FagsakDtoTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal sjekke at gjeldende utbetalingsperioder kommer med i fagsak dto`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato(10))
 
@@ -63,8 +64,10 @@ class FagsakDtoTest(
             vedtaksperiodeService = vedtaksperiodeService,
         )
 
+        // Act
         val fagsakDto = fagsakService.hentFagsakDto(fagsakId = førstegangsbehandling.fagsak.id)
 
+        // Assert
         assertThat(fagsakDto.data?.gjeldendeUtbetalingsperioder).isNotEmpty
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakIntegrationTest.kt
@@ -13,6 +13,7 @@ class FagsakIntegrationTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `hentMinimalFagsakerForPerson() skal return begge fagsaker for en person`() {
+        // Arrange
         val personFnr = randomFnr()
         val fagsakOmsorgperson =
             fagsakService.hentEllerOpprettFagsak(
@@ -32,8 +33,10 @@ class FagsakIntegrationTest(
                 FagsakType.BARN_ENSLIG_MINDREÅRIG,
             )
 
+        // Act
         val minimalFagsakList = fagsakService.hentMinimalFagsakerForPerson(fagsakOmsorgperson.aktør)
 
+        // Assert
         assertThat(minimalFagsakList.data)
             .hasSize(3)
             .extracting("id")
@@ -42,6 +45,7 @@ class FagsakIntegrationTest(
 
     @Test
     fun `hentMinimalFagsakForPerson() skal return riktig fagsak for en person`() {
+        // Arrange
         val personFnr = randomFnr()
         val fagsakOmsorgperson =
             fagsakService.hentEllerOpprettFagsak(
@@ -61,19 +65,27 @@ class FagsakIntegrationTest(
                 FagsakType.BARN_ENSLIG_MINDREÅRIG,
             )
 
+        // Act
         val defaultMinimalFagsak = fagsakService.hentMinimalFagsakForPerson(fagsakOmsorgperson.aktør)
+        // Assert
         assertThat(defaultMinimalFagsak.data!!.id).isEqualTo(fagsakOmsorgperson.id)
 
+        // Act
         val omsorgpersonMinimalFagsak =
             fagsakService.hentMinimalFagsakForPerson(fagsakOmsorgperson.aktør, FagsakType.NORMAL)
+        // Assert
         assertThat(omsorgpersonMinimalFagsak.data!!.id).isEqualTo(fagsakOmsorgperson.id)
 
+        // Act
         val institusjonMinimalFagsak =
             fagsakService.hentMinimalFagsakForPerson(fagsakOmsorgperson.aktør, FagsakType.INSTITUSJON)
+        // Assert
         assertThat(institusjonMinimalFagsak.data!!.id).isEqualTo(fagsakInstitusjon.id)
 
+        // Act
         val ensligMindreÅrigMinimalFagsak =
             fagsakService.hentMinimalFagsakForPerson(fagsakOmsorgperson.aktør, FagsakType.BARN_ENSLIG_MINDREÅRIG)
+        // Assert
         assertThat(ensligMindreÅrigMinimalFagsak.data!!.id).isEqualTo(fagsakEnsligMindreÅrig.id)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/grunnlag/personopplysninger/PersonopplysningGrunnlagForNyBehandlingServiceTest.kt
@@ -40,6 +40,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `opprettKopiEllerNyttPersonopplysningGrunnlag - skal opprette nytt PersonopplysningGrunnlag som kopi av personopplysningsgrunnlag fra forrige behandling ved satsendring`() {
+        // Arrange
         val morId = randomFnr()
         val barnId = randomFnr()
 
@@ -92,6 +93,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
                 satsendring,
             )
 
+        // Act
         personopplysningGrunnlagForNyBehandlingService.opprettKopiEllerNyttPersonopplysningGrunnlag(
             satsendringBehandling,
             førsteBehandling,
@@ -99,6 +101,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
             listOf(barnId),
         )
 
+        // Assert
         val grunnlagFraSatsendringBehandling =
             personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = satsendringBehandling.id)
 
@@ -113,6 +116,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
 
     @Test
     fun `opprettKopiEllerNyttPersonopplysningGrunnlag - skal opprette nytt PersonopplysningGrunnlag som kopi av personopplysningsgrunnlag fra forrige behandling med barn som hadde andeler tilkjent ytelse`() {
+        // Arrange
         val morId = randomFnr()
         val barn1Id = randomFnr()
         val barn2Id = randomFnr()
@@ -167,6 +171,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
                 satsendring,
             )
 
+        // Act
         personopplysningGrunnlagForNyBehandlingService.opprettKopiEllerNyttPersonopplysningGrunnlag(
             satsendringBehandling,
             førsteBehandling,
@@ -174,6 +179,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
             listOf(barn1Id, barn2Id),
         )
 
+        // Assert
         val grunnlagFraSatsendringBehandling =
             personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = satsendringBehandling.id)
 
@@ -192,6 +198,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
 
     @Test
     fun `opprettKopiEllerNyttPersonopplysningGrunnlag - skal opprette nytt PersonopplysningGrunnlag som kopi av personopplysningsgrunnlag fra forrige behandling ved årsak 'Falsk identitet'`() {
+        // Arrange
         val morId = randomFnr()
         val barnId = randomFnr()
 
@@ -246,6 +253,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
                 falskIdentitetBehandlingUtenID,
             )
 
+        // Act
         personopplysningGrunnlagForNyBehandlingService.opprettKopiEllerNyttPersonopplysningGrunnlag(
             falskIdentitetBehandling,
             førsteBehandling,
@@ -253,6 +261,7 @@ class PersonopplysningGrunnlagForNyBehandlingServiceTest(
             listOf(barnId),
         )
 
+        // Assert
         val grunnlagFraFalskIdentitetBehandling =
             personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = falskIdentitetBehandling.id)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/institusjon/InstitusjonServiceIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/institusjon/InstitusjonServiceIntegrasjonTest.kt
@@ -21,7 +21,7 @@ class InstitusjonServiceIntegrasjonTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `skal lagre og finne Institusjonsinfo for behandlingId`() {
-        // Given
+        // Arrange
         val orgNr = UUID.randomUUID().toString()
         val tssEksternId = UUID.randomUUID().toString()
         institusjonService.hentEllerOpprettInstitusjon(orgNr, tssEksternId)
@@ -33,10 +33,10 @@ class InstitusjonServiceIntegrasjonTest(
             )
         val behandling = lagBehandlingUtenId(fagsak).also { behandlingRepository.saveAndFlush(it) }
 
-        // When
+        // Act
         institusjonService.lagreInstitusjonsinfo(behandling.id)
 
-        // Then
+        // Assert
         institusjonsinfoRepository.findByBehandlingId(behandling.id)!!.also {
             assertThat(it.behandlingId).isEqualTo(behandling.id)
             assertThat(it.institusjon.orgNummer).isEqualTo(orgNr)
@@ -56,7 +56,7 @@ class InstitusjonServiceIntegrasjonTest(
 
     @Test
     fun `Hvis oppdatering av institusjonsinfo, så skal den gamle slettes og ny opprettes`() {
-        // Given
+        // Arrange
         val orgNr = UUID.randomUUID().toString()
         val tssEksternId = UUID.randomUUID().toString()
         institusjonService.hentEllerOpprettInstitusjon(orgNr, tssEksternId)
@@ -68,13 +68,13 @@ class InstitusjonServiceIntegrasjonTest(
             )
         val behandling = lagBehandlingUtenId(fagsak).also { behandlingRepository.saveAndFlush(it) }
 
-        // When
+        // Act
         institusjonService.lagreInstitusjonsinfo(behandling.id)
         val institusjonsinfo = institusjonsinfoRepository.findByBehandlingId(behandling.id)
         institusjonService.lagreInstitusjonsinfo(behandling.id)
         val enAnnenInstitusjonsinfo = institusjonsinfoRepository.findByBehandlingId(behandling.id)
 
-        // Then
+        // Assert
         assertThat(institusjonsinfo?.id).isNotNull()
         assertThat(enAnnenInstitusjonsinfo?.id).isNotNull()
         assertThat(institusjonsinfo!!.id).isNotEqualTo(enAnnenInstitusjonsinfo!!.id)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingRepositoryTest.kt
@@ -25,6 +25,7 @@ class KorrigertEtterbetalingRepositoryTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `finnAktivtKorrigeringPåBehandling skal returnere null dersom det ikke eksisterer en aktiv etterbetaling korrigering på behandling`() {
+        // Arrange
         val behandling = opprettBehandling()
 
         val inaktivKorrigertEtterbetaling =
@@ -38,14 +39,17 @@ class KorrigertEtterbetalingRepositoryTest(
 
         korrigertEtterbetalingRepository.saveAndFlush(inaktivKorrigertEtterbetaling)
 
+        // Act
         val ikkeEksisterendeKorrigertEtterbetaling =
             korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id)
 
+        // Assert
         assertThat(ikkeEksisterendeKorrigertEtterbetaling, Is(nullValue()))
     }
 
     @Test
     fun `finnAktivtKorrigeringPåBehandling skal returnere aktiv korrigering på behandling dersom det finnes`() {
+        // Arrange
         val behandling = opprettBehandling()
 
         val aktivKorrigertEtterbetaling =
@@ -59,15 +63,18 @@ class KorrigertEtterbetalingRepositoryTest(
 
         korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling)
 
+        // Act
         val eksisterendeKorrigertEtterbetaling =
             korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id)!!
 
+        // Assert
         assertThat(eksisterendeKorrigertEtterbetaling.begrunnelse, Is("Test på aktiv korrigering"))
         assertThat(eksisterendeKorrigertEtterbetaling.beløp, Is(1000))
     }
 
     @Test
     fun `Det skal kastes DataIntegrityViolationException dersom det forsøkes å lagre aktivt korrigering når det allerede finnes en`() {
+        // Arrange
         val behandling = opprettBehandling()
 
         val aktivKorrigertEtterbetaling =
@@ -90,6 +97,7 @@ class KorrigertEtterbetalingRepositoryTest(
 
         korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling)
 
+        // Act & Assert
         assertThrows<DataIntegrityViolationException> {
             korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling2)
         }
@@ -97,6 +105,7 @@ class KorrigertEtterbetalingRepositoryTest(
 
     @Test
     fun `hentAlleKorrigeringPåBehandling skal returnere alle KorrigertEtterbetaling på behandling`() {
+        // Arrange
         val behandling = opprettBehandling()
 
         val aktivKorrigertEtterbetaling =
@@ -120,9 +129,11 @@ class KorrigertEtterbetalingRepositoryTest(
         korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling)
         korrigertEtterbetalingRepository.saveAndFlush(inaktivKorrigertEtterbetaling)
 
+        // Act
         val eksisterendeKorrigertEtterbetaling =
             korrigertEtterbetalingRepository.finnAlleKorrigeringerPåBehandling(behandling.id)
 
+        // Assert
         assertThat(eksisterendeKorrigertEtterbetaling.size, Is(2))
         assertThat(eksisterendeKorrigertEtterbetaling.map { it.begrunnelse }, containsInAnyOrder("1", "2"))
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertvedtak/KorrigertVedtakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/korrigertvedtak/KorrigertVedtakRepositoryTest.kt
@@ -23,6 +23,7 @@ class KorrigertVedtakRepositoryTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `finnAktivtKorrigertVedtakPåBehandling skal returnere null dersom det ikke eksisterer en aktiv korrigering av vedtak på behandling`() {
+        // Arrange
         val behandling = opprettBehandling()
 
         val inaktivKorrigertVedtak =
@@ -35,14 +36,17 @@ class KorrigertVedtakRepositoryTest(
 
         korrigertVedtakRepository.saveAndFlush(inaktivKorrigertVedtak)
 
+        // Act
         val ikkeEksisterendeKorrigertVedtak =
             korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id)
 
+        // Assert
         Assertions.assertNull(ikkeEksisterendeKorrigertVedtak, "Skal ikke finnes aktiv korrigert vedtak på behandling")
     }
 
     @Test
     fun `finnAktivtKorrigertVedtakPåBehandling skal returnere aktiv korrigert vedtak når det eksisterer en aktiv korrigering av vedtak på behandling`() {
+        // Arrange
         val behandling = opprettBehandling()
 
         val aktivKorrigertVedtak =
@@ -55,9 +59,11 @@ class KorrigertVedtakRepositoryTest(
 
         korrigertVedtakRepository.saveAndFlush(aktivKorrigertVedtak)
 
+        // Act
         val eksisterendeKorrigertVedtak =
             korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id)
 
+        // Assert
         Assertions.assertNotNull(
             eksisterendeKorrigertVedtak,
             "Skal finnes aktiv korrigert vedtak på behandling",
@@ -66,6 +72,7 @@ class KorrigertVedtakRepositoryTest(
 
     @Test
     fun `Det skal kastes DataIntegrityViolationException dersom det forsøkes å lagre aktivt korrigert vedtak når det allerede finnes en`() {
+        // Arrange
         val behandling = opprettBehandling()
 
         val aktivKorrigertVedtak1 =
@@ -86,6 +93,7 @@ class KorrigertVedtakRepositoryTest(
 
         korrigertVedtakRepository.saveAndFlush(aktivKorrigertVedtak1)
 
+        // Act & Assert
         assertThrows<DataIntegrityViolationException> {
             korrigertVedtakRepository.saveAndFlush(aktivKorrigertVedtak2)
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/logg/LoggServiceTest.kt
@@ -49,6 +49,7 @@ class LoggServiceTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal lage noen logginnslag på forskjellige behandlinger og hente dem fra databasen`() {
+        // Arrange
         val behandling: Behandling = lagBehandling()
         val behandling1: Behandling = lagBehandling()
 
@@ -82,7 +83,10 @@ class LoggServiceTest(
             )
         loggService.lagre(logg3)
 
+        // Act
         val loggForBehandling = loggService.hentLoggForBehandling(behandling.id)
+
+        // Assert
         assertEquals(2, loggForBehandling.size)
 
         val loggForBehandling1 = loggService.hentLoggForBehandling(behandling1.id)
@@ -91,6 +95,7 @@ class LoggServiceTest(
 
     @Test
     fun `Skal lage logginnslag ved stegflyt for automatisk behandling`() {
+        // Arrange
         val barnsFødselsdato = LocalDate.of(2020, 2, 29)
         val barnetsIdent =
             FakePersonopplysningerService.leggTilPersonInfo(
@@ -110,6 +115,7 @@ class LoggServiceTest(
                 egendefinertMock = PersonInfo(fødselsdato = LocalDate.of(1990, 2, 19), kjønn = Kjønn.KVINNE, navn = "Mor Moresen"),
             )
 
+        // Act
         val behandling =
             stegService.opprettNyBehandlingOgRegistrerPersongrunnlagForFødselhendelse(
                 NyBehandlingHendelse(
@@ -118,6 +124,7 @@ class LoggServiceTest(
                 ),
             )
 
+        // Assert
         val loggForBehandling = loggService.hentLoggForBehandling(behandlingId = behandling.id)
         assertEquals(2, loggForBehandling.size)
         assertTrue(loggForBehandling.any { it.type == LoggType.LIVSHENDELSE && it.tekst == "Gjelder barn 29.02.20" })
@@ -127,7 +134,10 @@ class LoggServiceTest(
 
     @Test
     fun `Skal lage nye vilkårslogger og endringer`() {
+        // Arrange
         val behandling = lagBehandling()
+
+        // Act
         val vilkårsvurderingLogg =
             loggService.opprettVilkårsvurderingLogg(
                 behandling = behandling,
@@ -135,6 +145,7 @@ class LoggServiceTest(
                 nyttBehandlingsresultat = Behandlingsresultat.INNVILGET,
             )
 
+        // Assert
         assertNotNull(vilkårsvurderingLogg)
         assertEquals("Vilkårsvurdering gjennomført", vilkårsvurderingLogg!!.tittel)
 
@@ -155,6 +166,7 @@ class LoggServiceTest(
 
     @Test
     fun `Skal ikke logge ved uforandret behandlingsresultat`() {
+        // Act
         val vilkårsvurderingLogg =
             loggService.opprettVilkårsvurderingLogg(
                 behandling = lagBehandling(),
@@ -162,16 +174,20 @@ class LoggServiceTest(
                 nyttBehandlingsresultat = Behandlingsresultat.FORTSATT_INNVILGET,
             )
 
+        // Assert
         assertNull(vilkårsvurderingLogg)
     }
 
     @Test
     fun `Skal lage noen logginnslag på helmanuell migrering ved avvik innenfor beløpsgrenser`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
                 årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
             )
+
+        // Act
         loggService.opprettBehandlingLogg(BehandlingLoggRequest(behandling))
         loggService.opprettVilkårsvurderingLogg(behandling, behandling.resultat, Behandlingsresultat.INNVILGET)
         loggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = true)
@@ -183,6 +199,7 @@ class LoggServiceTest(
         )
         loggService.opprettFerdigstillBehandling(behandling)
 
+        // Assert
         val logger = loggService.hentLoggForBehandling(behandling.id)
         assertEquals(5, logger.size)
         assertTrue {
@@ -220,11 +237,14 @@ class LoggServiceTest(
 
     @Test
     fun `Skal lage noen logginnslag på helmanuell migrering ved avvik utenfor beløpsgrenser`() {
+        // Arrange
         val behandling =
             lagBehandling(
                 behandlingType = BehandlingType.MIGRERING_FRA_INFOTRYGD,
                 årsak = BehandlingÅrsak.HELMANUELL_MIGRERING,
             )
+
+        // Act
         loggService.opprettBehandlingLogg(BehandlingLoggRequest(behandling))
         loggService.opprettVilkårsvurderingLogg(behandling, behandling.resultat, Behandlingsresultat.INNVILGET)
         loggService.opprettSendTilBeslutterLogg(behandling = behandling, skalAutomatiskBesluttes = false)
@@ -236,6 +256,7 @@ class LoggServiceTest(
         )
         loggService.opprettFerdigstillBehandling(behandling)
 
+        // Assert
         val logger = loggService.hentLoggForBehandling(behandling.id)
         assertEquals(5, logger.size)
         assertTrue {
@@ -273,12 +294,15 @@ class LoggServiceTest(
 
     @Test
     fun `Om to logginnslag blir oppretta i samme sekund skal vi sortere med den første først`() {
+        // Arrange
         val behandlingId =
             lagBehandling(
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 årsak = BehandlingÅrsak.SØKNAD,
             ).id
         val tidspunkt = LocalDateTime.now()
+
+        // Act
         val logg1 =
             loggService.lagre(
                 Logg(
@@ -302,17 +326,21 @@ class LoggServiceTest(
                 ),
             )
 
+        // Assert
         val logginnslag = loggService.hentLoggForBehandling(behandlingId)
         assertEquals(listOf(logg2.id, logg1.id), logginnslag.map { it.id })
     }
 
     @Test
     fun `eldste logginnslag skal komme sist og nyaste først`() {
+        // Arrange
         val behandlingId =
             lagBehandling(
                 behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 årsak = BehandlingÅrsak.SØKNAD,
             ).id
+
+        // Act
         val eldst =
             loggService.lagre(
                 Logg(
@@ -344,6 +372,7 @@ class LoggServiceTest(
                 ),
             )
 
+        // Assert
         val logginnslag = loggService.hentLoggForBehandling(behandlingId)
         assertEquals(listOf(nyast.id, mellomst.id, eldst.id), logginnslag.map { it.id })
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/minside/MinSideBarnetrygdControllerTest.kt
@@ -45,6 +45,7 @@ class MinSideBarnetrygdControllerTest(
     inner class HentMinSideBarnetrygd {
         @Test
         fun `skal returnere UNAUTHORIZED når request mangler token`() {
+            // Act & Assert
             val error =
                 assertThrows<HttpClientErrorException> {
                     restClient
@@ -60,12 +61,14 @@ class MinSideBarnetrygdControllerTest(
 
         @Test
         fun `skal returnere FORBIDDEN når token mangler fødselsnummer`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(hentTokenForTokenX(null))
                 }
 
+            // Act & Assert
             val error =
                 assertThrows<HttpClientErrorException> {
                     restClient
@@ -81,12 +84,14 @@ class MinSideBarnetrygdControllerTest(
 
         @Test
         fun `skal returnere BAD_REQUEST når token inneholder ugyldig fødselsnummer`() {
+            // Arrange
             val headers =
                 HttpHeaders().apply {
                     contentType = MediaType.APPLICATION_JSON
                     setBearerAuth(hentTokenForTokenX("12345678910"))
                 }
 
+            // Act & Assert
             val error =
                 assertThrows<HttpClientErrorException> {
                     restClient
@@ -102,6 +107,7 @@ class MinSideBarnetrygdControllerTest(
 
         @Test
         fun `skal hente min side barnetrygd med TokenX-token`() {
+            // Arrange
             val fnr = randomFnr()
             val andelFom = YearMonth.now().minusMonths(5)
             val andelTom = YearMonth.now().plusMonths(5)
@@ -143,6 +149,7 @@ class MinSideBarnetrygdControllerTest(
                     setBearerAuth(hentTokenForTokenX(fnr))
                 }
 
+            // Act
             val response =
                 restClient
                     .get()
@@ -151,6 +158,7 @@ class MinSideBarnetrygdControllerTest(
                     .retrieve()
                     .toEntity<HentMinSideBarnetrygdDto.Suksess>()
 
+            // Assert
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(
                 response.body

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/modiacontext/ModiaContextControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/modiacontext/ModiaContextControllerTest.kt
@@ -21,8 +21,10 @@ class ModiaContextControllerTest(
 
     @Test
     fun `skal hente context`() {
+        // Act
         val response = modiaContextController.hentContext()
 
+        // Assert
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
         assertThat(response.body?.data?.aktivBruker).isEqualTo("13025514402")
@@ -31,11 +33,13 @@ class ModiaContextControllerTest(
 
     @Test
     fun `skal oppdatere context`() {
+        // Act
         val response =
             modiaContextController.settNyAktivBruker(
                 NyAktivBrukerIModiaContextDto(personIdent = "13025514402"),
             )
 
+        // Assert
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
         assertThat(response.body?.data?.aktivBruker).isEqualTo("13025514402")
@@ -44,6 +48,7 @@ class ModiaContextControllerTest(
 
     @Test
     fun `skal kaste feil ved ugyldig personIdent`() {
+        // Act & Assert
         val exception =
             assertThrows<IllegalStateException> {
                 modiaContextController.settNyAktivBruker(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringServiceTest.kt
@@ -30,6 +30,7 @@ class SimuleringServiceTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal verifisere at simulering blir lagert og oppdatert`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(randomSøkerFødselsdato())
         val barnFnr = leggTilPersonInfo(randomBarnFødselsdato())
         val behandlingEtterVilkårsvurderingSteg =
@@ -49,6 +50,7 @@ class SimuleringServiceTest(
         val vedtakSimuleringMottakerMock =
             simuleringsMottakere.map { it.tilBehandlingSimuleringMottaker(behandlingEtterVilkårsvurderingSteg) }
 
+        // Act & Assert
         assertEquals(
             vedtakSimuleringMottakerMock.size,
             simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingEtterVilkårsvurderingSteg.id).size,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlagTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/RegistrerPersongrunnlagTest.kt
@@ -28,6 +28,7 @@ class RegistrerPersongrunnlagTest(
     @Test
     @Tag("integration")
     fun `Legg til personer på behandling`() {
+        // Arrange
         val morId = randomFnr()
         val barn1Id = randomFnr()
         val barn2Id = randomFnr()
@@ -35,6 +36,8 @@ class RegistrerPersongrunnlagTest(
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(morId)
         val behandling1 =
             behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))
+
+        // Act
         stegService.håndterPersongrunnlag(
             behandling = behandling1,
             registrerPersongrunnlagDTO =
@@ -44,6 +47,7 @@ class RegistrerPersongrunnlagTest(
                 ),
         )
 
+        // Assert
         val grunnlag1 = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = behandling1.id)
 
         Assertions.assertEquals(3, grunnlag1!!.personer.size)
@@ -63,6 +67,7 @@ class RegistrerPersongrunnlagTest(
     @Test
     @Tag("integration")
     fun `Legg til barn på eksisterende behandling`() {
+        // Arrange
         val morId = randomFnr()
         val barn1Id = randomFnr()
         val barn2Id = randomFnr()
@@ -70,6 +75,8 @@ class RegistrerPersongrunnlagTest(
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(morId)
         val behandling1 =
             behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))
+
+        // Act
         stegService.håndterPersongrunnlag(
             behandling = behandling1,
             registrerPersongrunnlagDTO =
@@ -79,12 +86,14 @@ class RegistrerPersongrunnlagTest(
                 ),
         )
 
+        // Assert
         val grunnlag1 = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = behandling1.id)
 
         Assertions.assertEquals(2, grunnlag1!!.personer.size)
         Assertions.assertTrue(grunnlag1.personer.any { it.aktør.aktivFødselsnummer() == morId })
         Assertions.assertTrue(grunnlag1.personer.any { it.aktør.aktivFødselsnummer() == barn1Id })
 
+        // Act
         stegService.håndterPersongrunnlag(
             behandling = behandling1,
             registrerPersongrunnlagDTO =
@@ -97,6 +106,8 @@ class RegistrerPersongrunnlagTest(
                         ),
                 ),
         )
+
+        // Assert
         val grunnlag2 = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = behandling1.id)
 
         Assertions.assertEquals(3, grunnlag2!!.personer.size)
@@ -104,6 +115,7 @@ class RegistrerPersongrunnlagTest(
         Assertions.assertTrue(grunnlag2.personer.any { it.aktør.aktivFødselsnummer() == barn1Id })
         Assertions.assertTrue(grunnlag2.personer.any { it.aktør.aktivFødselsnummer() == barn2Id })
 
+        // Act
         // Skal ikke føre til flere personer på persongrunnlaget
         stegService.håndterPersongrunnlag(
             behandling = behandling1,
@@ -118,6 +130,7 @@ class RegistrerPersongrunnlagTest(
                 ),
         )
 
+        // Assert
         val grunnlag3 = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId = behandling1.id)
 
         Assertions.assertEquals(3, grunnlag3!!.personer.size)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/StegServiceIntegrationTest.kt
@@ -93,6 +93,7 @@ class StegServiceIntegrationTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal sette default-verdier på gift-vilkår for barn`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr1 = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
         val barnFnr2 =
@@ -110,6 +111,7 @@ class StegServiceIntegrationTest(
                     ),
             )
 
+        // Act
         val behandling =
             kjørStegprosessForFGB(
                 tilSteg = StegType.REGISTRERE_SØKNAD,
@@ -124,6 +126,7 @@ class StegServiceIntegrationTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         val vilkårsvurdering = vilkårsvurderingService.hentAktivForBehandling(behandlingId = behandling.id)!!
         assertEquals(
             Resultat.OPPFYLT,
@@ -145,8 +148,11 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Skal kjøre gjennom alle steg med datageneratoren`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
+
+        // Act
         val behandling =
             kjørStegprosessForFGB(
                 tilSteg = StegType.BEHANDLING_AVSLUTTET,
@@ -177,12 +183,14 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Skal feile når man prøver å håndtere feil steg`() {
+        // Arrange
         val (søkerFnr, _) = mockHentPersoninfoForIdenter()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søkerFnr)
         val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))
         assertEquals(FØRSTE_STEG, behandling.steg)
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             stegService.håndterVilkårsvurdering(behandling)
         }
@@ -190,6 +198,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Skal feile når man prøver å endre en avsluttet behandling`() {
+        // Arrange
         val (søkerFnr, _) = mockHentPersoninfoForIdenter()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søkerFnr)
@@ -200,10 +209,14 @@ class StegServiceIntegrationTest(
 
         behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BEHANDLING_AVSLUTTET))
         behandling.status = BehandlingStatus.AVSLUTTET
+
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 stegService.håndterSendTilBeslutter(behandling, "1234")
             }
+
+        // Assert
         assertEquals(
             "Behandling med id ${behandling.id} er avsluttet og stegprosessen kan ikke gjenåpnes",
             feil.message,
@@ -212,6 +225,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Skal feile når man prøver å noe annet enn å beslutte behandling når den er på dette steget`() {
+        // Arrange
         val (søkerFnr, _) = mockHentPersoninfoForIdenter()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søkerFnr)
@@ -222,6 +236,8 @@ class StegServiceIntegrationTest(
 
         behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))
         behandling.status = BehandlingStatus.FATTER_VEDTAK
+
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             stegService.håndterSendTilBeslutter(behandling, "1234")
         }
@@ -229,12 +245,15 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Skal feile når man prøver å kalle beslutning-steget med feil status på behandling`() {
+        // Arrange
         val (søkerFnr, _) = mockHentPersoninfoForIdenter()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søkerFnr)
         val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))
         behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
+
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             stegService.håndterBeslutningForVedtak(
                 behandling,
@@ -245,6 +264,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Underkjent beslutning setter steg tilbake til send til beslutter`() {
+        // Arrange
         val (søkerFnr, _) = mockHentPersoninfoForIdenter()
         val søkerAktørId = personidentService.hentAktør(søkerFnr)
 
@@ -264,22 +284,27 @@ class StegServiceIntegrationTest(
         behandling.behandlingStegTilstand.forEach { it.behandlingStegStatus = BehandlingStegStatus.UTFØRT }
         behandling.behandlingStegTilstand.add(BehandlingStegTilstand(0, behandling, StegType.BESLUTTE_VEDTAK))
         behandling.status = BehandlingStatus.FATTER_VEDTAK
+
+        // Act
         stegService.håndterBeslutningForVedtak(
             behandling,
             BeslutningPåVedtakDto(beslutning = Beslutning.UNDERKJENT, begrunnelse = "Feil"),
         )
 
+        // Assert
         val behandlingEtterPersongrunnlagSteg = behandlingHentOgPersisterService.hent(behandlingId = behandling.id)
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterPersongrunnlagSteg.steg)
     }
 
     @Test
     fun `Henlegge før behandling er sendt til beslutter`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
 
         val vilkårsvurdertBehandling = kjørGjennomStegInkludertVurderTilbakekreving(søkerFnr, listOf(barnFnr))
 
+        // Act
         val henlagtBehandling =
             stegService.håndterHenleggBehandling(
                 vilkårsvurdertBehandling,
@@ -288,6 +313,8 @@ class StegServiceIntegrationTest(
                     begrunnelse = "",
                 ),
             )
+
+        // Assert
         assertTrue(
             henlagtBehandling.behandlingStegTilstand.firstOrNull {
                 it.behandlingSteg == StegType.HENLEGG_BEHANDLING && it.behandlingStegStatus == BehandlingStegStatus.UTFØRT
@@ -304,6 +331,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Teknisk henleggelse med begrunnelse Satsendring skal beholde behandleSak-oppgaven åpen`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
 
@@ -315,6 +343,8 @@ class StegServiceIntegrationTest(
                 DbOppgave(behandling = behandling, type = Oppgavetype.BehandleUnderkjentVedtak, gsakId = "3"),
             ),
         )
+
+        // Act
         val henlagtBehandling =
             stegService.håndterHenleggBehandling(
                 behandling,
@@ -323,6 +353,8 @@ class StegServiceIntegrationTest(
                     begrunnelse = "Satsendring",
                 ),
             )
+
+        // Assert
         assertEquals(StegType.BEHANDLING_AVSLUTTET, henlagtBehandling.steg)
         assertTrue {
             oppgaveRepository
@@ -346,6 +378,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `Henlegge etter behandling er sendt til beslutter`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
 
@@ -355,6 +388,7 @@ class StegServiceIntegrationTest(
         val behandlingEtterSendTilBeslutter =
             behandlingHentOgPersisterService.hent(behandlingId = vilkårsvurdertBehandling.id)
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             stegService.håndterHenleggBehandling(
                 behandlingEtterSendTilBeslutter,
@@ -370,6 +404,7 @@ class StegServiceIntegrationTest(
     // Disse vil bli stoppet i BehandlingStegController.
     @Test
     fun `Henlegge dersom behandling står på FERDIGSTILLE_BEHANDLING steget`() {
+        // Arrange
         val (søkerFnr, _) = mockHentPersoninfoForIdenter()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(søkerFnr)
@@ -384,12 +419,14 @@ class StegServiceIntegrationTest(
             ),
         )
 
+        // Act
         val behandlingEtterHenleggelse =
             stegService.håndterHenleggBehandling(
                 behandling,
                 HenleggBehandlingInfoDto(årsak = HenleggÅrsak.FEILAKTIG_OPPRETTET, begrunnelse = ""),
             )
 
+        // Assert
         assertThat(behandlingEtterHenleggelse.steg).isEqualTo(StegType.BEHANDLING_AVSLUTTET)
         assertThat(behandlingEtterHenleggelse.status).isEqualTo(BehandlingStatus.AVSLUTTET)
         assertThat(behandlingEtterHenleggelse.behandlingStegTilstand.any { it.behandlingSteg == StegType.FERDIGSTILLE_BEHANDLING && it.behandlingStegStatus == BehandlingStegStatus.UTFØRT })
@@ -397,6 +434,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `skal kjøre gjennom steg for migreringsbehandling med årsak endre migreringsdato og avvik i simulering innenfor beløpsgrenser`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(30))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
 
@@ -445,6 +483,8 @@ class StegServiceIntegrationTest(
         )
 
         val nyMigreringsdato = LocalDate.now().minusMonths(6)
+
+        // Act
         val behandling =
             stegService.håndterNyBehandling(
                 NyBehandling(
@@ -457,6 +497,8 @@ class StegServiceIntegrationTest(
                     fagsakId = fagsak.id,
                 ),
             )
+
+        // Assert
         assertEquals(StegType.VILKÅRSVURDERING, behandling.steg)
         assertTrue {
             behandling.behandlingStegTilstand.any {
@@ -467,13 +509,20 @@ class StegServiceIntegrationTest(
         assertMigreringsdato(nyMigreringsdato, behandling)
         assertNotNull(vilkårsvurderingService.hentAktivForBehandling(behandling.id))
 
+        // Act
         val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)
+
+        // Assert
         assertEquals(StegType.BEHANDLINGSRESULTAT, behandlingEtterVilkårsvurdering.steg)
 
+        // Act
         val behandlingEtterBehandlingsresultatSteg =
             stegService.håndterBehandlingsresultat(behandlingEtterVilkårsvurdering)
+
+        // Assert
         assertEquals(StegType.VURDER_TILBAKEKREVING, behandlingEtterBehandlingsresultatSteg.steg)
 
+        // Act
         val behandlingEtterTilbakekrevingSteg =
             stegService.håndterVurderTilbakekreving(
                 behandlingEtterBehandlingsresultatSteg,
@@ -482,13 +531,18 @@ class StegServiceIntegrationTest(
                     begrunnelse = "ignorer tilbakekreving",
                 ),
             )
+
+        // Assert
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterTilbakekrevingSteg.steg)
 
+        // Act
         val behandlingEtterBeslutterSteg =
             stegService.håndterSendTilBeslutter(
                 behandlingEtterTilbakekrevingSteg,
                 "1234",
             )
+
+        // Assert
         assertEquals(StegType.FERDIGSTILLE_BEHANDLING, behandlingEtterBeslutterSteg.steg)
         assertTrue {
             behandlingEtterBeslutterSteg.behandlingStegTilstand.any {
@@ -513,6 +567,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `skal kjøre gjennom steg for migreringsbehandling med årsak endre migreringsdato og avvik i simulering utenefor beløpsgrenser`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(29))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
         val barnasIdenter = listOf(barnFnr)
@@ -560,6 +615,8 @@ class StegServiceIntegrationTest(
         )
 
         val nyMigreringsdato = LocalDate.now().minusMonths(6)
+
+        // Act
         val behandling =
             stegService.håndterNyBehandling(
                 NyBehandling(
@@ -572,6 +629,8 @@ class StegServiceIntegrationTest(
                     fagsakId = fagsak.id,
                 ),
             )
+
+        // Assert
         assertEquals(StegType.VILKÅRSVURDERING, behandling.steg)
         assertTrue {
             behandling.behandlingStegTilstand.any {
@@ -582,13 +641,20 @@ class StegServiceIntegrationTest(
         assertMigreringsdato(nyMigreringsdato, behandling)
         assertNotNull(vilkårsvurderingService.hentAktivForBehandling(behandling.id))
 
+        // Act
         val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)
+
+        // Assert
         assertEquals(StegType.BEHANDLINGSRESULTAT, behandlingEtterVilkårsvurdering.steg)
 
+        // Act
         val behandlingEtterBehandlingsresultatSteg =
             stegService.håndterBehandlingsresultat(behandlingEtterVilkårsvurdering)
+
+        // Assert
         assertEquals(StegType.VURDER_TILBAKEKREVING, behandlingEtterBehandlingsresultatSteg.steg)
 
+        // Act
         val behandlingEtterTilbakekrevingSteg =
             stegService.håndterVurderTilbakekreving(
                 behandlingEtterBehandlingsresultatSteg,
@@ -597,13 +663,18 @@ class StegServiceIntegrationTest(
                     begrunnelse = "ignorer tilbakekreving",
                 ),
             )
+
+        // Assert
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterTilbakekrevingSteg.steg)
 
+        // Act
         val behandlingEtterBeslutterSteg =
             stegService.håndterSendTilBeslutter(
                 behandlingEtterTilbakekrevingSteg,
                 "1234",
             )
+
+        // Assert
         assertEquals(StegType.FERDIGSTILLE_BEHANDLING, behandlingEtterBeslutterSteg.steg)
         assertTrue {
             behandlingEtterBeslutterSteg.behandlingStegTilstand.any {
@@ -628,6 +699,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `skal kjøre gjennom steg for migreringsbehandling med årsak endre migreringsdato og avvik i simulering utenfor beløpsgrenser`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(18))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
         val barnasIdenter = listOf(barnFnr)
@@ -675,6 +747,8 @@ class StegServiceIntegrationTest(
         )
 
         val nyMigreringsdato = LocalDate.now().minusMonths(6)
+
+        // Act
         val behandling =
             stegService.håndterNyBehandling(
                 NyBehandling(
@@ -687,6 +761,8 @@ class StegServiceIntegrationTest(
                     fagsakId = fagsak.id,
                 ),
             )
+
+        // Assert
         assertEquals(StegType.VILKÅRSVURDERING, behandling.steg)
         assertTrue {
             behandling.behandlingStegTilstand.any {
@@ -697,13 +773,20 @@ class StegServiceIntegrationTest(
         assertMigreringsdato(nyMigreringsdato, behandling)
         assertNotNull(vilkårsvurderingService.hentAktivForBehandling(behandling.id))
 
+        // Act
         val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)
+
+        // Assert
         assertEquals(StegType.BEHANDLINGSRESULTAT, behandlingEtterVilkårsvurdering.steg)
 
+        // Act
         val behandlingEtterBehandlingsresultatSteg =
             stegService.håndterBehandlingsresultat(behandlingEtterVilkårsvurdering)
+
+        // Assert
         assertEquals(StegType.VURDER_TILBAKEKREVING, behandlingEtterBehandlingsresultatSteg.steg)
 
+        // Act
         val behandlingEtterTilbakekrevingSteg =
             stegService.håndterVurderTilbakekreving(
                 behandlingEtterBehandlingsresultatSteg,
@@ -713,14 +796,17 @@ class StegServiceIntegrationTest(
                 ),
             )
 
+        // Assert
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterTilbakekrevingSteg.steg)
 
+        // Act
         val behandlingEtterSendTilBeslutterSteg =
             stegService.håndterSendTilBeslutter(
                 behandlingEtterTilbakekrevingSteg,
                 "1234",
             )
 
+        // Assert
         assertEquals(StegType.FERDIGSTILLE_BEHANDLING, behandlingEtterSendTilBeslutterSteg.steg)
 
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(behandling.id)
@@ -734,6 +820,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `skal kjøre gjennom steg for helmanuell migrering med avvik i simulering innenfor beløpsgrenser`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
         val barnasIdenter = listOf(barnFnr)
@@ -767,6 +854,8 @@ class StegServiceIntegrationTest(
         leggTilSimuleringResultat(fagsak.id.toString(), DetaljertSimuleringResultat(simuleringMottakerMock))
 
         val migreringsdato = LocalDate.now().minusMonths(6)
+
+        // Act
         val behandling =
             stegService.håndterNyBehandling(
                 NyBehandling(
@@ -779,6 +868,8 @@ class StegServiceIntegrationTest(
                     fagsakId = fagsak.id,
                 ),
             )
+
+        // Assert
         assertEquals(StegType.VILKÅRSVURDERING, behandling.steg)
         assertTrue {
             behandling.behandlingStegTilstand.any {
@@ -799,13 +890,20 @@ class StegServiceIntegrationTest(
         vilkårsvurdering.personResultater = setOf(søkerPersonResultat, barnPersonResultat)
         vilkårsvurderingService.oppdater(vilkårsvurdering)
 
+        // Act
         val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)
+
+        // Assert
         assertEquals(StegType.BEHANDLINGSRESULTAT, behandlingEtterVilkårsvurdering.steg)
 
+        // Act
         val behandlingEtterBehandlingsresultatSteg =
             stegService.håndterBehandlingsresultat(behandlingEtterVilkårsvurdering)
+
+        // Assert
         assertEquals(StegType.VURDER_TILBAKEKREVING, behandlingEtterBehandlingsresultatSteg.steg)
 
+        // Act
         val behandlingEtterTilbakekrevingSteg =
             stegService.håndterVurderTilbakekreving(
                 behandlingEtterBehandlingsresultatSteg,
@@ -814,13 +912,18 @@ class StegServiceIntegrationTest(
                     begrunnelse = "ignorer tilbakekreving",
                 ),
             )
+
+        // Assert
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterTilbakekrevingSteg.steg)
 
+        // Act
         val behandlingEtterBesultterSteg =
             stegService.håndterSendTilBeslutter(
                 behandlingEtterTilbakekrevingSteg,
                 "1234",
             )
+
+        // Assert
         assertEquals(StegType.IVERKSETT_MOT_OPPDRAG, behandlingEtterBesultterSteg.steg)
         assertTrue {
             behandlingEtterBesultterSteg.behandlingStegTilstand.any {
@@ -845,6 +948,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `skal kjøre gjennom steg for helmanuell migrering med avvik i simulering utenfor beløpsgrenser`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
         val barnasIdenter = listOf(barnFnr)
@@ -878,6 +982,8 @@ class StegServiceIntegrationTest(
         leggTilSimuleringResultat(fagsak.id.toString(), DetaljertSimuleringResultat(simuleringMottakerMock))
 
         val migreringsdato = LocalDate.now().minusMonths(6)
+
+        // Act
         val behandling =
             stegService.håndterNyBehandling(
                 NyBehandling(
@@ -890,6 +996,8 @@ class StegServiceIntegrationTest(
                     fagsakId = fagsak.id,
                 ),
             )
+
+        // Assert
         assertEquals(StegType.VILKÅRSVURDERING, behandling.steg)
         assertTrue {
             behandling.behandlingStegTilstand.any {
@@ -910,13 +1018,20 @@ class StegServiceIntegrationTest(
         vilkårsvurdering.personResultater = setOf(søkerPersonResultat, barnPersonResultat)
         vilkårsvurderingService.oppdater(vilkårsvurdering)
 
+        // Act
         val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)
+
+        // Assert
         assertEquals(StegType.BEHANDLINGSRESULTAT, behandlingEtterVilkårsvurdering.steg)
 
+        // Act
         val behandlingEtterBehandlingsresultatSteg =
             stegService.håndterBehandlingsresultat(behandlingEtterVilkårsvurdering)
+
+        // Assert
         assertEquals(StegType.VURDER_TILBAKEKREVING, behandlingEtterBehandlingsresultatSteg.steg)
 
+        // Act
         val behandlingEtterTilbakekrevingSteg =
             stegService.håndterVurderTilbakekreving(
                 behandlingEtterBehandlingsresultatSteg,
@@ -925,16 +1040,21 @@ class StegServiceIntegrationTest(
                     begrunnelse = "ignorer tilbakekreving",
                 ),
             )
+
+        // Assert
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterTilbakekrevingSteg.steg)
 
+        // Act
         val behandlingEtterSendTilBeslutterSteg =
             stegService.håndterSendTilBeslutter(
                 behandlingEtterTilbakekrevingSteg,
                 "1234",
             )
 
+        // Assert
         assertEquals(StegType.BESLUTTE_VEDTAK, behandlingEtterSendTilBeslutterSteg.steg)
 
+        // Act
         val behandlingEtterBesluttVedtakSteg =
             stegService.håndterBeslutningForVedtak(
                 behandlingEtterSendTilBeslutterSteg,
@@ -944,6 +1064,7 @@ class StegServiceIntegrationTest(
                 ),
             )
 
+        // Assert
         assertEquals(StegType.IVERKSETT_MOT_OPPDRAG, behandlingEtterBesluttVedtakSteg.steg)
 
         assertTrue {
@@ -970,6 +1091,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `skal kjøre gjennom steg for helmanuell migrering med manuelle posteringer med avvik innenfor beløpsgrenser`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(35))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
 
@@ -1004,6 +1126,8 @@ class StegServiceIntegrationTest(
         leggTilSimuleringResultat(fagsak.id.toString(), DetaljertSimuleringResultat(simuleringMottakerMock))
 
         val migreringsdato = LocalDate.now().minusMonths(6)
+
+        // Act
         val behandling =
             stegService.håndterNyBehandling(
                 NyBehandling(
@@ -1016,6 +1140,8 @@ class StegServiceIntegrationTest(
                     fagsakId = fagsak.id,
                 ),
             )
+
+        // Assert
         assertEquals(StegType.VILKÅRSVURDERING, behandling.steg)
         assertTrue {
             behandling.behandlingStegTilstand.any {
@@ -1036,13 +1162,19 @@ class StegServiceIntegrationTest(
         vilkårsvurdering.personResultater = setOf(søkerPersonResultat, barnPersonResultat)
         vilkårsvurderingService.oppdater(vilkårsvurdering)
 
+        // Act
         val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)
+
+        // Assert
         assertEquals(StegType.BEHANDLINGSRESULTAT, behandlingEtterVilkårsvurdering.steg)
 
+        // Act
         val behandlingEtterBehandlingsresultatSteg =
             stegService.håndterBehandlingsresultat(behandlingEtterVilkårsvurdering)
+        // Assert
         assertEquals(StegType.VURDER_TILBAKEKREVING, behandlingEtterBehandlingsresultatSteg.steg)
 
+        // Act
         val behandlingEtterTilbakekrevingSteg =
             stegService.håndterVurderTilbakekreving(
                 behandlingEtterBehandlingsresultatSteg,
@@ -1051,17 +1183,22 @@ class StegServiceIntegrationTest(
                     begrunnelse = "ignorer tilbakekreving",
                 ),
             )
+
+        // Assert
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterTilbakekrevingSteg.steg)
 
+        // Act
         val behandlingEtterSendTilBeslutterSteg =
             stegService.håndterSendTilBeslutter(
                 behandlingEtterTilbakekrevingSteg,
                 "1234",
             )
 
+        // Assert
         assertEquals(StegType.BESLUTTE_VEDTAK, behandlingEtterSendTilBeslutterSteg.steg)
 
         // Må manuelt godkjenne vedtak
+        // Act
         val behandlingEtterBesluttVedtakSteg =
             stegService.håndterBeslutningForVedtak(
                 behandlingEtterSendTilBeslutterSteg,
@@ -1071,6 +1208,7 @@ class StegServiceIntegrationTest(
                 ),
             )
 
+        // Assert
         assertEquals(StegType.IVERKSETT_MOT_OPPDRAG, behandlingEtterBesluttVedtakSteg.steg)
 
         assertTrue {
@@ -1097,6 +1235,7 @@ class StegServiceIntegrationTest(
 
     @Test
     fun `skal kjøre gjennom steg for endre migreringsdato behandling og automatisk godkjenne totrinnskontroll`() {
+        // Arrange
         val søkerFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(37))
         val barnFnr = leggTilPersonInfo(fødselsdato = LocalDate.now().minusYears(2))
         val barnasIdenter = listOf(barnFnr)
@@ -1144,6 +1283,8 @@ class StegServiceIntegrationTest(
         )
 
         val migreringsdato = LocalDate.now().minusMonths(6)
+
+        // Act
         val behandling =
             stegService.håndterNyBehandling(
                 NyBehandling(
@@ -1156,6 +1297,8 @@ class StegServiceIntegrationTest(
                     fagsakId = fagsak.id,
                 ),
             )
+
+        // Assert
         assertEquals(StegType.VILKÅRSVURDERING, behandling.steg)
         assertTrue {
             behandling.behandlingStegTilstand.any {
@@ -1171,13 +1314,20 @@ class StegServiceIntegrationTest(
         vilkårsvurdering.personResultater = setOf(søkerPersonResultat, barnPersonResultat)
         vilkårsvurderingService.oppdater(vilkårsvurdering)
 
+        // Act
         val behandlingEtterVilkårsvurdering = stegService.håndterVilkårsvurdering(behandling)
+
+        // Assert
         assertEquals(StegType.BEHANDLINGSRESULTAT, behandlingEtterVilkårsvurdering.steg)
 
+        // Act
         val behandlingEtterBehandlingsresultatSteg =
             stegService.håndterBehandlingsresultat(behandlingEtterVilkårsvurdering)
+
+        // Assert
         assertEquals(StegType.VURDER_TILBAKEKREVING, behandlingEtterBehandlingsresultatSteg.steg)
 
+        // Act
         val behandlingEtterTilbakekrevingSteg =
             stegService.håndterVurderTilbakekreving(
                 behandlingEtterBehandlingsresultatSteg,
@@ -1186,14 +1336,18 @@ class StegServiceIntegrationTest(
                     begrunnelse = "ignorer tilbakekreving",
                 ),
             )
+
+        // Assert
         assertEquals(StegType.SEND_TIL_BESLUTTER, behandlingEtterTilbakekrevingSteg.steg)
 
+        // Act
         val behandlingEtterSendTilBeslutterSteg =
             stegService.håndterSendTilBeslutter(
                 behandlingEtterTilbakekrevingSteg,
                 "1234",
             )
 
+        // Assert
         assertEquals(StegType.FERDIGSTILLE_BEHANDLING, behandlingEtterSendTilBeslutterSteg.steg)
 
         assertTrue {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingForNyBehandlingServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/steg/VilkårsvurderingForNyBehandlingServiceTest.kt
@@ -72,6 +72,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `skal lage vilkårsvurderingsperiode for migrering ved flyttesak`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val søkerFødselsdato = LocalDate.of(1984, 1, 14)
@@ -157,12 +158,16 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
         val nyMigreringsdato = LocalDate.now().minusMonths(5)
+
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato(
                 behandling = behandling,
                 forrigeBehandlingSomErVedtatt = forrigeBehandling,
                 nyMigreringsdato = nyMigreringsdato,
             )
+
+        // Assert
         Assertions.assertTrue { vilkårsvurdering.personResultater.isNotEmpty() }
         val søkerVilkårResultat =
             vilkårsvurdering.personResultater.first { it.aktør.aktivFødselsnummer() == fnr }.vilkårResultater
@@ -200,6 +205,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 
     @Test
     fun `skal lage vilkårsvurderingsperiode for migrering ved flere perioder`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val søkerFødselsdato = LocalDate.of(1984, 8, 1)
@@ -327,12 +333,16 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
         val nyMigreringsdato = LocalDate.of(2021, 1, 1)
+
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato(
                 behandling = behandling,
                 forrigeBehandlingSomErVedtatt = forrigeBehandling,
                 nyMigreringsdato = nyMigreringsdato,
             )
+
+        // Assert
         Assertions.assertTrue { vilkårsvurdering.personResultater.isNotEmpty() }
         val søkerVilkårResultat =
             vilkårsvurdering.personResultater.first { it.aktør.aktivFødselsnummer() == fnr }.vilkårResultater
@@ -375,6 +385,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 
     @Test
     fun `genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato - skal ikke vurdere VilkårResultater som ikke er oppfylt fra forrige behandling ved kopiering til nye VilkårResultater`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val søkerFødselsdato = LocalDate.of(1984, 8, 1)
@@ -504,12 +515,15 @@ class VilkårsvurderingForNyBehandlingServiceTest(
             )
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato(
                 behandling = behandling,
                 forrigeBehandlingSomErVedtatt = forrigeBehandling,
                 nyMigreringsdato = nyMigreringsdato,
             )
+
+        // Assert
         Assertions.assertTrue { vilkårsvurdering.personResultater.isNotEmpty() }
         val søkerVilkårResultat =
             vilkårsvurdering.personResultater.first { it.aktør.aktivFødselsnummer() == søkerFnr }.vilkårResultater
@@ -560,6 +574,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 
     @Test
     fun `genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato - skal kopiere over alle felter, inkludert UtdypendeVilkårsvurdering, med unntak av fom og tom for VilkårResultatene som blir forskjøvet av ny migreringsdato`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val søkerFødselsdato = LocalDate.of(1984, 8, 1)
@@ -657,12 +672,15 @@ class VilkårsvurderingForNyBehandlingServiceTest(
             )
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato(
                 behandling = behandling,
                 forrigeBehandlingSomErVedtatt = forrigeBehandling,
                 nyMigreringsdato = nyMigreringsdato,
             )
+
+        // Assert
         assertThat(vilkårsvurdering.personResultater).isNotEmpty
         val søkerVilkårResultat =
             vilkårsvurdering.personResultater.first { it.aktør.aktivFødselsnummer() == søkerFnr }.vilkårResultater
@@ -678,6 +696,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 
     @Test
     fun `genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato - skal kunne identifisere og kopiere forkjøvede vilkår som alltid starter fra fødselsdato når aktør har fått ny fødselsdato siden forrige behandling`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val søkerFødselsdato = LocalDate.of(1984, 8, 1)
@@ -780,12 +799,15 @@ class VilkårsvurderingForNyBehandlingServiceTest(
             )
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.genererVilkårsvurderingForMigreringsbehandlingMedÅrsakEndreMigreringsdato(
                 behandling = behandling,
                 forrigeBehandlingSomErVedtatt = forrigeBehandling,
                 nyMigreringsdato = nyMigreringsdato,
             )
+
+        // Assert
         assertThat(vilkårsvurdering.personResultater).isNotEmpty
         val søkerVilkårResultat =
             vilkårsvurdering.personResultater.first { it.aktør.aktivFødselsnummer() == søkerFnr }.vilkårResultater
@@ -805,6 +827,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 
     @Test
     fun `skal lage vilkårsvurderingsperiode for helmanuell migrering`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val barnetsFødselsdato = LocalDate.of(2020, 8, 15)
@@ -829,12 +852,15 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
         val nyMigreringsdato = LocalDate.of(2021, 1, 1)
+
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.genererVilkårsvurderingForHelmanuellMigrering(
                 behandling,
                 nyMigreringsdato,
             )
 
+        // Assert
         Assertions.assertTrue { vilkårsvurdering.personResultater.isNotEmpty() }
         Assertions.assertTrue { vilkårsvurdering.personResultater.size == 2 }
 
@@ -875,6 +901,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 
     @Test
     fun `skal lage vilkårsvurderingsperiode for helmanuell migrering med migreringsdato før barnetsfødselsdato`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
         val barnetsFødselsdato = LocalDate.of(2021, 8, 15)
@@ -899,12 +926,15 @@ class VilkårsvurderingForNyBehandlingServiceTest(
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
         val nyMigreringsdato = LocalDate.of(2021, 1, 1)
+
+        // Act
         val vilkårsvurdering =
             vilkårsvurderingForNyBehandlingService.genererVilkårsvurderingForHelmanuellMigrering(
                 behandling,
                 nyMigreringsdato,
             )
 
+        // Assert
         Assertions.assertTrue { vilkårsvurdering.personResultater.isNotEmpty() }
         Assertions.assertTrue { vilkårsvurdering.personResultater.size == 2 }
 
@@ -945,6 +975,7 @@ class VilkårsvurderingForNyBehandlingServiceTest(
 
     @Test
     fun `skal kopiere vilkårsvurdering og endrede utbetalingsandeler fra forrige behandling ved satsendring`() {
+        // Arrange
         val søkerFnr = randomFnr()
         val barnFnr = randomFnr()
         val søkerAktør = personidentService.hentOgLagreAktør(søkerFnr, true)
@@ -1061,8 +1092,10 @@ class VilkårsvurderingForNyBehandlingServiceTest(
                 overstyrendeVilkårResultater = emptyMap(),
             )
 
+        // Act
         vilkårsvurderingForNyBehandlingService.opprettVilkårsvurderingUtenomHovedflyt(behandling2, behandling)
 
+        // Assert
         val kopiertVilkårsvurdering = vilkårsvurderingForNyBehandlingService.hentVilkårsvurderingThrows(behandling2.id)
 
         val kopiertEndredeUtbetalingsandeler = endretUtbetalingAndelRepository.findByBehandlingId(behandling2.id)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/totrinnskontroll/TotrinnskontrollTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/totrinnskontroll/TotrinnskontrollTest.kt
@@ -35,13 +35,17 @@ class TotrinnskontrollTest(
     @Test
     @Tag("integration")
     fun `Skal godkjenne 2 trinnskontroll`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
         val behandling =
             behandlingService.opprettBehandling(nyOrdinærBehandling(fagsakId = fagsak.id))
 
+        // Act
         behandlingService.sendBehandlingTilBeslutter(behandling)
+
+        // Assert
         assertEquals(BehandlingStatus.FATTER_VEDTAK, behandlingHentOgPersisterService.hent(behandling.id).status)
         assertThat(
             saksstatistikkMellomlagringRepository.findByTypeAndTypeId(
@@ -59,10 +63,12 @@ class TotrinnskontrollTest(
                 .behandlingStatus,
         ).isEqualTo(BehandlingStatus.FATTER_VEDTAK.name)
 
+        // Act
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling = behandling)
 
         totrinnskontrollService.besluttTotrinnskontroll(behandling, "Beslutter", "beslutterId", Beslutning.GODKJENT)
 
+        // Assert
         assertEquals(BehandlingStatus.IVERKSETTER_VEDTAK, behandlingHentOgPersisterService.hent(behandling.id).status)
 
         assertThat(
@@ -88,17 +94,24 @@ class TotrinnskontrollTest(
     @Test
     @Tag("integration")
     fun `Skal underkjenne 2 trinnskontroll`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
         val behandling =
             behandlingService.opprettBehandling(nyOrdinærBehandling(fagsakId = fagsak.id))
 
+        // Act
         behandlingService.sendBehandlingTilBeslutter(behandling)
+
+        // Assert
         assertEquals(BehandlingStatus.FATTER_VEDTAK, behandlingHentOgPersisterService.hent(behandling.id).status)
 
+        // Act
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling = behandling)
         totrinnskontrollService.besluttTotrinnskontroll(behandling, "Beslutter", "beslutterId", Beslutning.UNDERKJENT)
+
+        // Assert
         assertEquals(BehandlingStatus.UTREDES, behandlingHentOgPersisterService.hent(behandling.id).status)
         assertThat(
             saksstatistikkMellomlagringRepository.findByTypeAndTypeId(
@@ -122,6 +135,7 @@ class TotrinnskontrollTest(
 
     @Test
     fun `Skal ikke kunne godkjenne eget vedtak`() {
+        // Arrange
         val totrinnskontroll =
             Totrinnskontroll(
                 behandling = lagBehandlingUtenId(),
@@ -132,11 +146,13 @@ class TotrinnskontrollTest(
                 godkjent = true,
             )
 
+        // Act & Assert
         assertTrue(totrinnskontroll.erUgyldig())
     }
 
     @Test
     fun `Skal kunne underkjenne eget vedtak`() {
+        // Arrange
         val totrinnskontroll =
             Totrinnskontroll(
                 behandling = lagBehandlingUtenId(),
@@ -147,6 +163,7 @@ class TotrinnskontrollTest(
                 godkjent = false,
             )
 
+        // Act & Assert
         assertFalse(totrinnskontroll.erUgyldig())
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/VedtakServiceTest.kt
@@ -191,6 +191,7 @@ class VedtakServiceTest(
     @Test
     @Tag("integration")
     fun `Opprett behandling med vedtak`() {
+        // Arrange
         val fnr = randomFnr()
         val barnFnr = randomFnr()
 
@@ -215,6 +216,7 @@ class VedtakServiceTest(
             )
         persongrunnlagService.lagreOgDeaktiverGammel(personopplysningGrunnlag)
 
+        // Act
         behandlingService.opprettOgInitierNyttVedtakForBehandling(behandling = behandling)
 
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(
@@ -229,6 +231,7 @@ class VedtakServiceTest(
             Beslutning.GODKJENT,
         )
 
+        // Assert
         val hentetVedtak = vedtakService.hentAktivForBehandling(behandling.id)
         Assertions.assertNotNull(hentetVedtak)
         Assertions.assertNull(hentetVedtak!!.vedtaksdato)
@@ -245,11 +248,13 @@ class VedtakServiceTest(
     @Test
     @Tag("integration")
     fun `Kast feil når det forsøkes å oppdatere et vedtak som ikke er lagret`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr)
         val behandling = behandlingService.lagreNyOgDeaktiverGammelBehandling(lagBehandlingUtenId(fagsak))
 
+        // Act & Assert
         assertThrows<Feil> {
             vedtakService.oppdater(
                 Vedtak(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/domene/VedtaksperiodeRepositoryTest.kt
@@ -26,6 +26,7 @@ class VedtaksperiodeRepositoryTest(
     inner class FinnBehandlingIdForVedtaksperiode {
         @Test
         fun `skal kunne hente behandlingId til en vedtaksperiode`() {
+            // Arrange
             val søker = aktørIdRepository.save(randomAktør())
             val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
             val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak))
@@ -34,6 +35,7 @@ class VedtaksperiodeRepositoryTest(
             lagVedtaksperiodeMedBegrunnelser.begrunnelser.clear()
             val vedtaksperiode = vedtaksperiodeRepository.save(lagVedtaksperiodeMedBegrunnelser)
 
+            // Act & Assert
             assertThat(vedtaksperiodeRepository.finnBehandlingIdForVedtaksperiode(vedtaksperiode.id))
                 .isEqualTo(behandling.id)
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/feilutbetaltValuta/FeilutbetaltValutaServiceTest.kt
@@ -22,6 +22,7 @@ class FeilutbetaltValutaServiceTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun kanLagreEndreOgSlette() {
+        // Arrange
         val fagsak =
             lagFagsakUtenId(aktør = randomAktør().also { aktørIdRepository.save(it) }).let { fagsakRepository.save(it) }
         val behandling = lagBehandlingUtenId(fagsak = fagsak).let { behandlingHentOgPersisterService.lagreEllerOppdater(it, false) }
@@ -33,14 +34,17 @@ class FeilutbetaltValutaServiceTest(
                 feilutbetaltBeløp = 1234,
             )
 
+        // Act
         val id = feilutbetaltValutaService.leggTilFeilutbetaltValutaPeriode(feilutbetaltValuta = feilutbetaltValuta, behandlingId = behandling.id)
 
+        // Assert
         feilutbetaltValutaService
             .hentFeilutbetaltValutaPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it[0].id).isEqualTo(id) }
             .also { Assertions.assertThat(it[0].fom).isNotNull() }
             .also { Assertions.assertThat(it[0].tom).isNotNull() }
 
+        // Act
         feilutbetaltValutaService.oppdatertFeilutbetaltValutaPeriode(
             feilutbetaltValutaDto =
                 FeilutbetaltValutaDto(
@@ -52,11 +56,13 @@ class FeilutbetaltValutaServiceTest(
             id = id,
         )
 
+        // Assert
         feilutbetaltValutaService
             .hentFeilutbetaltValutaPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it.get(0).id).isEqualTo(id) }
             .also { Assertions.assertThat(it.get(0).tom).isEqualTo("2020-05-31") }
 
+        // Arrange
         val feilutbetaltValuta2 =
             FeilutbetaltValutaDto(
                 id = 0,
@@ -65,15 +71,19 @@ class FeilutbetaltValutaServiceTest(
                 feilutbetaltBeløp = 100,
             )
 
+        // Act
         val id2 = feilutbetaltValutaService.leggTilFeilutbetaltValutaPeriode(feilutbetaltValuta = feilutbetaltValuta2, behandlingId = behandling.id)
 
+        // Assert
         feilutbetaltValutaService
             .hentFeilutbetaltValutaPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it.size).isEqualTo(2) }
             .also { Assertions.assertThat(it.get(0).id).isEqualTo(id2) }
 
+        // Act
         feilutbetaltValutaService.fjernFeilutbetaltValutaPeriode(id = id, behandlingId = behandling.id)
 
+        // Assert
         feilutbetaltValutaService
             .hentFeilutbetaltValutaPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it.size).isEqualTo(1) }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceIT.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceIT.kt
@@ -22,6 +22,7 @@ class RefusjonEøsServiceIT(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun kanLagreEndreOgSlette() {
+        // Arrange
         val fagsak =
             lagFagsakUtenId(aktør = randomAktør().also { aktørIdRepository.save(it) }).let { fagsakRepository.save(it) }
         val behandling =
@@ -36,14 +37,17 @@ class RefusjonEøsServiceIT(
                 refusjonAvklart = true,
             )
 
+        // Act
         val id = refusjonEøsService.leggTilRefusjonEøsPeriode(refusjonEøs = refusjonEøs, behandlingId = behandling.id)
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it[0].id).isEqualTo(id) }
             .also { Assertions.assertThat(it[0].fom).isEqualTo("2020-01-01") }
             .also { Assertions.assertThat(it[0].tom).isEqualTo("2021-05-31") }
 
+        // Act
         refusjonEøsService.oppdaterRefusjonEøsPeriode(
             refusjonEøsDto =
                 RefusjonEøsDto(
@@ -57,6 +61,7 @@ class RefusjonEøsServiceIT(
             id = id,
         )
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it[0].id).isEqualTo(id) }
@@ -65,6 +70,7 @@ class RefusjonEøsServiceIT(
             .also { Assertions.assertThat(it[0].land).isEqualTo("NL") }
             .also { Assertions.assertThat(it[0].refusjonAvklart).isEqualTo(false) }
 
+        // Arrange
         val refusjonEøs2 =
             RefusjonEøsDto(
                 id = 0,
@@ -75,15 +81,19 @@ class RefusjonEøsServiceIT(
                 refusjonAvklart = false,
             )
 
+        // Act
         val id2 = refusjonEøsService.leggTilRefusjonEøsPeriode(refusjonEøs = refusjonEøs2, behandlingId = behandling.id)
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it.size).isEqualTo(2) }
             .also { Assertions.assertThat(it[0].id).isEqualTo(id2) }
 
+        // Act
         refusjonEøsService.fjernRefusjonEøsPeriode(id = id)
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it.size).isEqualTo(1) }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakRepositoryTest.kt
@@ -24,12 +24,14 @@ class SammensattKontrollsakRepositoryTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `save skal kaste feil dersom vi forsøker å lagre ny SammensattKontrollsak og det allerede finnes en SammensattKontrollsak tilknyttet behandling`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak))
 
         sammensattKontrollsakRepository.saveAndFlush(SammensattKontrollsak(behandlingId = behandling.id, fritekst = "Fritekst"))
 
+        // Act & Assert
         assertThrows<DataIntegrityViolationException> { sammensattKontrollsakRepository.saveAndFlush(SammensattKontrollsak(behandlingId = behandling.id, fritekst = "Fritekst")) }
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vedtak/sammensattKontrollsak/SammensattKontrollsakServiceTest.kt
@@ -36,13 +36,17 @@ class SammensattKontrollsakServiceTest(
 
     @Test
     fun `finnSammensattKontrollsak skal returnere SammensattKontrollsak dersom det finnes en SammensattKontrollsak knyttet til behandlingsId`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak))
 
         sammensattKontrollsakRepository.saveAndFlush(SammensattKontrollsak(behandlingId = behandling.id, fritekst = "Fritekst"))
 
+        // Act
         val sammensattKontrollsak = sammensattKontrollsakRepository.finnSammensattKontrollsakForBehandling(behandling.id)
+
+        // Assert
         assertThat(sammensattKontrollsak).isNotNull
         assertThat(sammensattKontrollsak!!.behandlingId).isEqualTo(behandling.id)
         assertThat(sammensattKontrollsak.fritekst).isEqualTo("Fritekst")
@@ -50,12 +54,15 @@ class SammensattKontrollsakServiceTest(
 
     @Test
     fun `opprettSammensattKontrollsak skal opprette SammensattKontrollsak basert på OpprettSammensattKontrollsakDto`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak))
 
+        // Act
         val sammensattKontrollsak = sammensattKontrollsakService.opprettSammensattKontrollsak(OpprettSammensattKontrollsakDto(behandlingId = behandling.id, fritekst = "Fritekst"))
 
+        // Assert
         assertThat(sammensattKontrollsak.behandlingId).isEqualTo(behandling.id)
         assertThat(sammensattKontrollsak.fritekst).isEqualTo("Fritekst")
 
@@ -66,13 +73,17 @@ class SammensattKontrollsakServiceTest(
 
     @Test
     fun `oppdaterSammensattKontrollsak skal oppdatere SammensattKontrollsak basert på SammensattKontrollsakDto`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak))
 
         val eksisterendeSammensattKontrollsak = sammensattKontrollsakService.opprettSammensattKontrollsak(OpprettSammensattKontrollsakDto(behandlingId = behandling.id, fritekst = "Fritekst"))
+
+        // Act
         val oppdatertSammensattKontrollsak = sammensattKontrollsakService.oppdaterSammensattKontrollsak(SammensattKontrollsakDto(id = eksisterendeSammensattKontrollsak.id, behandlingId = behandling.id, fritekst = "Oppdatert fritekst"))
 
+        // Assert
         assertThat(oppdatertSammensattKontrollsak.id).isEqualTo(eksisterendeSammensattKontrollsak.id)
         assertThat(oppdatertSammensattKontrollsak.behandlingId).isEqualTo(behandling.id)
         assertThat(oppdatertSammensattKontrollsak.fritekst).isEqualTo("Oppdatert fritekst")
@@ -85,13 +96,17 @@ class SammensattKontrollsakServiceTest(
 
     @Test
     fun `slettSammensattKontrollsak skal slette SammensattKontrollsak basert på SammensattKontrollsakDto`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandlingUtenId(fagsak = fagsak))
 
         val eksisterendeSammensattKontrollsak = sammensattKontrollsakService.opprettSammensattKontrollsak(OpprettSammensattKontrollsakDto(behandlingId = behandling.id, fritekst = "Fritekst"))
+
+        // Act
         sammensattKontrollsakService.slettSammensattKontrollsak(eksisterendeSammensattKontrollsak.id)
 
+        // Assert
         assertThat(sammensattKontrollsakService.finnSammensattKontrollsak(behandlingId = behandling.id)).isNull()
 
         val loggForBehandling = loggService.hentLoggForBehandling(behandling.id)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AndelTilkjentYtelseOffsetTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AndelTilkjentYtelseOffsetTest.kt
@@ -60,6 +60,7 @@ class AndelTilkjentYtelseOffsetTest(
 
     @Test
     fun `Skal ha riktig offset for andeler når man legger til ny andel`() {
+        // Arrange
         val personScenario1: ScenarioDto = lagScenario(barnFødselsdato)
         val fagsak1: MinimalFagsakDto = lagFagsak(personScenario = personScenario1)
         val behandling1 =
@@ -76,6 +77,7 @@ class AndelTilkjentYtelseOffsetTest(
                 barnFødselsdato = barnFødselsdato,
             )
 
+        // Act
         val andelerBehandling1 = beregningService.hentAndelerTilkjentYtelseForBehandling(behandlingId = behandling1.id)
         val offsetBehandling1 = andelerBehandling1.mapNotNull { it.periodeOffset }.map { it.toInt() }.sorted()
 
@@ -85,6 +87,7 @@ class AndelTilkjentYtelseOffsetTest(
         val nyAndelIBehandling2 = andelerBehandling2.single { it.erSmåbarnstillegg() }
         val forventetOffsetNyAndel = offsetBehandling1.max() + 1
 
+        // Assert
         Assertions.assertEquals(forventetOffsetNyAndel, nyAndelIBehandling2.periodeOffset?.toInt())
 
         // Ønsker at uendrede andeler skal beholde samme offset

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AutobrevSmåbarnstilleggOpphørTest.kt
@@ -48,6 +48,7 @@ class AutobrevSmåbarnstilleggOpphørTest(
 
     @Test
     fun `Plukk riktige behandlinger - skal være nyeste, løpende med opphør i småbarnstillegg for valgt måned`() {
+        // Arrange
         val personScenario1: ScenarioDto = lagScenario(barnFødselsdato)
         val fagsak1: MinimalFagsakDto = lagFagsak(personScenario = personScenario1)
         fullførBehandling(
@@ -79,9 +80,12 @@ class AutobrevSmåbarnstilleggOpphørTest(
                 barnFødselsdato = barnFødselsdato,
             )
 
+        // Act
         val andelerForSmåbarnstilleggFagsak1Behandling2 =
             andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = fagsak2behandling2.id)
         val førsteDagIStønadTomMåned = YearMonth.now().minusMonths(1)
+
+        // Assert
         assertEquals(
             førsteDagIStønadTomMåned,
             andelerForSmåbarnstilleggFagsak1Behandling2
@@ -90,11 +94,13 @@ class AutobrevSmåbarnstilleggOpphørTest(
                 }?.stønadTom,
         )
 
+        // Act
         val fagsaker: List<Long> =
             fagsakRepository.finnAlleFagsakerMedOpphørSmåbarnstilleggIMåned(
                 iverksatteLøpendeBehandlinger = listOf(fagsak1behandling2.id, fagsak2behandling2.id),
             )
 
+        // Assert
         assertTrue(fagsaker.containsAll(listOf(fagsak2.id)))
         assertFalse(fagsaker.contains(fagsak1.id))
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/BehandlingSatsendringTest.kt
@@ -67,6 +67,7 @@ class BehandlingSatsendringTest(
 
     @Test
     fun `Skal kjøre satsendring på løpende fagsak hvor brukeren har barnetrygd under 6 år`() {
+        // Arrange
         val scenario = lagScenario().also { stubScenario(it) }
         val behandling = opprettBehandling(scenario)
         val atyForBehandlingMedGammelSatsFraFørMars2024 =
@@ -86,9 +87,11 @@ class BehandlingSatsendringTest(
         // Fjerner mocking slik at den siste satsendringen vi fjernet via mocking nå skal komme med.
         unmockkObject(SatsTidspunkt)
 
+        // Act
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, hentAktivSatsendringstidspunkt()))
 
+        // Assert
         assertEquals(SatsendringSvar.SATSENDRING_KJØRT_OK, satsendringResultat)
 
         val satsendringBehandling = behandlingHentOgPersisterService.finnAktivForFagsak(fagsakId = behandling.fagsak.id)
@@ -120,15 +123,18 @@ class BehandlingSatsendringTest(
 
     @Test
     fun `Skal ignorere satsendring hvis siste sats alt er satt`() {
+        // Arrange
         // Fjerner mocking slik at den siste satsendringen vi fjernet via mocking nå skal komme med.
         unmockkObject(SatsTidspunkt)
 
         val scenario = lagScenario().also { stubScenario(it) }
         val behandling = opprettBehandling(scenario)
 
+        // Act
         val satsendringResultat =
             autovedtakSatsendringService.kjørBehandling(SatsendringTaskDto(behandling.fagsak.id, hentAktivSatsendringstidspunkt()))
 
+        // Assert
         assertEquals(SatsendringSvar.SATSENDRING_ER_ALLEREDE_UTFØRT, satsendringResultat)
 
         val satskjøring = satskjøringRepository.findByFagsakIdAndSatsTidspunkt(behandling.fagsak.id, satsTidspunkt = hentAktivSatsendringstidspunkt())

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelMedUtvidetAndelTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelMedUtvidetAndelTest.kt
@@ -27,6 +27,7 @@ class EndretUtbetalingAndelMedUtvidetAndelTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal teste at endret utbetalingsandeler for ordinær og utvidet endrer utbetaling for søker og barn`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2022, 10, 15)
 
         val scenario =
@@ -116,6 +117,7 @@ class EndretUtbetalingAndelMedUtvidetAndelTest(
                 erTilknyttetAndeler = true,
             )
 
+        // Act
         familieBaSakKlient().leggTilEndretUtbetalingAndel(
             utvidetBehandlingDtoEtterBehandlingsresultat.behandlingId,
             endretUtbetalingAndelDtoUtvidetBarnetrygd,
@@ -144,6 +146,7 @@ class EndretUtbetalingAndelMedUtvidetAndelTest(
             behandlingId = utvidetBehandlingDtoEtterBehandlingsresultat.behandlingId,
         )
 
+        // Assert
         val andelerTilkjentYtelseMedEndretPeriode =
             andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = utvidetBehandlingDtoEtterBehandlingsresultat.behandlingId)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndretUtbetalingAndelTest.kt
@@ -29,6 +29,7 @@ class EndretUtbetalingAndelTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal teste at endret utbetalingsandel overskriver eksisterende utbetalingsandel`() {
+        // Arrange
         val (scenario, utvidetBehandlingDto) = genererBehandlingsresultat()
 
         val endretFom = YearMonth.of(2021, 9)
@@ -48,11 +49,13 @@ class EndretUtbetalingAndelTest(
                 erTilknyttetAndeler = true,
             )
 
+        // Act
         familieBaSakKlient().leggTilEndretUtbetalingAndel(
             utvidetBehandlingDto.data!!.behandlingId,
             endretUtbetalingAndelDto,
         )
 
+        // Assert
         val andelerTilkjentYtelseMedEndretPeriode =
             andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = utvidetBehandlingDto.data!!.behandlingId)
 
@@ -83,6 +86,7 @@ class EndretUtbetalingAndelTest(
 
     @Test
     fun `Skal teste at fjernet endret utbetalingsandel oppretter tidligere eksisterende utbetalingsandel`() {
+        // Arrange
         val (scenario, utvidetBehandlingDto) = genererBehandlingsresultat()
 
         val endretFom = YearMonth.of(2021, 9)
@@ -114,11 +118,13 @@ class EndretUtbetalingAndelTest(
                 .first()
                 .id
 
+        // Act
         familieBaSakKlient().fjernEndretUtbetalingAndel(
             utvidetBehandlingDto.data!!.behandlingId,
             endretUtbetalingAndelId!!,
         )
 
+        // Assert
         val andelerTilkjentYtelseEtterFjeringAvEndretUtbetaling =
             andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = utvidetBehandlingDto.data!!.behandlingId)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndringstidspunktTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/EndringstidspunktTest.kt
@@ -38,6 +38,7 @@ class EndringstidspunktTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal filtrere bort alle vedtaksperioder før endringstidspunktet`() {
+        // Arrange
         val barnFødselsdato = LocalDate.now().minusYears(2)
         val scenario =
             ScenarioDto(
@@ -116,6 +117,7 @@ class EndringstidspunktTest(
 
         overstyrendeVilkårResultaterRevurdering[scenario.søker.aktørId] = emptyList()
 
+        // Act
         val revurdering =
             kjørStegprosessForBehandling(
                 tilSteg = StegType.BEHANDLING_AVSLUTTET,
@@ -137,6 +139,7 @@ class EndringstidspunktTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         val vedtak = vedtakService.hentAktivForBehandlingThrows(behandlingId = revurdering.id)
         val vedtaksperioder = vedtaksperiodeService.hentPersisterteVedtaksperioder(vedtak)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseFørstegangsbehandlingTest.kt
@@ -38,6 +38,7 @@ class FødselshendelseFørstegangsbehandlingTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal innvilge fødselshendelse på mor med 1 barn født november 2021 og behandles desember 2021 uten utbetalinger`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker = ScenarioPersonDto(fødselsdato = "1996-01-12", fornavn = "Mor", etternavn = "Søker"),
@@ -50,6 +51,8 @@ class FødselshendelseFørstegangsbehandlingTest(
                         ),
                     ),
             ).also { stubScenario(it) }
+
+        // Act
         val behandling =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -66,6 +69,7 @@ class FødselshendelseFørstegangsbehandlingTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         val fagsakDtoEtterBehandlingAvsluttet =
             familieBaSakKlient().hentFagsak(fagsakId = behandling!!.fagsak.id)
         generellAssertFagsak(
@@ -112,6 +116,7 @@ class FødselshendelseFørstegangsbehandlingTest(
 
     @Test
     fun `Skal innvilge fødselshendelse på mor med 2 barn uten utbetalinger`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker = ScenarioPersonDto(fødselsdato = "1996-01-12", fornavn = "Mor", etternavn = "Søker"),
@@ -129,6 +134,8 @@ class FødselshendelseFørstegangsbehandlingTest(
                         ),
                     ),
             ).also { stubScenario(it) }
+
+        // Act
         val behandling =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -145,6 +152,7 @@ class FødselshendelseFørstegangsbehandlingTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         val fagsakDtoEtterBehandlingAvsluttet =
             familieBaSakKlient().hentFagsak(fagsakId = behandling!!.fagsak.id)
         generellAssertFagsak(
@@ -172,6 +180,7 @@ class FødselshendelseFørstegangsbehandlingTest(
 
     @Test
     fun `Skal innvilge fødselshendelse på mor med 2 barn der barna er født i hver sin måned`() {
+        // Arrange
         val fødselsdagBarn2 = LocalDate.now().førsteDagIInneværendeMåned()
         val fødselsdagBarn1 = fødselsdagBarn2.minusDays(1)
 
@@ -194,6 +203,8 @@ class FødselshendelseFørstegangsbehandlingTest(
                         ),
                     ),
             ).also { stubScenario(it) }
+
+        // Act
         val behandling =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -210,6 +221,7 @@ class FødselshendelseFørstegangsbehandlingTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         val fagsakDtoEtterBehandlingAvsluttet =
             familieBaSakKlient().hentFagsak(fagsakId = behandling!!.fagsak.id)
         generellAssertFagsak(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseHenleggelseTest.kt
@@ -77,6 +77,7 @@ class FødselshendelseHenleggelseTest(
 
     @Test
     fun `Skal henlegge fødselshendelse på grunn av at søker er under 18 (filtreringsregel)`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker =
@@ -95,6 +96,7 @@ class FødselshendelseHenleggelseTest(
                     ),
             ).also { stubScenario(it) }
 
+        // Act
         val behandling =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -111,6 +113,7 @@ class FødselshendelseHenleggelseTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         assertEquals(Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE, behandling?.resultat)
         assertEquals(StegType.BEHANDLING_AVSLUTTET, behandling?.steg)
 
@@ -132,6 +135,7 @@ class FødselshendelseHenleggelseTest(
 
     @Test
     fun `Skal henlegge fødselshendelse på grunn av at barn ikke er bosatt i riket og bor ikke med mor (vilkårsvurdering)`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker = ScenarioPersonDto(fødselsdato = "1993-01-12", fornavn = "Mor", etternavn = "Søker"),
@@ -147,6 +151,8 @@ class FødselshendelseHenleggelseTest(
             ).also { stubScenario(it) }
 
         val barnIdent = scenario.barna.first().ident
+
+        // Act
         val behandling =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -163,6 +169,7 @@ class FødselshendelseHenleggelseTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         assertEquals(Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE, behandling?.resultat)
         assertEquals(StegType.BEHANDLING_AVSLUTTET, behandling?.steg)
 
@@ -203,6 +210,7 @@ class FødselshendelseHenleggelseTest(
 
     @Test
     fun `Skal henlegge fødselshendelse på grunn av at mor mottar utvidet barnetrygd (filtreringsregel)`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker =
@@ -254,6 +262,7 @@ class FødselshendelseHenleggelseTest(
             ),
         )
 
+        // Act
         val revurdering =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -270,6 +279,7 @@ class FødselshendelseHenleggelseTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         assertEquals(BehandlingUnderkategori.UTVIDET, revurdering?.underkategori)
         assertEquals(Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE, revurdering?.resultat)
         assertEquals(StegType.BEHANDLING_AVSLUTTET, revurdering?.steg)
@@ -290,6 +300,7 @@ class FødselshendelseHenleggelseTest(
 
     @Test
     fun `Skal henlegge fødselshendelse på grunn av at mor mottar EØS-barnetrygd (filtreringsregel)`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker =
@@ -335,6 +346,7 @@ class FødselshendelseHenleggelseTest(
 
         oppdaterBehandlingOgRegelverkTilEøs(behandling)
 
+        // Act
         val revurdering =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -351,6 +363,7 @@ class FødselshendelseHenleggelseTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         assertEquals(BehandlingKategori.EØS, revurdering?.kategori)
         assertEquals(Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE, revurdering?.resultat)
         assertEquals(StegType.BEHANDLING_AVSLUTTET, revurdering?.steg)
@@ -371,6 +384,7 @@ class FødselshendelseHenleggelseTest(
 
     @Test
     fun `Skal sende tredjelandsborgere fra Ukraina til manuel oppfølging (midlertidig regel for ukrainakonflikten)`() {
+        // Arrange
         val fødselsdato = "1993-01-12"
         val barnFødselsdato = now()
         val scenario =
@@ -406,6 +420,8 @@ class FødselshendelseHenleggelseTest(
                         ),
                     ),
             ).also { stubScenario(it) }
+
+        // Act
         val behandling =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -422,6 +438,7 @@ class FødselshendelseHenleggelseTest(
                 brevmalService = brevmalService,
             )!!
 
+        // Assert
         assertEquals(Behandlingsresultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE, behandling.resultat)
         assertEquals(StegType.BEHANDLING_AVSLUTTET, behandling.steg)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseRevurderingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/FødselshendelseRevurderingTest.kt
@@ -34,6 +34,7 @@ class FødselshendelseRevurderingTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal innvilge fødselshendelse på mor med 1 barn med eksisterende utbetalinger`() {
+        // Arrange
         val revurderingsbarnSinFødselsdato = now().minusMonths(3)
         val scenario =
             ScenarioDto(
@@ -70,6 +71,8 @@ class FødselshendelseRevurderingTest(
 
         val søkerIdent = scenario.søker.ident
         val vurdertBarn = scenario.barna.maxByOrNull { it.fødselsdato }!!.ident
+
+        // Act
         val behandling =
             behandleFødselshendelse(
                 nyBehandlingHendelse =
@@ -87,6 +90,7 @@ class FødselshendelseRevurderingTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         val fagsakDtoEtterBehandlingAvsluttet =
             familieBaSakKlient().hentFagsak(fagsakId = behandling!!.fagsak.id)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/HenleggelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/HenleggelseTest.kt
@@ -54,8 +54,10 @@ class HenleggelseTest(
 
     @Test
     fun `Opprett behandling, henlegg behandling feilaktig opprettet og opprett behandling på nytt`() {
+        // Arrange
         val førsteBehandling = opprettBehandlingOgRegistrerSøknad(scenarioDto)
 
+        // Act
         val responseHenlagtSøknad =
             familieBaSakKlient().henleggSøknad(
                 førsteBehandling.behandlingId,
@@ -65,6 +67,7 @@ class HenleggelseTest(
                 ),
             )
 
+        // Assert
         generellAssertUtvidetBehandlingDto(
             utvidetBehandlingDto = responseHenlagtSøknad,
             behandlingStatus = BehandlingStatus.AVSLUTTET,
@@ -88,7 +91,10 @@ class HenleggelseTest(
 
     @Test
     fun `Opprett behandling, hent forhåndsvising av brev, henlegg behandling søknad trukket`() {
+        // Arrange
         val førsteBehandling = opprettBehandlingOgRegistrerSøknad(scenarioDto)
+
+        // Act
 
         /**
          * Denne forhåndsvisningen går ikke til sanity for øyeblikket, men det er en mulighet å legge til
@@ -113,6 +119,7 @@ class HenleggelseTest(
                 ),
             )
 
+        // Assert
         generellAssertUtvidetBehandlingDto(
             utvidetBehandlingDto = responseHenlagtSøknad,
             behandlingStatus = BehandlingStatus.AVSLUTTET,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/OpplysningspliktTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/OpplysningspliktTest.kt
@@ -46,6 +46,7 @@ class OpplysningspliktTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal opprette opplysningsplikt-vilkår på søker når 'innhente opplysninger'-brev sendes ut og ta med hjemmel 17 og 18 i vedtaksbrev når opplysningsplikt-vilkåret ikke er oppfylt`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker = ScenarioPersonDto(fødselsdato = "1990-04-20", fornavn = "Mor", etternavn = "Søker"),
@@ -74,6 +75,7 @@ class OpplysningspliktTest(
             )
 
         // Send "innhente opplysninger"-brev og sjekk at opplysningsplikt vilkåret dukker opp på _kun_ søker
+        // Act
         dokumentService.sendManueltBrev(
             fagsakId = behandling.fagsak.id,
             manueltBrevRequest =
@@ -101,6 +103,7 @@ class OpplysningspliktTest(
                 ?.filter { !it.erSøkersResultater() }
                 ?.flatMap { it.andreVurderinger.filter { it.type == AnnenVurderingType.OPPLYSNINGSPLIKT } } ?: emptyList()
 
+        // Assert
         Assertions.assertTrue(opplysningspliktVilkårPåSøker != null)
         Assertions.assertTrue(opplysningspliktVilkårPåBarna.isEmpty())
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/ReduksjonFraForrigeIverksatteBehandlingTest.kt
@@ -61,6 +61,7 @@ class ReduksjonFraForrigeIverksatteBehandlingTest(
 
     @Test
     fun `Skal lage reduksjon fra sist iverksatte behandling-periode når småbarnstillegg blir borte`() {
+        // Arrange
         val personScenario: ScenarioDto = lagScenario(barnFødselsdato)
         val fagsak: MinimalFagsakDto = lagFagsak(personScenario)
 
@@ -91,6 +92,7 @@ class ReduksjonFraForrigeIverksatteBehandlingTest(
             perioderBehandling1.filter { utvidetVedtaksperiodeMedBegrunnelser -> utvidetVedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.any { it.ytelseType == YtelseType.SMÅBARNSTILLEGG } }.size,
         )
 
+        // Act
         val behandling2 =
             fullførRevurderingUtenOvergangstonad(
                 fagsak = fagsak,
@@ -104,6 +106,7 @@ class ReduksjonFraForrigeIverksatteBehandlingTest(
         val periodeMedReduksjon =
             perioderBehandling2.singleOrNull { it.type == Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING }
 
+        // Assert
         Assertions.assertEquals(
             0,
             perioderBehandling2.filter { it.utbetalingsperiodeDetaljer.any { it.ytelseType == YtelseType.SMÅBARNSTILLEGG } }.size,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RestartAvSmåbarnstilleggTest.kt
@@ -73,6 +73,7 @@ class RestartAvSmåbarnstilleggTest(
 
     @Test
     fun `Skal finne alle fagsaker hvor småbarnstillegg starter opp igjen inneværende måned, og ikke er begrunnet`() {
+        // Arrange
         val restartSmåbarnstilleggMåned = LocalDate.now().plusMonths(4)
 
         // Fagsak 1 - har åpen behandling og skal ikke tas med
@@ -166,9 +167,11 @@ class RestartAvSmåbarnstilleggTest(
                 ),
         )
 
+        // Act
         val fagsaker: List<Long> =
             restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned(måned = restartSmåbarnstilleggMåned.toYearMonth())
 
+        // Assert
         Assertions.assertTrue(fagsaker.containsAll(listOf(fagsak2.id)))
         Assertions.assertFalse(fagsaker.contains(fagsak1.id))
         Assertions.assertFalse(fagsaker.contains(fagsak3.id))
@@ -178,6 +181,7 @@ class RestartAvSmåbarnstilleggTest(
     @Test
     @Disabled("TODO denne er ustabil i main og trenger å fikses. Sikkert pga månedskifte. Sees på senere")
     fun `Skal finne en fagsak hvor småbarnstillegg starter opp igjen inneværende måned selv om det er utført satsendring`() {
+        // Arrange
         val satsendringDato = SatsService.finnSisteSatsFor(SatsType.SMA).gyldigFom.toYearMonth()
 
         val senesteSatsTidspunkt = LocalDate.of(2022, 12, 1)
@@ -220,14 +224,17 @@ class RestartAvSmåbarnstilleggTest(
         // satsendring gjør at den får en ny andel på småbarnstillegg med gyldig fom satsendringsdatoen
         fullførSatsendring(fagsakMedSatsendringOgSmåbarnstilleggSomSkalRestartes.id, satsendringDato)
 
+        // Act
         val fagsaker: List<Long> =
             restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned(måned = satsendringDato)
 
+        // Assert
         Assertions.assertTrue(fagsaker.contains(fagsakMedSatsendringOgSmåbarnstilleggSomSkalRestartes.id))
     }
 
     @Test
     fun `Satsendring skal ikke restarte småbarnstillegg på allerede løpende småbarnstillegg`() {
+        // Arrange
         val satsendringDato = SatsService.finnSisteSatsFor(SatsType.SMA).gyldigFom.toYearMonth()
 
         mockkObject(SatsTidspunkt)
@@ -264,9 +271,11 @@ class RestartAvSmåbarnstilleggTest(
         // satsendring gjør at den får en ny andel på småbarnstillegg med gyldig fom satsendringsdatoen
         fullførSatsendring(fagsakMedSatsendringOgSmåbarnstilleggSomIkkeSkalRestartes.id, satsendringDato)
 
+        // Act
         val fagsaker: List<Long> =
             restartAvSmåbarnstilleggService.finnAlleFagsakerMedRestartetSmåbarnstilleggIMåned(måned = satsendringDato)
 
+        // Assert
         Assertions.assertFalse(fagsaker.contains(fagsakMedSatsendringOgSmåbarnstilleggSomIkkeSkalRestartes.id))
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingDødsfallTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingDødsfallTest.kt
@@ -43,6 +43,7 @@ class RevurderingDødsfallTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Dødsfall bruker skal kjøre gjennom`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker =
@@ -96,6 +97,7 @@ class RevurderingDødsfallTest(
                 ),
             )
 
+        // Act
         val behandlingDødsfall =
             kjørStegprosessForBehandling(
                 tilSteg = StegType.BEHANDLING_AVSLUTTET,
@@ -113,6 +115,7 @@ class RevurderingDødsfallTest(
                 brevmalService = brevmalService,
             )
 
+        // Assert
         val fagsakDtoEtterBehandlingAvsluttet =
             familieBaSakKlient().hentFagsak(fagsakId = behandlingDødsfall.fagsak.id)
 
@@ -126,6 +129,7 @@ class RevurderingDødsfallTest(
 
     @Test
     fun `Dødsfall bruker skal stoppes dersom ikke bosatt i riket er stoppet før dagens dato`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker =
@@ -162,6 +166,7 @@ class RevurderingDødsfallTest(
         val overstyrendeVilkårResultater =
             (scenario.barna + scenario.søker).associate { it.aktørId to emptyList<VilkårResultat>() }.toMutableMap()
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             kjørStegprosessForBehandling(
                 tilSteg = StegType.BEHANDLINGSRESULTAT,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/RevurderingMedEndredeUtbetalingandelerTest.kt
@@ -68,6 +68,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Endrede utbetalingsandeler fra forrige behandling kopieres riktig og oppdaterer andel med riktig beløp`() {
+        // Arrange
         val scenario =
             ScenarioDto(
                 søker =
@@ -127,6 +128,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
                 forrigeBehandlingSomErVedtatt = iverksattFørstegangsbehandling,
             )
 
+        // Act
         gjennomførVilkårsvurdering(
             vilkårsvurdering = vilkårsvurderingRevurdering,
             behandling = behandlingRevurdering,
@@ -141,6 +143,7 @@ class RevurderingMedEndredeUtbetalingandelerTest(
             )
         val andelerPåvirketAvEndringer = andelerTilkjentYtelse.filter { it.prosent == BigDecimal.ZERO }
 
+        // Assert
         assertEquals(1, kopierteEndredeUtbetalingAndeler.size)
 
         assertThat(andelerPåvirketAvEndringer).allSatisfy { andel ->

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TekniskEndringAvFødselshendelseTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TekniskEndringAvFødselshendelseTest.kt
@@ -41,6 +41,7 @@ class TekniskEndringAvFødselshendelseTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Skal teknisk opphøre fødselshendelse`() {
+        // Arrange
         System.setProperty(FeatureToggle.TEKNISK_ENDRING.navn, "true")
 
         val scenario =
@@ -71,6 +72,7 @@ class TekniskEndringAvFødselshendelseTest(
                 brevmalService = brevmalService,
             )!!
 
+        // Act
         val utvidetBehandlingDto =
             familieBaSakKlient().opprettBehandling(
                 behandlingType = BehandlingType.TEKNISK_ENDRING,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TriggingAvAutobrevOmregningPgaAlderTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/TriggingAvAutobrevOmregningPgaAlderTest.kt
@@ -45,14 +45,20 @@ class TriggingAvAutobrevOmregningPgaAlderTest(
 ) : AbstractVerdikjedetest() {
     @Test
     fun `Omregning og autobrev skal ikke kjøre hvis behandling er begrunnet for 18 åringer`() {
+        // Act
         val behandlinger = kjørFørstegangsbehandlingOgTriggAutobrev(Standardbegrunnelse.REDUKSJON_UNDER_18_ÅR)
+
+        // Assert
         assertThat(behandlinger).hasSize(1)
         assertThat(behandlinger.filter { it.opprettetÅrsak == BehandlingÅrsak.SØKNAD }).hasSize(1)
     }
 
     @Test
     fun `Omregning og autobrev skal kjøre hvis behandling IKKE er begrunnet for 18 åringer`() {
+        // Act
         val behandlinger = kjørFørstegangsbehandlingOgTriggAutobrev(null)
+
+        // Assert
         assertThat(behandlinger.size).isEqualTo(2)
         assertThat(behandlinger.filter { it.opprettetÅrsak == BehandlingÅrsak.SØKNAD }).hasSize(1)
         assertThat(behandlinger.filter { it.opprettetÅrsak == BehandlingÅrsak.OMREGNING_18ÅR }).hasSize(1)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingFlyttResultaterTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/vilkårsvurdering/VilkårsvurderingFlyttResultaterTest.kt
@@ -46,6 +46,7 @@ class VilkårsvurderingFlyttResultaterTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun `Skal ikke endre på forrige behandling sin vilkårsvurdering ved flytting av resultater`() {
+        // Arrange
         val søker = lagPerson(type = PersonType.SØKER)
         val barn1Fnr = leggTilPersonInfo(randomBarnFødselsdato(alder = 6))
         val barn1Aktør = personidentService.hentAktør(barn1Fnr)
@@ -131,6 +132,7 @@ class VilkårsvurderingFlyttResultaterTest(
         val vilkårsvurderingFraForrigeBehandlingFørNyRevurdering =
             vilkårsvurderingService.hentAktivForBehandling(behandlingId = førstegangsbehandling.id)
 
+        // Act
         // Lager revurdering når utvidet ikke løper, så underkategorien er ordinær
         kjørStegprosessForBehandling(
             tilSteg = StegType.REGISTRERE_PERSONGRUNNLAG,
@@ -148,6 +150,7 @@ class VilkårsvurderingFlyttResultaterTest(
             brevmalService = brevmalService,
         )
 
+        // Assert
         // Sjekker at vilkårsvurderingen fra forrige behandling ikke er endret
         val vilkårsvurderingFraForrigeBehandlingEtterNyRevurdering =
             vilkårsvurderingService.hentAktivForBehandling(behandlingId = førstegangsbehandling.id)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/RolletilgangTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/RolletilgangTest.kt
@@ -46,6 +46,7 @@ class RolletilgangTest(
 ) : WebSpringAuthTestRunner() {
     @Test
     fun `Skal kaste feil når innlogget veileder prøver å opprette fagsak gjennom rest-endepunkt`() {
+        // Arrange
         val fnr = randomFnr()
 
         val header = HttpHeaders()
@@ -69,6 +70,7 @@ class RolletilgangTest(
                 header,
             )
 
+        // Act & Assert
         val error =
             assertThrows<HttpClientErrorException> {
                 restClient
@@ -80,6 +82,7 @@ class RolletilgangTest(
                     .body<Ressurs<MinimalFagsakDto>>()
             }
 
+        // Assert
         val ressurs: Ressurs<MinimalFagsakDto> = jsonMapper.readValue(error.responseBodyAsString)
 
         assertEquals(HttpStatus.FORBIDDEN, error.statusCode)
@@ -92,6 +95,7 @@ class RolletilgangTest(
 
     @Test
     fun `Skal få 201 når innlogget saksbehandler prøver å opprette fagsak gjennom rest-endepunkt, tester også db-tilgangskontroll`() {
+        // Arrange
         val fnr = randomFnr()
 
         val header = HttpHeaders()
@@ -106,6 +110,7 @@ class RolletilgangTest(
             ),
         )
 
+        // Act
         val response =
             restClient
                 .post()
@@ -120,12 +125,14 @@ class RolletilgangTest(
                 ).retrieve()
                 .toEntity<Ressurs<MinimalFagsakDto>>()
 
+        // Assert
         assertEquals(HttpStatus.CREATED, response.statusCode)
         assertEquals(Ressurs.Status.SUKSESS, response.body!!.status)
     }
 
     @Test
     fun `Skal kaste feil når innlogget veileder prøver å opprette behandling gjennom test-rest-endepunkt som validerer på db-nivå`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsak(FagsakRequest(personIdent = fnr))
@@ -147,6 +154,7 @@ class RolletilgangTest(
                 header,
             )
 
+        // Act & Assert
         val error =
             assertThrows<HttpClientErrorException> {
                 restClient
@@ -158,6 +166,7 @@ class RolletilgangTest(
                     .body<Ressurs<MinimalFagsakDto>>()
             }
 
+        // Assert
         val ressurs: Ressurs<Behandling> = jsonMapper.readValue(error.responseBodyAsString)
 
         assertEquals(HttpStatus.FORBIDDEN, error.statusCode)
@@ -170,6 +179,7 @@ class RolletilgangTest(
 
     @Test
     fun `Skal kaste feil når innlogget saksbehandler prøver å kalle på et forvalterendepunkt`() {
+        // Arrange
         val header = HttpHeaders()
         header.contentType = MediaType.APPLICATION_JSON
         header.setBearerAuth(
@@ -189,6 +199,7 @@ class RolletilgangTest(
                 header,
             )
 
+        // Act & Assert
         val error =
             assertThrows<HttpClientErrorException> {
                 restClient
@@ -200,6 +211,7 @@ class RolletilgangTest(
                     .body<Ressurs<MinimalFagsakDto>>()
             }
 
+        // Assert
         val ressurs: Ressurs<Fagsak> = jsonMapper.readValue(error.responseBodyAsString)
 
         assertEquals(HttpStatus.FORBIDDEN, error.statusCode)
@@ -212,6 +224,7 @@ class RolletilgangTest(
 
     @Test
     fun `Skal få 200 OK når innlogget forvalter prøver å kalle på et forvalterendepunkt`() {
+        // Arrange
         val header = HttpHeaders()
         header.contentType = MediaType.APPLICATION_JSON
         header.setBearerAuth(
@@ -232,6 +245,7 @@ class RolletilgangTest(
                 header,
             )
 
+        // Act
         val response =
             restClient
                 .post()
@@ -241,6 +255,7 @@ class RolletilgangTest(
                 .retrieve()
                 .toEntity(String::class.java)
 
+        // Assert
         assertEquals(HttpStatus.OK, response.statusCode)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/sikkerhet/TilgangControllerTest.kt
@@ -20,6 +20,7 @@ class TilgangControllerTest(
 ) : AbstractSpringIntegrationTest() {
     @Test
     fun testHarTilgangTilKode6Person() {
+        // Arrange
         val fødselsdato = LocalDate.now()
         val fnr =
             leggTilPersonInfo(
@@ -29,7 +30,10 @@ class TilgangControllerTest(
 
         fakeFamilieIntegrasjonerTilgangskontrollKlient.leggTilTilganger(listOf(Tilgang(fnr, true)))
 
+        // Act
         val response = tilgangController.hentTilgangOgDiskresjonskode(TilgangRequestDTO(fnr))
+
+        // Assert
         val tilgangDTO = response.body?.data ?: throw Feil("Fikk ikke forventet respons")
         assertThat(tilgangDTO.adressebeskyttelsegradering).isEqualTo(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)
         assertThat(tilgangDTO.saksbehandlerHarTilgang).isEqualTo(true)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
@@ -68,6 +68,7 @@ class SaksstatistikkTest(
     @Test
     @Tag("integration")
     fun `Skal lagre saksstatistikk sak til repository, sende meldinger og slette melding fra mellomlagring etter sending`() {
+        // Arrange
         val fnr = randomFnr()
         val fagsakId =
             fagsakController
@@ -78,6 +79,7 @@ class SaksstatistikkTest(
 
         val mellomlagredeStatistikkHendelser = saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SAK, fagsakId)
 
+        // Assert
         assertEquals(1, mellomlagredeStatistikkHendelser.size)
         assertEquals(SAK, mellomlagredeStatistikkHendelser.first().type)
         assertNull(mellomlagredeStatistikkHendelser.first().konvertertTidspunkt)
@@ -90,8 +92,10 @@ class SaksstatistikkTest(
         val lagretJsonSomSakDVH: SakDVH =
             sakstatistikkObjectMapper.readValue(mellomlagredeStatistikkHendelser.first().json, SakDVH::class.java)
 
+        // Act
         saksstatistikkScheduler.sendSaksstatistikk()
 
+        // Assert
         assertNull(saksstatistikkMellomlagringRepository.findByIdOrNull(mellomlagredeStatistikkHendelser.first().id))
         assertEquals(lagretJsonSomSakDVH, sendteMeldinger["sak-$fagsakId"] as SakDVH)
     }
@@ -99,6 +103,7 @@ class SaksstatistikkTest(
     @Test
     @Tag("integration")
     fun `Skal lagre saksstatistikk behandling til repository, sende meldinger og slette melding fra mellomlagring etter sending`() {
+        // Arrange
         val fnr = randomFnr()
 
         val fagsak = fagsakService.hentEllerOpprettFagsakForPersonIdent(fnr, false)
@@ -113,6 +118,8 @@ class SaksstatistikkTest(
 
         val mellomlagretBehandling =
             saksstatistikkMellomlagringRepository.findByTypeAndTypeId(BEHANDLING, behandling.id)
+
+        // Assert
         assertEquals(2, mellomlagretBehandling.size)
         assertNull(mellomlagretBehandling.first().konvertertTidspunkt)
         assertNull(mellomlagretBehandling.first().sendtTidspunkt)
@@ -126,8 +133,10 @@ class SaksstatistikkTest(
         val lagretJsonSomSakDVH: BehandlingDVH =
             sakstatistikkObjectMapper.readValue(mellomlagretBehandling.last().json, BehandlingDVH::class.java)
 
+        // Act
         saksstatistikkScheduler.sendSaksstatistikk()
 
+        // Assert
         assertNull(saksstatistikkMellomlagringRepository.findByIdOrNull(mellomlagretBehandling.first().id))
         assertEquals(lagretJsonSomSakDVH, sendteMeldinger["behandling-${behandling.id}"] as BehandlingDVH)
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/TaskTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/TaskTest.kt
@@ -20,6 +20,7 @@ class TaskTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `Tasker skal ha unikt navn`() {
+        // Act
         val taskTyper: List<String> =
             tasker
                 .stream()
@@ -30,6 +31,7 @@ class TaskTest : AbstractSpringIntegrationTest() {
                     Collectors.toList<String>(),
                 )
 
+        // Assert
         Assertions.assertEquals(tasker.size, taskTyper.distinct().size)
     }
 
@@ -47,6 +49,7 @@ class TaskTest : AbstractSpringIntegrationTest() {
 
     @Test
     fun `doTask skal ha annotasjon WithSpan for bedre tracing`() {
+        // Act
         val taskerUtenWithSpan =
             tasker.mapNotNull { task ->
                 val doTaskMethod =
@@ -60,6 +63,7 @@ class TaskTest : AbstractSpringIntegrationTest() {
                 }
             }
 
+        // Assert
         assertTrue(taskerUtenWithSpan.isEmpty(), taskerUtenWithSpan.joinToString("\n"))
     }
 


### PR DESCRIPTION
### 📮 Favro: NAV-30008

### 💰 Hva skal gjøres, og hvorfor?

Legger til `// Arrange`, `// Act` og `// Assert`-kommentarer i testene våre, slik at hele testsuiten følger konvensjonen som allerede er dokumentert i `AGENTS.md`.

Før: 187 av 457 testfiler fulgte konvensjonen.
Etter: **441 av 457 (96,5 %)**.

**238 filer endret, 3803 innsettinger, 26 slettinger.**

Endringene er rene kommentar-innsettinger. Ingen testlogikk er endret. De 26 slettingene er gjennomgått enkeltvis:
- 21 er omdøping fra `// Given/When/Then` til `// Arrange/Act/Assert` i `OpprettOppgaveTaskTest` og `InstitusjonServiceIntegrasjonTest`, slik at de følger samme konvensjon som resten (414 filer bruker `// Arrange`)
- 3 er linjeflytting og fjerning av doble blanklinjer
- 2 er i `ManueltBrevRequestTest` — en kjedet `.tilBrev(...)` er splittet i `val brevRequest` + et eget act-kall, slik at testen får et tydelig Act-steg. Semantisk identisk, men den eneste endringen som går utover ren kommentar-innsetting.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

