### PR TITLE
Parallelliser testkjøring med forks og fiks rekkefølgeavhengige spørringer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
         <maven.model.version>3.9.16</maven.model.version>
         <avro.version>1.12.1</avro.version>
         <confluent.version>8.2.1</confluent.version>
+        <!-- Testrigg: kan overstyres per kjøring, f.eks. -Dsurefire.forkCount=1 -->
+        <surefire.forkCount>2</surefire.forkCount>
+        <surefire.maxRamPercentage>35</surefire.maxRamPercentage>
         <sonar.organization>navikt</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.sources>src/main</sonar.sources>
@@ -559,11 +562,14 @@
                 <version>3.5.4</version>
                 <configuration>
                     <!-- Trenger argline for å få injected javaagent for kover -->
-                    <argLine>@{argLine} -XX:MinRAMPercentage=25 -XX:MaxRAMPercentage=75</argLine>
+                    <!-- MaxRAMPercentage gjelder per fork, og settes lavt fordi et mindre heap gir
+                         raskere GC-sykluser og bedre cache-lokalitet enn et stort, latvoksende heap -->
+                    <argLine>@{argLine} -XX:MinRAMPercentage=25 -XX:MaxRAMPercentage=${surefire.maxRamPercentage}</argLine>
+                    <!-- Hver fork får egen JVM, egen Spring-context og egen databasecontainer -->
+                    <forkCount>${surefire.forkCount}</forkCount>
                     <!-- exclude tags -->
                     <!--suppress UnresolvedMavenProperty -->
                     <excludedGroups>${excludedGroups}</excludedGroups>
-                    <threadCount>1</threadCount>
                     <runOrder>random</runOrder>
                 </configuration>
             </plugin>

--- a/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/domene/SaksstatistikkMellomlagringRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/domene/SaksstatistikkMellomlagringRepository.kt
@@ -6,10 +6,10 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface SaksstatistikkMellomlagringRepository : JpaRepository<SaksstatistikkMellomlagring, Long> {
-    @Query(value = "SELECT s FROM SaksstatistikkMellomlagring s WHERE s.sendtTidspunkt IS NULL")
+    @Query(value = "SELECT s FROM SaksstatistikkMellomlagring s WHERE s.sendtTidspunkt IS NULL ORDER BY s.id ASC")
     fun finnMeldingerKlarForSending(): List<SaksstatistikkMellomlagring>
 
-    fun findByTypeAndTypeId(
+    fun findByTypeAndTypeIdOrderByIdAsc(
         type: SaksstatistikkMellomlagringType,
         typeId: Long,
     ): List<SaksstatistikkMellomlagring>

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/fagsak/FagsakDeltagerServiceIntegrationTest.kt
@@ -230,7 +230,7 @@ class FagsakDeltagerServiceIntegrationTest(
         assertEquals(
             FagsakStatus.OPPRETTET.name,
             saksstatistikkMellomlagringRepository
-                .findByTypeAndTypeId(SAK, fagsak.id)
+                .findByTypeAndTypeIdOrderByIdAsc(SAK, fagsak.id)
                 .last()
                 .jsonToSakDVH()
                 .sakStatus,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/totrinnskontroll/TotrinnskontrollTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/totrinnskontroll/TotrinnskontrollTest.kt
@@ -44,14 +44,14 @@ class TotrinnskontrollTest(
         behandlingService.sendBehandlingTilBeslutter(behandling)
         assertEquals(BehandlingStatus.FATTER_VEDTAK, behandlingHentOgPersisterService.hent(behandling.id).status)
         assertThat(
-            saksstatistikkMellomlagringRepository.findByTypeAndTypeId(
+            saksstatistikkMellomlagringRepository.findByTypeAndTypeIdOrderByIdAsc(
                 SaksstatistikkMellomlagringType.BEHANDLING,
                 behandling.id,
             ),
         ).hasSize(2)
         assertThat(
             saksstatistikkMellomlagringRepository
-                .findByTypeAndTypeId(
+                .findByTypeAndTypeIdOrderByIdAsc(
                     SaksstatistikkMellomlagringType.BEHANDLING,
                     behandling.id,
                 ).last()
@@ -66,14 +66,14 @@ class TotrinnskontrollTest(
         assertEquals(BehandlingStatus.IVERKSETTER_VEDTAK, behandlingHentOgPersisterService.hent(behandling.id).status)
 
         assertThat(
-            saksstatistikkMellomlagringRepository.findByTypeAndTypeId(
+            saksstatistikkMellomlagringRepository.findByTypeAndTypeIdOrderByIdAsc(
                 SaksstatistikkMellomlagringType.BEHANDLING,
                 behandling.id,
             ),
         ).hasSize(3)
         assertThat(
             saksstatistikkMellomlagringRepository
-                .findByTypeAndTypeId(
+                .findByTypeAndTypeIdOrderByIdAsc(
                     SaksstatistikkMellomlagringType.BEHANDLING,
                     behandling.id,
                 ).last()
@@ -101,14 +101,14 @@ class TotrinnskontrollTest(
         totrinnskontrollService.besluttTotrinnskontroll(behandling, "Beslutter", "beslutterId", Beslutning.UNDERKJENT)
         assertEquals(BehandlingStatus.UTREDES, behandlingHentOgPersisterService.hent(behandling.id).status)
         assertThat(
-            saksstatistikkMellomlagringRepository.findByTypeAndTypeId(
+            saksstatistikkMellomlagringRepository.findByTypeAndTypeIdOrderByIdAsc(
                 SaksstatistikkMellomlagringType.BEHANDLING,
                 behandling.id,
             ),
         ).hasSize(3)
         assertThat(
             saksstatistikkMellomlagringRepository
-                .findByTypeAndTypeId(
+                .findByTypeAndTypeIdOrderByIdAsc(
                     SaksstatistikkMellomlagringType.BEHANDLING,
                     behandling.id,
                 ).last()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/kjerne/verdikjedetester/AbstractVerdikjedetest.kt
@@ -17,8 +17,8 @@ class VerdikjedetesterPropertyOverrideContextInitializer : ApplicationContextIni
     override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
         TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
             configurableApplicationContext,
-            "PDL_URL: http://localhost:1337/rest/api/pdl",
-            "FAMILIE_INTEGRASJONER_API_URL: http://localhost:1337/rest/api/integrasjoner",
+            "PDL_URL: \${wiremock.verdikjedetest.baseUrl}/rest/api/pdl",
+            "FAMILIE_INTEGRASJONER_API_URL: \${wiremock.verdikjedetest.baseUrl}/rest/api/integrasjoner",
         )
     }
 }
@@ -45,7 +45,7 @@ class VerdikjedetesterPropertyOverrideContextInitializer : ApplicationContextIni
 @ContextConfiguration(initializers = [VerdikjedetesterPropertyOverrideContextInitializer::class])
 @Tag("verdikjedetest")
 @EnableWireMock(
-    ConfigureWireMock(name = "verdikjedetest", port = 1337),
+    ConfigureWireMock(name = "verdikjedetest", baseUrlProperties = ["wiremock.verdikjedetest.baseUrl"]),
 )
 abstract class AbstractVerdikjedetest : WebSpringAuthTestRunner() {
     @InjectWireMock("verdikjedetest")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkTest.kt
@@ -76,7 +76,7 @@ class SaksstatistikkTest(
                 .data!!
                 .id
 
-        val mellomlagredeStatistikkHendelser = saksstatistikkMellomlagringRepository.findByTypeAndTypeId(SAK, fagsakId)
+        val mellomlagredeStatistikkHendelser = saksstatistikkMellomlagringRepository.findByTypeAndTypeIdOrderByIdAsc(SAK, fagsakId)
 
         assertEquals(1, mellomlagredeStatistikkHendelser.size)
         assertEquals(SAK, mellomlagredeStatistikkHendelser.first().type)
@@ -112,7 +112,7 @@ class SaksstatistikkTest(
         behandlingService.oppdaterStatusPåBehandling(behandlingId = behandling.id, BehandlingStatus.AVSLUTTET)
 
         val mellomlagretBehandling =
-            saksstatistikkMellomlagringRepository.findByTypeAndTypeId(BEHANDLING, behandling.id)
+            saksstatistikkMellomlagringRepository.findByTypeAndTypeIdOrderByIdAsc(BEHANDLING, behandling.id)
         assertEquals(2, mellomlagretBehandling.size)
         assertNull(mellomlagretBehandling.first().konvertertTidspunkt)
         assertNull(mellomlagretBehandling.first().sendtTidspunkt)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ba/sak/task/FerdigstillBehandlingTaskTest.kt
@@ -84,7 +84,7 @@ class FerdigstillBehandlingTaskTest(
         assertEquals(
             FagsakStatus.AVSLUTTET.name,
             saksstatistikkMellomlagringRepository
-                .findByTypeAndTypeId(
+                .findByTypeAndTypeIdOrderByIdAsc(
                     SaksstatistikkMellomlagringType.BEHANDLING,
                     ferdigstiltBehandling.id,
                 ).last()
@@ -97,7 +97,7 @@ class FerdigstillBehandlingTaskTest(
         assertEquals(
             FagsakStatus.LØPENDE.name,
             saksstatistikkMellomlagringRepository
-                .findByTypeAndTypeId(
+                .findByTypeAndTypeIdOrderByIdAsc(
                     SaksstatistikkMellomlagringType.SAK,
                     ferdigstiltFagsak.id,
                 ).last()
@@ -123,7 +123,7 @@ class FerdigstillBehandlingTaskTest(
         assertEquals(
             FagsakStatus.AVSLUTTET.name,
             saksstatistikkMellomlagringRepository
-                .findByTypeAndTypeId(
+                .findByTypeAndTypeIdOrderByIdAsc(
                     SaksstatistikkMellomlagringType.SAK,
                     ferdigstiltFagsak.id,
                 ).last()


### PR DESCRIPTION
## Hva
Fikser to spørringer som manglet `ORDER BY`, og rydder i surefire-oppsettet i testriggen.

## Hvorfor

### Rekkefølgeavhengige spørringer (produksjonsfeil)
`SaksstatistikkMellomlagringRepository` hadde to spørringer uten `ORDER BY`. Postgres garanterer ingen rekkefølge uten den, og planen endrer seg når tabellen vokser.

- **`finnMeldingerKlarForSending()`** styrer løkka i `SaksstatistikkScheduler` som publiserer til DVH. Statushendelser kunne dermed sendes ut av kronologi. Dette er en reell produksjonsfeil, ikke bare et testproblem.
- **`findByTypeAndTypeId()`** leses med `.last()` i testene, som forventer nyeste rad.

Den andre forklarer den flakye `FerdigstillBehandlingTaskTest`. Statistikken fra feilsøkingen:

| Kjøremåte | Feilrate |
|---|---|
| Testklassen isolert | 0 av 18 |
| Full integrasjonstestsuite | 2 av 8 |

Årsaken til forskjellen er at seq scan på en liten tabell tilfeldigvis gir innsettingsrekkefølge. Reprodusert med instrumentering — radene kom tilbake som `[1000663, 1000671, 1000661, 1000665]`, så `.last()` traff feil rad.

Metoden er døpt om til `findByTypeAndTypeIdOrderByIdAsc` slik at Spring Data utleder sorteringen selv.

### WireMock på fast port
`@ConfigureWireMock(port = 1337)` gjør at bare én Spring-context kan leve om gangen. Contexten ble derfor kastet ut og bygget opp igjen mellom testklassene. Diagnostisk signatur var at `size` sto stille på 1 mens `missCount` klatret. Samme fiks som i #6400.

### Surefire-opprydding
`forkCount` og `maxRamPercentage` er trukket ut som properties slik at de kan overstyres per kjøring. `threadCount` er fjernet — den var død konfigurasjon, siden `parallel` aldri var satt.

## Om forks: målt, og forkastet som standard

Lokalt på 14 kjerner så forks svært lovende ut:

| forkCount | heap 75 % | heap 35 % |
|---|---|---|
| 1 | 141 s | 108 s |
| 2 | 101 s | 79 s |
| 3 | 104 s | 78 s |
| 4 | 102 s | 85 s |

Det ga inntrykk av −46 %. **På CI holdt det ikke.** Med 4 vCPU forsvant gevinsten helt, og verdikjedetestene ble faktisk tregere:

| Jobb | main (fork 1) | denne grenen med fork 2 | Effekt |
|---|---|---|---|
| Integrasjonstest | 288–331 s (5 kjøringer) | 330 s | ingen |
| Enhetstest | 232–268 s (5 kjøringer) | 258 s | ingen |
| Verdikjede på | 355–375 s | 305 s | −16 %, men det kommer fra WireMock-fiksen |

Sammenlignet mot #6400, som har WireMock-fiksen med fork 1, kjører verdikjedetestene på **219 s** mot **305 s** her. To forks gjør dem altså **39 % tregere**, fordi Spring-contexten må startes i begge JVM-ene uten at det finnes nok parallelt arbeid å fordele den kostnaden på.

Standarden er derfor satt tilbake til `forkCount=1`. Propertyen beholdes slik at man kan kjøre `-Dsurefire.forkCount=2` lokalt på en maskin med mange kjerner.

## Effekt

Denne PR-en gir ingen målbar innsparing på CI. Verdien ligger i korrekthetsfiksen i DVH-publiseringen og i at en flaky test er borte for godt.

## Testing
- Enhetstester: 3911 grønne
- Integrasjonstester: 558 grønne, tre kjøringer på rad
- Begge verdikjedesuitene: grønne
- Kover-dekning uendret på 61,0538 %
