### PR TITLE
Bruker service-discovery mot familie-oppdrag-backend

### DIFF
--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -35,7 +35,6 @@ FAMILIE_BA_INFOTRYGD_API_URL: https://familie-ba-infotrygd.dev-fss-pub.nais.io
 FAMILIE_BA_INFOTRYGD_FEED_API_URL: https://familie-ba-infotrygd-feed.dev-fss-pub.nais.io/api
 
 FAMILIE_OPPDRAG_API_URL: https://familie-oppdrag.dev-fss-pub.nais.io/api
-FAMILIE_OPPDRAG_BACKEND_API_URL: https://familie-oppdrag-backend.intern.dev.nav.no/api
 CRON_FAGSAKSTATUS_SCHEDULER: "0 0/30 * ? * *"
 CRON_LÅS_FAGSAK_SCHEDULER: "0 0/30 * ? * *"
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -38,7 +38,6 @@ FAMILIE_BA_INFOTRYGD_FEED_API_URL: https://familie-ba-infotrygd-feed.prod-fss-pu
 
 FAMILIE_OPPDRAG_API_URL: https://familie-oppdrag.prod-fss-pub.nais.io/api
 FAMILIE_OPPDRAG_SCOPE: api://prod-fss.teamfamilie.familie-oppdrag/.default
-FAMILIE_OPPDRAG_BACKEND_API_URL: https://familie-oppdrag-backend.intern.nav.no/api
 FAMILIE_OPPDRAG_BACKEND_SCOPE: api://prod-gcp.teamfamilie.familie-oppdrag-backend/.default
 
 # Swagger


### PR DESCRIPTION
### 📮 Favro: [NAV-30011](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-30011)

### 💰 Hva skal gjøres, og hvorfor?

Fungerer ikke å bruke ingress-url til `familie-oppdrag-backend` internt i et cluster (dev/prod), så bytter til service-discovery.