### PR TITLE
NAV-22519: Vis deployet branch i preprod

### DIFF
--- a/.github/workflows/manual-deploy-dev.yaml
+++ b/.github/workflows/manual-deploy-dev.yaml
@@ -87,8 +87,7 @@ jobs:
         needs.verdikjedetest-feature-toggle-av.result == 'success' &&
         needs.verdikjedetest-feature-toggle-paa.result == 'success'
       ))
-    # TODO NAV-22519: sett tilbake til @main før merge
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@NAV-22519_eksponer_deployet_branch # ratchet:exclude
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp

--- a/.github/workflows/manual-deploy-dev.yaml
+++ b/.github/workflows/manual-deploy-dev.yaml
@@ -87,7 +87,8 @@ jobs:
         needs.verdikjedetest-feature-toggle-av.result == 'success' &&
         needs.verdikjedetest-feature-toggle-paa.result == 'success'
       ))
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
+    # TODO NAV-22519: sett tilbake til @main før merge
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@NAV-22519_eksponer_deployet_branch # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp

--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -146,6 +146,10 @@ spec:
       value: preprod
     - name: JDK_JAVA_OPTIONS
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+    - name: APP_VERSION
+      value: {{ VERSION }}
+    - name: APP_BRANCH
+      value: {{ BRANCH }}
   kafka:
     pool: nav-dev
   strategy:

--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -147,9 +147,9 @@ spec:
     - name: JDK_JAVA_OPTIONS
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
     - name: APP_VERSION
-      value: {{ VERSION }}
+      value: "{{ VERSION }}"
     - name: APP_BRANCH
-      value: {{ BRANCH }}
+      value: "{{ BRANCH }}"
   kafka:
     pool: nav-dev
   strategy:

--- a/src/main/kotlin/no/nav/familie/ba/sak/internal/PreprodController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/internal/PreprodController.kt
@@ -6,10 +6,12 @@ import no.nav.familie.ba.sak.config.featureToggle.miljø.Profil
 import no.nav.familie.ba.sak.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Profile
 import org.springframework.core.env.Environment
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -25,7 +27,12 @@ class PreprodController(
     private val environment: Environment,
     @Qualifier("shortCache")
     private val shortCacheManager: CacheManager,
+    @Value("\${APP_BRANCH:ukjent}") private val branch: String,
+    @Value("\${APP_VERSION:ukjent}") private val versjon: String,
 ) {
+    @GetMapping("/versjonsinfo")
+    fun hentVersjonsinfo(): ResponseEntity<Ressurs<VersjonsinfoDto>> = ResponseEntity.ok(Ressurs.success(VersjonsinfoDto(branch = branch, versjon = versjon)))
+
     @PutMapping(path = ["/{behandlingId}/fyll-ut-vilkarsvurdering"])
     fun settFomPåTommeVilkårTilFødselsdato(
         @PathVariable behandlingId: Long,
@@ -59,3 +66,8 @@ class PreprodController(
         return ResponseEntity.ok("Personopplysninger-cache er tømt")
     }
 }
+
+data class VersjonsinfoDto(
+    val branch: String,
+    val versjon: String,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerTest.kt
@@ -8,23 +8,41 @@ import org.springframework.cache.CacheManager
 import org.springframework.core.env.Environment
 
 class PreprodControllerTest {
-    private val preprodController =
-        PreprodController(
-            testVerktøyService = mockk<TestVerktøyService>(),
-            tilgangService = mockk<TilgangService>(),
-            environment = mockk<Environment>(),
-            shortCacheManager = mockk<CacheManager>(),
-            branch = "NAV-22519_min_branch",
-            versjon = "familie-ba-sak:abc123",
-        )
+    private fun lagPreprodController(
+        branch: String,
+        versjon: String,
+    ) = PreprodController(
+        testVerktøyService = mockk<TestVerktøyService>(),
+        tilgangService = mockk<TilgangService>(),
+        environment = mockk<Environment>(),
+        shortCacheManager = mockk<CacheManager>(),
+        branch = branch,
+        versjon = versjon,
+    )
 
     @Test
     fun `skal returnere deployet branch og versjon`() {
+        // Arrange
+        val preprodController = lagPreprodController(branch = "NAV-22519_min_branch", versjon = "familie-ba-sak:abc123")
+
         // Act
         val respons = preprodController.hentVersjonsinfo()
 
         // Assert
         assertThat(respons.body?.data?.branch).isEqualTo("NAV-22519_min_branch")
         assertThat(respons.body?.data?.versjon).isEqualTo("familie-ba-sak:abc123")
+    }
+
+    @Test
+    fun `skal returnere ukjent når branch og versjon ikke er satt som miljøvariabler`() {
+        // Arrange
+        val preprodController = lagPreprodController(branch = "ukjent", versjon = "ukjent")
+
+        // Act
+        val respons = preprodController.hentVersjonsinfo()
+
+        // Assert
+        assertThat(respons.body?.data?.branch).isEqualTo("ukjent")
+        assertThat(respons.body?.data?.versjon).isEqualTo("ukjent")
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerTest.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ba.sak.internal
+
+import io.mockk.mockk
+import no.nav.familie.ba.sak.sikkerhet.TilgangService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cache.CacheManager
+import org.springframework.core.env.Environment
+
+class PreprodControllerTest {
+    private val preprodController =
+        PreprodController(
+            testVerktøyService = mockk<TestVerktøyService>(),
+            tilgangService = mockk<TilgangService>(),
+            environment = mockk<Environment>(),
+            shortCacheManager = mockk<CacheManager>(),
+            branch = "NAV-22519_min_branch",
+            versjon = "familie-ba-sak:abc123",
+        )
+
+    @Test
+    fun `skal returnere deployet branch og versjon`() {
+        // Act
+        val respons = preprodController.hentVersjonsinfo()
+
+        // Assert
+        assertThat(respons.body?.data?.branch).isEqualTo("NAV-22519_min_branch")
+        assertThat(respons.body?.data?.versjon).isEqualTo("familie-ba-sak:abc123")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ba/sak/internal/PreprodControllerTest.kt
@@ -32,17 +32,4 @@ class PreprodControllerTest {
         assertThat(respons.body?.data?.branch).isEqualTo("NAV-22519_min_branch")
         assertThat(respons.body?.data?.versjon).isEqualTo("familie-ba-sak:abc123")
     }
-
-    @Test
-    fun `skal returnere ukjent når branch og versjon ikke er satt som miljøvariabler`() {
-        // Arrange
-        val preprodController = lagPreprodController(branch = "ukjent", versjon = "ukjent")
-
-        // Act
-        val respons = preprodController.hentVersjonsinfo()
-
-        // Assert
-        assertThat(respons.body?.data?.branch).isEqualTo("ukjent")
-        assertThat(respons.body?.data?.versjon).isEqualTo("ukjent")
-    }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-22519

### 💰 Hva skal gjøres, og hvorfor?
Viser hvilken branch som er deployet i preprod, slik at testere vet hva de tester.

- `.nais/app-dev.yaml`: eksponerer `APP_VERSION` og `APP_BRANCH` fra nais-variablene.
- `PreprodController`: nytt endepunkt `GET /api/preprod/versjonsinfo` som returnerer branch og versjon. Kontrolleren er allerede `@Profile("!prod")`, så endepunktet finnes ikke i prod. Verdiene defaulter til `ukjent` lokalt.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.
